### PR TITLE
docs: inline idless lookup guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.1.2
+
+### Changed
+
+- Kept the ID-less lookup guidance inside the embedded quickstart instead of a
+  separate README section.
+- Added API reference documentation to the v0.2+ roadmap.
+
 ## v0.1.1
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -68,8 +68,6 @@ echo db.locate(id)                        # current owner, computed locally
 echo db.locate(id, at = 120.0)            # future owner, also computed locally
 ```
 
-## If You Do Not Know The ID
-
 `get(id)` is the fastest path when the application already has a RocheDB ID. If
 the ID is not known, start from a ring.
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -79,6 +79,7 @@ all of them fit into v0.2.0:
 - browser / WASM local-state boundary
 - stronger cluster operational stories
 - package publication workflows
+- API reference documentation
 - Prometheus / OpenMetrics and Datadog metrics adapters
 
 ## Final Release Gate

--- a/docs/rochedb-status.md
+++ b/docs/rochedb-status.md
@@ -135,6 +135,7 @@ single v0.2.0 milestone.
 - Unity official asset
 - Unreal official plugin
 - package publishing workflows for language drivers
+- API reference documentation
 - Prometheus / OpenMetrics and Datadog metrics adapters
 - Universe redundancy: mirror manifests, verification, object-storage adapters, warp lanes, parity, and PITR
 - Cluster repair protocol: checksums, scrub, replica comparison, and repair metrics

--- a/rochedb.nimble
+++ b/rochedb.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.1"
+version       = "0.1.2"
 author        = "puffball1567"
 description   = "RocheDB PoC - ephemeris-based distributed document/vector store"
 license       = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Remove the separate 'If You Do Not Know The ID' README heading and keep the guidance inside the embedded quickstart
- Add API reference documentation to the v0.2+ roadmap
- Bump patch version to 0.1.2 and update CHANGELOG

## Tests
- Not run; documentation/package metadata change only