### PR TITLE
docs: explain idless lookup and bump to v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.1.1
+
+### Changed
+
+- Documented how to look up records when the application does not already have a
+  RocheDB ID: start from a ring with `listByRing`, use ring-scoped `retrieve`
+  for vector/RAG lookup, and use `atlas()` / ring descriptions to choose scope.
+
 ## v0.1.0 Technical Preview
 
 Initial public technical preview target.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,36 @@ echo db.locate(id)                        # current owner, computed locally
 echo db.locate(id, at = 120.0)            # future owner, also computed locally
 ```
 
+## If You Do Not Know The ID
+
+`get(id)` is the fastest path when the application already has a RocheDB ID. If
+the ID is not known, start from a ring.
+
+```nim
+import rochedb
+
+var db = rochedb.open(dataDir = "data")
+
+discard db.put("""{"slug":"hello","title":"Hello"}""", ring = "docs/japan")
+discard db.put("""{"slug":"refund","title":"Refund guide"}""", ring = "docs/japan")
+
+for item in db.listByRing("docs/japan"):
+  echo item.payload
+```
+
+For vector/RAG-style lookup, search the ring directly:
+
+```nim
+let hits = db.retrieve(@[1.0'f32, 0.0'f32], ring = "docs/japan", budget = 3)
+
+for hit in hits:
+  echo hit.payload
+```
+
+If the right ring is not obvious, use `atlas()` and ring descriptions to choose
+the search scope first. RocheDB is designed to avoid ID-less global scans when a
+ring coordinate is available.
+
 ## Why It Helps Web Systems
 
 RocheDB is useful outside AI workflows when the application naturally has

--- a/rochedb.nimble
+++ b/rochedb.nimble
@@ -1,7 +1,7 @@
 # Package
 
-version       = "0.1.0"
-author        = "holmes"
+version       = "0.1.1"
+author        = "puffball1567"
 description   = "RocheDB PoC - ephemeris-based distributed document/vector store"
 license       = "Apache-2.0"
 srcDir        = "src"


### PR DESCRIPTION
## Summary
- Add a README section for users who do not already have a RocheDB ID
- Show ring-based listing and vector retrieval as the ID-less lookup paths
- Point readers to atlas/ring descriptions for choosing search scope
- Bump the package patch version to 0.1.1 and record the docs change in CHANGELOG

## Tests
- Not run; documentation/package metadata change only