### PR TITLE
docs: add contribution policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.1.3
+
+### Added
+
+- Added `CONTRIBUTING.md` with a pre-1.0 contribution policy focused on
+  real-world verification reports, operational evidence, benchmark results,
+  recovery reports, and small documentation fixes.
+
 ## v0.1.2
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,79 @@
+# Contributing to RocheDB
+
+RocheDB is currently developed as a tightly controlled technical-preview
+database project. The core implementation direction is maintained by the project
+owner.
+
+At this stage, the most useful contributions are not broad feature pull
+requests. They are real-world verification reports that help evaluate whether
+RocheDB behaves correctly outside the author's local environment.
+
+## Preferred Contributions
+
+Please focus on:
+
+- benchmark results on real hardware;
+- cloud deployment reports on AWS, GCP, Azure, or bare-metal environments;
+- failure and recovery test reports;
+- driver compatibility reports;
+- FAISS setup reports across Linux distributions and CPU architectures;
+- WAL / backup / restore / compact verification reports;
+- reproducible bug reports with logs, commands, versions, and data shape;
+- documentation corrections for tested behavior.
+
+Good reports include:
+
+- RocheDB commit or tag;
+- OS, CPU, memory, disk, filesystem, and container/runtime details;
+- exact commands used;
+- dataset size, ring count, vector dimensions, payload size, and workload shape;
+- expected behavior;
+- actual behavior;
+- logs, metrics, benchmark output, or minimal reproduction data.
+
+## Pull Request Policy
+
+Small documentation fixes are welcome.
+
+Implementation pull requests may be closed or redirected unless they were
+discussed first. RocheDB's data model, transaction behavior, persistence format,
+wire protocol, and recovery semantics are intentionally kept under central
+design control while the project is pre-1.0.
+
+If you want to propose a code change, open an issue or discussion first with:
+
+- the problem being solved;
+- why it belongs in RocheDB core rather than a driver, adapter, or external
+  tool;
+- compatibility impact;
+- recovery / durability impact;
+- test plan.
+
+## What Not To Submit Yet
+
+Please do not send large unsolicited PRs for:
+
+- new query languages;
+- alternative storage engines;
+- new consensus systems;
+- large refactors;
+- cloud-specific managed-service integrations;
+- enterprise plugin features;
+- package publication automation;
+- API-breaking driver rewrites.
+
+These may become relevant later, but the current project priority is
+measurable correctness, recovery behavior, operational evidence, and carefully
+controlled design evolution.
+
+## Security
+
+Do not open public issues for suspected security vulnerabilities involving
+authentication, secret keys, encrypted backups, or data exposure. Contact the
+project owner privately first.
+
+## License
+
+By contributing documentation, reports, tests, or code, you agree that your
+contribution is provided under the repository license unless a separate written
+agreement says otherwise.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ corpus size toward semantic working-set size.
 - Halo capture design: [docs/rochedb-halo-capture.md](docs/rochedb-halo-capture.md)
 - Changelog: [CHANGELOG.md](CHANGELOG.md)
 - Third-party notices: [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md)
+- Contribution policy: [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## Quickstart: Embedded Mode
 

--- a/rochedb.nimble
+++ b/rochedb.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.2"
+version       = "0.1.3"
 author        = "puffball1567"
 description   = "RocheDB PoC - ephemeris-based distributed document/vector store"
 license       = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Add CONTRIBUTING.md with a pre-1.0 contribution policy
- Focus external contributions on real hardware reports, operational evidence, benchmarks, failure/recovery reports, and small documentation fixes
- Clarify that broad implementation PRs should be discussed first and may be redirected
- Bump patch version to 0.1.3 and update CHANGELOG

## Tests
- Not run; documentation/package metadata change only