### PR TITLE
Clarify CLI installation paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ corpus size toward semantic working-set size.
 ## Documents
 
 - Documentation site entry point: [docs/index.md](docs/index.md)
+- Installation: [docs/installation.md](docs/installation.md)
 - Public API reference: [docs/public-api.md](docs/public-api.md)
 - Configuration reference: [docs/config-reference.md](docs/config-reference.md)
 - CLI reference: [docs/cli-reference.md](docs/cli-reference.md)
@@ -99,25 +100,54 @@ nimble install rochedb
 roche --help
 ```
 
+When working from a source checkout before registry publication, install the
+local package onto your PATH:
+
+```sh
+nimble install -y
+roche --help
+```
+
+Nimble installs binaries into `~/.nimble/bin` by default. If `roche` is not
+found, add it to your shell PATH:
+
+```sh
+export PATH="$HOME/.nimble/bin:$PATH"
+```
+
+For server-style installs, build locally and install the binaries into
+`/usr/local/bin`, the usual source-install location for database tools:
+
+```sh
+nim c -d:release --nimcache:/tmp/nimcache_roche -o:bin/roche src/rochecli.nim
+nim c -d:release --nimcache:/tmp/nimcache_roched -o:bin/roched src/roched.nim
+sudo install -m 0755 bin/roche /usr/local/bin/roche
+sudo install -m 0755 bin/roched /usr/local/bin/roched
+```
+
+See [docs/installation.md](docs/installation.md) for PATH and system install
+details.
+
 Use RocheDB from a Nim program in this repository by importing the public module:
 
 ```nim
 import rochedb
 ```
 
-For command-line tools and demos, build the binaries:
+For command-line tools and demos that need repo-local binaries, build them under
+`bin/`:
 
 ```sh
 nim c -d:release --nimcache:/tmp/nimcache_roche -o:bin/roche src/rochecli.nim
-nim c -d:release --nimcache:/tmp/nimcache_roched -o:src/roched src/roched.nim
+nim c -d:release --nimcache:/tmp/nimcache_roched -o:bin/roched src/roched.nim
 ```
 
 Basic CLI document workflow:
 
 ```sh
-bin/roche put --data=data --ring=docs/japan --payload='{"title":"Hello"}'
-bin/roche list-ring --data=data --ring=docs/japan
-bin/roche get --data=data --id=RAW_ID
+roche put --data=data --ring=docs/japan --payload='{"title":"Hello"}'
+roche list-ring --data=data --ring=docs/japan
+roche get --data=data --id=RAW_ID
 ```
 
 Optional FAISS vector backend:
@@ -126,7 +156,7 @@ Optional FAISS vector backend:
 scripts/fetch_faiss.sh
 scripts/setup_faiss_toolchain.sh   # only needed when system CMake is too old
 scripts/build_faiss_bridge.sh
-bin/roche doctor
+roche doctor
 ```
 
 The built-in exact vector backend works without FAISS. FAISS is recommended for
@@ -357,8 +387,8 @@ bin/rochebench
 
 ```sh
 nim c -d:release -o:bin/roche src/rochecli.nim
-bin/roche working-set-bench --n=100000 --rings=100 --queries=50 --budget=20
-bin/roche memory-pressure-bench --n=100000 --rings=100 --queries=50 --budget=20 --payload-bytes=512
+roche working-set-bench --n=100000 --rings=100 --queries=50 --budget=20
+roche memory-pressure-bench --n=100000 --rings=100 --queries=50 --budget=20 --payload-bytes=512
 RUN_REDIS=0 examples/memory_pressure_case_study.sh
 examples/ai_rag_case_study.sh
 ```
@@ -368,7 +398,7 @@ examples/ai_rag_case_study.sh
 Use an existing local Redis server:
 
 ```sh
-bin/roche redis-bench --n=100000 --payload-bytes=100 --redis=127.0.0.1:6379
+roche redis-bench --n=100000 --payload-bytes=100 --redis=127.0.0.1:6379
 ```
 
 Or use the Docker-based smoke comparison:
@@ -409,8 +439,8 @@ bin/roched --id=0 --peers=127.0.0.1:7301 \
 Encrypted backup / restore:
 
 ```sh
-bin/roche backup-encrypted --data=data --backup=backup.enc --passphrase=change-me
-bin/roche restore-encrypted --backup=backup.enc --data=restored --passphrase=change-me
+roche backup-encrypted --data=data --backup=backup.enc --passphrase=change-me
+roche restore-encrypted --backup=backup.enc --data=restored --passphrase=change-me
 ```
 
 ### Driver Checks
@@ -452,7 +482,7 @@ bin/demo
 scripts/fetch_faiss.sh
 scripts/setup_faiss_toolchain.sh
 scripts/build_faiss_bridge.sh
-bin/roche doctor
+roche doctor
 examples/vector_backend_bench.sh
 ```
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -5,7 +5,45 @@ title: CLI Reference
 
 # CLI Reference
 
-Build the CLI:
+Install the command:
+
+```sh
+nimble install rochedb
+roche --help
+```
+
+When working from a source checkout before registry publication, install the
+local package onto your PATH:
+
+```sh
+nimble install -y
+roche --help
+```
+
+Nimble installs binaries into `~/.nimble/bin` by default. If `roche` is not
+found, add it to your shell PATH:
+
+```sh
+export PATH="$HOME/.nimble/bin:$PATH"
+```
+
+For persistent shell setup:
+
+```sh
+printf '\nexport PATH="$HOME/.nimble/bin:$PATH"\n' >> ~/.profile
+```
+
+For server-style installs, use `/usr/local/bin`:
+
+```sh
+nim c -d:release --nimcache:/tmp/nimcache_roche -o:bin/roche src/rochecli.nim
+nim c -d:release --nimcache:/tmp/nimcache_roched -o:bin/roched src/roched.nim
+sudo install -m 0755 bin/roche /usr/local/bin/roche
+sudo install -m 0755 bin/roched /usr/local/bin/roched
+```
+
+For repo-local development without installing, you can also build and run a
+local binary:
 
 ```sh
 nim c -d:release --nimcache:/tmp/nimcache_roche -o:bin/roche src/rochecli.nim
@@ -40,11 +78,11 @@ These commands work with `--data=DIR` for embedded mode and `--peers=...` for a
 running cluster.
 
 ```sh
-bin/roche put --data=data --ring=docs/japan --payload='{"title":"Hello"}'
-bin/roche list-ring --data=data --ring=docs/japan
-bin/roche get --data=data --id=RAW_ID
-bin/roche query --data=data --id=RAW_ID --selection='{ title }'
-bin/roche count-ring --data=data --ring=docs/japan
+roche put --data=data --ring=docs/japan --payload='{"title":"Hello"}'
+roche list-ring --data=data --ring=docs/japan
+roche get --data=data --id=RAW_ID
+roche query --data=data --id=RAW_ID --selection='{ title }'
+roche count-ring --data=data --ring=docs/japan
 ```
 
 | Command | Required flags | Purpose |
@@ -68,7 +106,7 @@ Use the `rawId` printed by `put` for scripts and reproducible examples.
 exploration:
 
 ```sh
-bin/roche shell --data=data
+roche shell --data=data
 ```
 
 Minimal shell commands:

--- a/docs/cloud-operations.md
+++ b/docs/cloud-operations.md
@@ -4,13 +4,13 @@ RocheDB v0.1.0 exposes lightweight node metrics through the existing wire
 protocol and CLI:
 
 ```sh
-bin/rochecli metrics --peers=127.0.0.1:7301,127.0.0.1:7302,127.0.0.1:7303
+roche metrics --peers=127.0.0.1:7301,127.0.0.1:7302,127.0.0.1:7303
 ```
 
 Recovery mirrors can be verified as a separate operational check:
 
 ```sh
-bin/rochecli recovery-verify --mirror=/backup/rochedb-a --metrics
+roche recovery-verify --mirror=/backup/rochedb-a --metrics
 ```
 
 For multi-universe recovery, keep the recovery topology in a JSON file and pass
@@ -77,13 +77,13 @@ secrets separately:
 ```
 
 ```sh
-bin/rochecli recovery-backup --data=/var/lib/rochedb \
+roche recovery-backup --data=/var/lib/rochedb \
   --universe-config=/etc/rochedb/recovery.json
 
-bin/rochecli recovery-status --universe-config=/etc/rochedb/recovery.json \
+roche recovery-status --universe-config=/etc/rochedb/recovery.json \
   --metrics
 
-bin/rochecli recovery-restore --universe-config=/etc/rochedb/recovery.json \
+roche recovery-restore --universe-config=/etc/rochedb/recovery.json \
   --data=/var/lib/rochedb-restored
 ```
 
@@ -166,7 +166,7 @@ similar platforms.
 
 ## Recovery Mirror Metrics
 
-`rochecli recovery-verify --metrics` emits one key/value line when the recovery
+`roche recovery-verify --metrics` emits one key/value line when the recovery
 mirror is valid. It exits non-zero when the mirror is missing, corrupt,
 undecryptable, or inconsistent with its manifest.
 
@@ -182,7 +182,7 @@ undecryptable, or inconsistent with its manifest.
 | `recoveryMirrorWarpJobs` | Warp jobs in the mirror | Delayed update recovery visibility |
 | `recoveryMirrorUniverseSyncEvents` | Universe sync outbox events in the mirror | Eventual-sync backlog recovery visibility |
 
-`rochecli recovery-status --metrics` verifies every configured universe
+`roche recovery-status --metrics` verifies every configured universe
 independently, counts healthy universes, and exits non-zero when the configured
 `requiredHealthy` threshold is not met.
 

--- a/docs/driver-installation.md
+++ b/docs/driver-installation.md
@@ -20,7 +20,7 @@ and build FAISS after cloning:
 scripts/fetch_faiss.sh
 scripts/setup_faiss_toolchain.sh   # only needed when system CMake is too old
 scripts/build_faiss_bridge.sh
-bin/rochecli doctor
+roche doctor
 ```
 
 By default, `scripts/fetch_faiss.sh` fetches the configured FAISS tag and records

--- a/docs/faiss-versioning.md
+++ b/docs/faiss-versioning.md
@@ -45,7 +45,7 @@ Use `ROCHE_FAISS_VERSION`:
 ```sh
 ROCHE_FAISS_VERSION=v1.14.2 scripts/fetch_faiss.sh
 scripts/build_faiss_bridge.sh
-bin/rochecli doctor
+roche doctor
 ```
 
 ## Installing an Exact Commit
@@ -81,7 +81,7 @@ This is the right mode for:
 
    ```sh
    scripts/build_faiss_bridge.sh
-   bin/rochecli doctor
+   roche doctor
    scripts/test_core.sh
    ```
 
@@ -97,7 +97,7 @@ When RocheDB maintainers update the recommended default:
 
 1. Choose the new default FAISS tag.
 2. Test it with `scripts/fetch_faiss.sh`, `scripts/build_faiss_bridge.sh`,
-   `bin/rochecli doctor`, and the release smoke suite.
+   `roche doctor`, and the release smoke suite.
 3. Update the default `VERSION` in `scripts/fetch_faiss.sh`.
 4. Commit the updated `third_party/faiss.version`.
 5. Update this document and third-party notices if license or build
@@ -110,7 +110,7 @@ If FAISS publishes a security fix, users can immediately choose a patched tag:
 ```sh
 ROCHE_FAISS_VERSION=vX.Y.Z scripts/fetch_faiss.sh
 scripts/build_faiss_bridge.sh
-bin/rochecli doctor
+roche doctor
 ```
 
 RocheDB maintainers should then test the patched version and update the

--- a/docs/github-release-v0.1.0.md
+++ b/docs/github-release-v0.1.0.md
@@ -41,7 +41,7 @@ The pre-release verification pass covered:
 - `scripts/driver_compat.sh`
 - Docker-backed PHP / Swift / Kotlin driver smoke
 - `examples/ai_rag_case_study.sh`
-- `rochecli doctor` for the FAISS bridge
+- `roche doctor` for the FAISS bridge
 
 ## Known Gaps
 

--- a/docs/github-release-v0.2.0.md
+++ b/docs/github-release-v0.2.0.md
@@ -22,7 +22,7 @@ needed for broader evaluation.
   readonly mirrors.
 - Docker Compose demos for a single galaxy, a three-node galaxy, and a
   local/remote universe-shaped topology.
-- `bin/roche` CLI CRUD workflows, ring list/count, atlas, and a minimal
+- `roche` CLI CRUD workflows, ring list/count, atlas, and a minimal
   interactive shell.
 - GitHub Pages documentation structure with public API, config, CLI, topology,
   universe sync, protocol compatibility, cloud metrics, and threat model pages.

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ downstream AI/RAG or application logic.
 ## Start Here
 
 - [Concept](rochedb-concept.md)
+- [Installation](installation.md)
 - [Public API](public-api.md)
 - [Configuration Reference](config-reference.md)
 - [CLI Reference](cli-reference.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,106 @@
+---
+layout: page
+title: Installation
+---
+
+# Installation
+
+RocheDB installs command-line binaries named `roche`, `roched`, `rochecli`,
+`rochebench`, and `rochesim`.
+
+For normal use, the command should be available as `roche`, not as
+`bin/roche`. The `bin/` form is only for source-tree development and smoke
+tests.
+
+## Prerequisites
+
+- Nim `2.0.0` or newer
+- `git`
+- `gcc` or another C compiler supported by Nim
+- `libsodium` development files for `nimsodium`
+
+## User Install
+
+After Nimble registry publication:
+
+```sh
+nimble install rochedb
+```
+
+Before registry publication, from a source checkout:
+
+```sh
+git clone https://github.com/puffball1567/rochedb.git
+cd rochedb
+nimble install -y
+```
+
+Nimble installs binaries into `~/.nimble/bin` by default. Add it to your shell
+PATH if `roche --help` is not found:
+
+```sh
+export PATH="$HOME/.nimble/bin:$PATH"
+```
+
+For a persistent shell setup:
+
+```sh
+printf '\nexport PATH="$HOME/.nimble/bin:$PATH"\n' >> ~/.profile
+```
+
+Then verify:
+
+```sh
+roche --help
+roched --help
+```
+
+## System Install
+
+For server-style deployments, use `/usr/local/bin`, matching the usual source
+install location for database tools such as MySQL or PostgreSQL client/server
+binaries.
+
+Build repo-local binaries:
+
+```sh
+nim c -d:release --nimcache:/tmp/nimcache_roche -o:bin/roche src/rochecli.nim
+nim c -d:release --nimcache:/tmp/nimcache_roched -o:bin/roched src/roched.nim
+```
+
+Install them onto the system PATH:
+
+```sh
+sudo install -m 0755 bin/roche /usr/local/bin/roche
+sudo install -m 0755 bin/roched /usr/local/bin/roched
+```
+
+Optional development and benchmark tools:
+
+```sh
+nim c -d:release --nimcache:/tmp/nimcache_rochebench -o:bin/rochebench src/rochebench.nim
+nim c -d:release --nimcache:/tmp/nimcache_rochesim -o:bin/rochesim src/rochesim.nim
+sudo install -m 0755 bin/rochebench /usr/local/bin/rochebench
+sudo install -m 0755 bin/rochesim /usr/local/bin/rochesim
+```
+
+Verify:
+
+```sh
+command -v roche
+command -v roched
+roche --help
+```
+
+## Source-Tree Development
+
+Use repo-local binaries only when you explicitly want to test the current
+checkout without installing it:
+
+```sh
+nim c -d:release --nimcache:/tmp/nimcache_roche -o:bin/roche src/rochecli.nim
+bin/roche --help
+```
+
+Documentation and examples use `roche` for installed usage. Test scripts may use
+`bin/roche` to avoid depending on the user's PATH.

--- a/docs/rochedb-bench.md
+++ b/docs/rochedb-bench.md
@@ -101,7 +101,7 @@ measured layer: core `27.5 ns`, public API `54.7 ns`, and C ABI `77.7 ns`.
 - RocheDB setup: three `roched` nodes, persistence enabled, single client,
   persistent TCP connection, 100-byte payload, `n=10000`
 - Reproduction: start three `roched` processes with `--id=k --peers=...
-  --data=...`, then run `bin/rochecli bench --peers=... --n=10000`
+  --data=...`, then run `roche bench --peers=... --n=10000`
 - Benchmark guard: the client chooses a stable ring whose arc ownership does not
   cross a boundary during the run, using `locate(now) == locate(now + 60s)`
 
@@ -187,7 +187,7 @@ working set can still be read in a competitive latency class.
 - Date: 2026-07-04
 - Environment: same machine, AMD Ryzen 5 5600H / Linux 6.8 / Nim 2.2.10
   `-d:release`, embedded mode, persistence disabled
-- Reproduction: `bin/rochecli working-set-bench --n=10000 --rings=100
+- Reproduction: `roche working-set-bench --n=10000 --rings=100
   --queries=10 --budget=20`
 - Purpose: measure whether ring routing reduces physically scanned records per
   query, rather than full-scanning the entire corpus faster
@@ -240,7 +240,7 @@ fewer records.
 - Date: 2026-07-05
 - Environment: same machine, AMD Ryzen 5 5600H / Linux 6.8 / Nim 2.2.10
   `-d:release`, embedded mode, persistence disabled
-- Reproduction: `bin/rochecli memory-pressure-bench --n=100000 --rings=100
+- Reproduction: `roche memory-pressure-bench --n=100000 --rings=100
   --queries=50 --budget=20 --payload-bytes=512`
 - Docker case-study script: `RUN_REDIS=0 examples/memory_pressure_case_study.sh`
 - Purpose: evaluate the demand-side memory-reduction hypothesis as candidate
@@ -273,7 +273,7 @@ Token reduction is covered by the RAG-style quality-fixed benchmark.
 - Date: 2026-07-04
 - Environment: same machine, AMD Ryzen 5 5600H / Linux 6.8 / Nim 2.2.10
   `-d:release`, embedded mode, persistence disabled
-- Reproduction: `bin/rochecli rag-bench --n=8000 --queries=80 --budget=20
+- Reproduction: `roche rag-bench --n=8000 --queries=80 --budget=20
   --routed-budget=3`
 - Purpose: test whether scanned records and estimated tokens can be reduced
   while holding recall fixed

--- a/docs/rochedb-shelfer-integration.md
+++ b/docs/rochedb-shelfer-integration.md
@@ -187,17 +187,17 @@ Current implementation:
 - The exact vector backend can search multiple selected rings in one pass.
 - Ring names are persisted in the WAL and hierarchy is restored after reopen.
 - Persistent embedded stores can compact the WAL with `compact` /
-  `rochecli compact --data=DIR`, keeping only live records and metadata.
+  `roche compact --data=DIR`, keeping only live records and metadata.
 - Persistent embedded stores can create and restore compact WAL backups with
-  `backup` / `restoreBackup` or `rochecli backup --data=DIR --backup=DIR` and
-  `rochecli restore --backup=DIR --data=DIR`.
+  `backup` / `restoreBackup` or `roche backup --data=DIR --backup=DIR` and
+  `roche restore --backup=DIR --data=DIR`.
 - Persistent embedded stores can export readable JSON Lines dumps with `dump`
-  or `rochecli dump --data=DIR --out=FILE`; this is for inspection and
+  or `roche dump --data=DIR --out=FILE`; this is for inspection and
   migration, not crash recovery.
 - External NoSQL JSON Lines exports can be imported with routing rules:
   `importJsonl(..., ringField = "tenant", ringPrefix = "tenant/",
   payloadField = "body", vecField = "embedding")` or
-  `rochecli import-jsonl --data=DIR --in=FILE --ring-field=tenant`.
+  `roche import-jsonl --data=DIR --in=FILE --ring-field=tenant`.
   The selected ring is created automatically, so imports can distribute
   existing documents into RocheDB's ring hierarchy during ingestion.
 - The builtin planner ranks expanded candidates with deterministic DB-local
@@ -299,7 +299,7 @@ untrusted RAG content until runtime policy accepts them.
 2. Add a small RocheDB RAG adapter for Shelfer as a separate module or plugin.
 3. Map RocheDB `RetrieveStats` into Shelfer RAG/resource utility records.
 4. Add a feedback loop that recommends ring budgets and source routing.
-5. Measure quality-fixed reductions with `rochecli rag-bench` and Shelfer
+5. Measure quality-fixed reductions with `roche rag-bench` and Shelfer
    context investment reports.
 
 The important KPI is not only latency. For AI workloads the target is:

--- a/docs/rochedb-status.de.md
+++ b/docs/rochedb-status.de.md
@@ -18,7 +18,7 @@ Release checklist: [release-checklist.md](./release-checklist.md)
 | Vector retrieve | Done | FAISS bridge is the intended production path; exact backend remains for tests and fallback |
 | Ring / hierarchy | Done | `ring = "a/b/c"` and child-ring expansion |
 | Galaxy isolation | Done | Separate data dir / peer list / credential boundary |
-| Atlas / ring map | Done | `atlas()` and `rochecli atlas` |
+| Atlas / ring map | Done | `atlas()` and `roche atlas` |
 | Retrieval tuning profile | Done | amount / scope / depth |
 | FAISS vector backend | PoC | Dynamic bridge via `libroche_faiss.so`; default fetch tag is FAISS `v1.14.3`; exact commit pinning is optional via `ROCHE_FAISS_COMMIT` |
 | WASM browser embedded | Post-v0.1 candidate | Browser state boundary / IndexedDB / OPFS |

--- a/docs/rochedb-status.fr.md
+++ b/docs/rochedb-status.fr.md
@@ -18,7 +18,7 @@ Release checklist: [release-checklist.md](./release-checklist.md)
 | Vector retrieve | Done | FAISS bridge is the intended production path; exact backend remains for tests and fallback |
 | Ring / hierarchy | Done | `ring = "a/b/c"` and child-ring expansion |
 | Galaxy isolation | Done | Separate data dir / peer list / credential boundary |
-| Atlas / ring map | Done | `atlas()` and `rochecli atlas` |
+| Atlas / ring map | Done | `atlas()` and `roche atlas` |
 | Retrieval tuning profile | Done | amount / scope / depth |
 | FAISS vector backend | PoC | Dynamic bridge via `libroche_faiss.so`; default fetch tag is FAISS `v1.14.3`; exact commit pinning is optional via `ROCHE_FAISS_COMMIT` |
 | WASM browser embedded | Post-v0.1 candidate | Browser state boundary / IndexedDB / OPFS |

--- a/docs/rochedb-status.ja.md
+++ b/docs/rochedb-status.ja.md
@@ -17,7 +17,7 @@
 | Vector retrieve | 完了 | FAISS bridge が本番想定。Exact backend は小規模、テスト、fallback 用 |
 | Ring / hierarchy | 完了 | `ring = "a/b/c"` と child-ring expansion |
 | Galaxy isolation | 完了 | data dir / peer list / credential の境界 |
-| Atlas / ring map | 完了 | `atlas()` と `rochecli atlas` |
+| Atlas / ring map | 完了 | `atlas()` と `roche atlas` |
 | Retrieval tuning profile | 完了 | amount / scope / depth |
 | FAISS vector backend | PoC | `libroche_faiss.so` dynamic bridge。default fetch tag は FAISS `v1.14.3`; exact commit pinning は `ROCHE_FAISS_COMMIT` で optional |
 | WASM browser embedded | v0.1 後の候補 | Browser state boundary / IndexedDB / OPFS |

--- a/docs/rochedb-status.ko.md
+++ b/docs/rochedb-status.ko.md
@@ -17,7 +17,7 @@ Release checklist: [release-checklist.md](./release-checklist.md)
 | Vector retrieve | Done | FAISS bridge is the intended production path; exact backend remains for tests and fallback |
 | Ring / hierarchy | Done | `ring = "a/b/c"` and child-ring expansion |
 | Galaxy isolation | Done | Separate data dir / peer list / credential boundary |
-| Atlas / ring map | Done | `atlas()` and `rochecli atlas` |
+| Atlas / ring map | Done | `atlas()` and `roche atlas` |
 | Retrieval tuning profile | Done | amount / scope / depth |
 | FAISS vector backend | PoC | Dynamic bridge via `libroche_faiss.so`; default fetch tag is FAISS `v1.14.3`; exact commit pinning is optional via `ROCHE_FAISS_COMMIT` |
 | WASM browser embedded | Post-v0.1 candidate | Browser state boundary / IndexedDB / OPFS |

--- a/docs/rochedb-status.md
+++ b/docs/rochedb-status.md
@@ -25,10 +25,10 @@ Translations:
 | Vector retrieve | Done | FAISS bridge is the intended production vector path. Exact backend remains for small datasets, tests, and fallback |
 | Ring / hierarchy | Done | `ring = "a/b/c"` and child-ring expansion |
 | Galaxy isolation | Done | Separate data dir / peer list / credential boundary |
-| Atlas / ring map | Done | `atlas()` and `rochecli atlas` |
+| Atlas / ring map | Done | `atlas()` and `roche atlas` |
 | Galaxy/ring description | Done | Atlas map annotations, not payload text |
 | Retrieval tuning profile | Done | amount / scope / depth |
-| FAISS vector backend | PoC | Dynamic bridge via `libroche_faiss.so`; default fetch tag is FAISS `v1.14.3`, exact commit pinning is optional via `ROCHE_FAISS_COMMIT`; `rochecli doctor`, bridge build, `tests/tapi.nim`, and `examples/vector_backend_bench.sh` are verified locally |
+| FAISS vector backend | PoC | Dynamic bridge via `libroche_faiss.so`; default fetch tag is FAISS `v1.14.3`, exact commit pinning is optional via `ROCHE_FAISS_COMMIT`; `roche doctor`, bridge build, `tests/tapi.nim`, and `examples/vector_backend_bench.sh` are verified locally |
 | FAISS GPU backend | Not planned for core | RocheDB is designed to reduce the search set before ANN/LLM work. Needing GPU FAISS is treated as a placement or retrieval-profile issue first |
 | Retrieval planner | PoC | Deterministic heuristic planner. Stronger planner claims require larger real-corpus benchmarks and further tuning |
 | WASM browser embedded | Post-v0.1 candidate | Browser state boundary / IndexedDB / OPFS |
@@ -45,7 +45,7 @@ Translations:
 | Compact | Done | Rebuilds WAL from live records |
 | Backup / restore | Done | Backup as compacted WAL and restore into another data dir |
 | Dump / import-jsonl | Done | NoSQL JSONL import rules |
-| Universe sync outbox | PoC | WAL-backed eventual sync event queue with idempotent apply, ack/prune, `putSynced`, latest-only pending coalescing, delayed timestamp apply windows, `rochecli universe-export` / `universe-apply` JSONL handoff, one-shot `rochecli universe-sync` between local data dirs, remote `--peers` delivery via `UAPPLY`, and `universe-status` operational counters. It is a durable scheduler boundary, not immediate global consistency |
+| Universe sync outbox | PoC | WAL-backed eventual sync event queue with idempotent apply, ack/prune, `putSynced`, latest-only pending coalescing, delayed timestamp apply windows, `roche universe-export` / `universe-apply` JSONL handoff, one-shot `roche universe-sync` between local data dirs, remote `--peers` delivery via `UAPPLY`, and `universe-status` operational counters. It is a durable scheduler boundary, not immediate global consistency |
 | Crash recovery tests | Partial | Torn WAL tail repair, compact interruption, partial commit cases |
 | Strong durability / fsync knob | Done | `open(dataDir=..., durability=durStrong)` and `roched --durability=strong`; store/API tests cover reopen, transaction, compact |
 | Core test suite | Done | `scripts/test_core.sh` runs orbital core, selection, field, store, and public API tests |
@@ -122,7 +122,7 @@ Translations:
 | Galaxy isolation | Done | Limits blast radius by galaxy |
 | TLS | Planned | Required for public-network deployments |
 | Ring/galaxy authz | PoC | Ring prefix authorization is implemented for named-ring wire operations; richer role policy is pending |
-| Backup encryption | Done | `backupEncrypted` / `restoreEncryptedBackup` and `rochecli backup-encrypted` / `restore-encrypted` use nimsodium secretbox |
+| Backup encryption | Done | `backupEncrypted` / `restoreEncryptedBackup` and `roche backup-encrypted` / `restore-encrypted` use nimsodium secretbox |
 | General audit log | Planned | Full append-only access/change audit for enterprise / regulated workloads. Warp jobs already persist attempts / retryAt / ack / dead-letter state, but that is job state, not a database-wide audit log |
 | Threat model document | Draft | `docs/threat-model.md` covers assets, trust boundaries, current controls, and known gaps |
 

--- a/docs/rochedb-status.zh.md
+++ b/docs/rochedb-status.zh.md
@@ -17,7 +17,7 @@ Release checklist: [release-checklist.md](./release-checklist.md)
 | Vector retrieve | Done | FAISS bridge is the intended production path; exact backend remains for tests and fallback |
 | Ring / hierarchy | Done | `ring = "a/b/c"` and child-ring expansion |
 | Galaxy isolation | Done | Separate data dir / peer list / credential boundary |
-| Atlas / ring map | Done | `atlas()` and `rochecli atlas` |
+| Atlas / ring map | Done | `atlas()` and `roche atlas` |
 | Retrieval tuning profile | Done | amount / scope / depth |
 | FAISS vector backend | PoC | Dynamic bridge via `libroche_faiss.so`; default fetch tag is FAISS `v1.14.3`; exact commit pinning is optional via `ROCHE_FAISS_COMMIT` |
 | WASM browser embedded | Post-v0.1 candidate | Browser state boundary / IndexedDB / OPFS |

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -93,6 +93,6 @@ drivers.
   boundary.
 - Keep ring and atlas descriptions free of secrets; they are routing metadata,
   not protected payload fields.
-- Export `rochecli metrics` output to CloudWatch, Cloud Monitoring, or a similar
+- Export `roche metrics` output to CloudWatch, Cloud Monitoring, or a similar
   system and alert on transaction backlog, error growth, auth failures, WAL
   growth, connection pressure, and unexpected restarts.

--- a/docs/topology-config.md
+++ b/docs/topology-config.md
@@ -30,13 +30,13 @@ The topology file is JSON.
 Run:
 
 ```sh
-bin/rochecli recovery-backup --data=/var/lib/rochedb \
+roche recovery-backup --data=/var/lib/rochedb \
   --universe-config=/etc/rochedb/topology.json
 
-bin/rochecli recovery-status --universe-config=/etc/rochedb/topology.json \
+roche recovery-status --universe-config=/etc/rochedb/topology.json \
   --metrics
 
-bin/rochecli recovery-restore --universe-config=/etc/rochedb/topology.json \
+roche recovery-restore --universe-config=/etc/rochedb/topology.json \
   --data=/var/lib/rochedb-restored
 ```
 
@@ -212,7 +212,7 @@ excluded as write targets during `recovery-backup`.
 The recovery CLI can create entries without a topology file:
 
 ```sh
-bin/rochecli recovery-backup --data=/var/lib/rochedb \
+roche recovery-backup --data=/var/lib/rochedb \
   --mirror=/backup/app-main \
   --universe=local-a \
   --galaxy=app-main \

--- a/docs/topology-examples.md
+++ b/docs/topology-examples.md
@@ -375,7 +375,7 @@ universe: remote
 
 This is useful for explaining the concept. In production, place remote
 universes on truly independent infrastructure and validate recovery with
-`rochecli recovery-status` and restore drills.
+`roche recovery-status` and restore drills.
 
 ## Pattern 9. Durable Universe Sync Demo
 
@@ -393,17 +393,17 @@ examples/universe_sync_demo.sh
 The local demo script creates separate source and target data directories,
 enqueues a universe sync event, applies it idempotently to the target,
 acknowledges it in the source outbox, and prunes the acknowledged event. It
-then repeats the same boundary through `rochecli universe-export` and
-`rochecli universe-sync`.
+then repeats the same boundary through `roche universe-export` and
+`roche universe-sync`.
 
 Remote delivery uses the same source outbox but sends events to a running
 RocheDB server:
 
 ```sh
-bin/rochecli universe-status --data=/var/lib/roche-source
-bin/rochecli universe-sync --data=/var/lib/roche-source \
+roche universe-status --data=/var/lib/roche-source
+roche universe-sync --data=/var/lib/roche-source \
   --peers=remote-roche.internal:7301 --prune-acked
-bin/rochecli universe-status --peers=remote-roche.internal:7301
+roche universe-status --peers=remote-roche.internal:7301
 ```
 
 Runnable remote smoke:

--- a/docs/universe-sync.md
+++ b/docs/universe-sync.md
@@ -28,7 +28,7 @@ same event is idempotent and returns `SKIPPED` instead of duplicating data.
 For offline or batch movement between two data directories:
 
 ```bash
-src/rochecli universe-sync --data=/var/lib/roche/source --target=/var/lib/roche/target
+roche universe-sync --data=/var/lib/roche/source --target=/var/lib/roche/target
 ```
 
 Use `--prune-acked` only after the target state is considered durable enough for
@@ -39,7 +39,7 @@ your recovery policy.
 For a running cluster:
 
 ```bash
-src/rochecli universe-sync \
+roche universe-sync \
   --data=/var/lib/roche/source \
   --peers=127.0.0.1:17611,127.0.0.1:17612,127.0.0.1:17613 \
   --username=admin \
@@ -70,19 +70,19 @@ such as comments can store timestamped documents and sort at read time.
 Source outbox status:
 
 ```bash
-src/rochecli universe-status --data=/var/lib/roche/source
+roche universe-status --data=/var/lib/roche/source
 ```
 
 Remote apply status:
 
 ```bash
-src/rochecli universe-status --peers=127.0.0.1:17611,127.0.0.1:17612
+roche universe-status --peers=127.0.0.1:17611,127.0.0.1:17612
 ```
 
 Metrics format:
 
 ```bash
-src/rochecli universe-status --peers=127.0.0.1:17611,127.0.0.1:17612 --metrics
+roche universe-status --peers=127.0.0.1:17611,127.0.0.1:17612 --metrics
 ```
 
 Remote status reports both durable applied event keys and process-local apply


### PR DESCRIPTION
Clarifies that installed usage should call `roche` directly, documents Nimble PATH setup, and adds system install steps for `/usr/local/bin/roche` and `/usr/local/bin/roched`.\n\nVerification:\n- `git diff --check`\n- Markdown relative link check for README and docs