### PR TITLE
Update Nimble installation guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v0.2.2
+
+### Changed
+
+- Updated installation documentation now that RocheDB is available through
+  Nimble.
+- Clarified that non-Nim language packages remain repository-local foundations
+  while `nimble install rochedb` is the normal Nim install path.
+- Bumped package metadata to `0.2.2`.
+
+## v0.2.1
+
+### Changed
+
+- Clarified CLI installation paths and documented `~/.nimble/bin` PATH setup.
+- Added system install guidance for `/usr/local/bin/roche` and
+  `/usr/local/bin/roched`.
+- Added a dedicated installation page and linked it from README and the docs
+  index.
+
 ## v0.2.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ corpus size toward semantic working-set size.
 
 ## Installation
 
-RocheDB v0.2.x is a technical preview. Registry packages are not published yet,
-so the current installation path is a local clone.
+RocheDB v0.2.x is a technical preview. The Nim package is available through
+Nimble, while non-Nim language packages are still repository-local foundations.
 
 Prerequisites:
 
@@ -85,27 +85,21 @@ Prerequisites:
 - `git`
 - `gcc` or another C compiler supported by Nim
 
-Clone and verify the embedded database:
-
-```sh
-git clone https://github.com/puffball1567/rochedb.git
-cd rochedb
-scripts/test_core.sh
-```
-
-After Nimble registry publication, the intended install path is:
+Install the CLI and Nim library:
 
 ```sh
 nimble install rochedb
 roche --help
 ```
 
-When working from a source checkout before registry publication, install the
-local package onto your PATH:
+Clone the repository when you want to run the full source test suite, examples,
+or driver smoke tests:
 
 ```sh
+git clone https://github.com/puffball1567/rochedb.git
+cd rochedb
+scripts/test_core.sh
 nimble install -y
-roche --help
 ```
 
 Nimble installs binaries into `~/.nimble/bin` by default. If `roche` is not
@@ -252,9 +246,9 @@ rules.
 | Kotlin/JVM | `drivers/kotlin` | JNI / C ABI wrapper | Docker smoke |
 
 Detailed setup notes are in
-[docs/driver-installation.md](docs/driver-installation.md). Package publishing
-to npm, PyPI, Cargo, Composer, NuGet, Maven, and other registries is a post-v0.1
-roadmap item and is not part of the current technical-preview claim.
+[docs/driver-installation.md](docs/driver-installation.md). Nimble package
+registration is complete. Package publishing to npm, PyPI, Cargo, Composer,
+NuGet, Maven, and other non-Nim registries remains a post-v0.2 roadmap item.
 
 ## Cluster Mode
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -12,8 +12,7 @@ nimble install rochedb
 roche --help
 ```
 
-When working from a source checkout before registry publication, install the
-local package onto your PATH:
+When working from a source checkout, install the local package onto your PATH:
 
 ```sh
 nimble install -y

--- a/docs/driver-installation.md
+++ b/docs/driver-installation.md
@@ -8,7 +8,8 @@ RocheDB drivers currently use two paths:
 - Native TCP wire drivers for cluster-oriented use.
 - C ABI wrappers for embedded/local use and language binding stability.
 
-Registry publication is not claimed yet. The examples below assume a local clone
+The Nim package is available through Nimble. Non-Nim drivers are still
+repository-local foundations, so the driver examples below assume a local clone
 of this repository.
 
 ## Optional FAISS Setup
@@ -44,8 +45,14 @@ nim c -d:release --nimcache:/tmp/nimcache_roched -o:src/roched src/roched.nim
 
 ## Nim
 
-Until registry publication, use a local clone and import the public API
-directly:
+Install from Nimble:
+
+```sh
+nimble install rochedb
+roche --help
+```
+
+Then import the public API:
 
 ```nim
 import rochedb
@@ -55,17 +62,10 @@ let id = db.put("hello", ring = "docs")
 echo db.get(id)
 ```
 
-Run:
+From a source checkout, run:
 
 ```sh
 scripts/test_core.sh
-```
-
-After Nimble registry publication, the intended install path is:
-
-```sh
-nimble install rochedb
-roche --help
 ```
 
 ## C ABI

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -21,13 +21,14 @@ tests.
 
 ## User Install
 
-After Nimble registry publication:
+Install RocheDB from Nimble:
 
 ```sh
 nimble install rochedb
 ```
 
-Before registry publication, from a source checkout:
+Use a source checkout when you want to run the full test suite, examples, or
+driver smoke tests:
 
 ```sh
 git clone https://github.com/puffball1567/rochedb.git

--- a/docs/rochedb-status.de.md
+++ b/docs/rochedb-status.de.md
@@ -65,7 +65,7 @@ Release checklist: [release-checklist.md](./release-checklist.md)
 | PHP / Swift / Kotlin | Done | Docker smoke available |
 | C# / C++ | Done | OSS generic wrappers; Unity / Unreal official assets are separate candidates |
 | React Native / WASM | Post-v0.1 candidate | Browser / local state boundary |
-| Package publishing | Post-v0.1 candidate | npm / PyPI / Cargo / Composer / NuGet / Maven |
+| Nimble package publishing | Done | `nimble install rochedb` is available. Non-Nim registries remain future work |
 
 ## Benchmarks / Demos
 

--- a/docs/rochedb-status.fr.md
+++ b/docs/rochedb-status.fr.md
@@ -65,7 +65,7 @@ Release checklist: [release-checklist.md](./release-checklist.md)
 | PHP / Swift / Kotlin | Done | Docker smoke available |
 | C# / C++ | Done | OSS generic wrappers; Unity / Unreal official assets are separate candidates |
 | React Native / WASM | Post-v0.1 candidate | Browser / local state boundary |
-| Package publishing | Post-v0.1 candidate | npm / PyPI / Cargo / Composer / NuGet / Maven |
+| Nimble package publishing | Done | `nimble install rochedb` is available. Non-Nim registries remain future work |
 
 ## Benchmarks / Demos
 

--- a/docs/rochedb-status.ja.md
+++ b/docs/rochedb-status.ja.md
@@ -64,7 +64,7 @@
 | PHP / Swift / Kotlin | 完了 | Docker smoke あり |
 | C# / C++ | 完了 | OSS generic wrappers。Unity / Unreal 公式 asset は別候補 |
 | React Native / WASM | v0.1 後の候補 | Browser / local state boundary |
-| Package publishing | v0.1 後の候補 | npm / PyPI / Cargo / Composer / NuGet / Maven |
+| Nimble package publishing | 完了 | `nimble install rochedb` が利用可能。非Nimレジストリは今後の作業 |
 
 ## Benchmarks / Demos
 

--- a/docs/rochedb-status.ko.md
+++ b/docs/rochedb-status.ko.md
@@ -64,7 +64,7 @@ Release checklist: [release-checklist.md](./release-checklist.md)
 | PHP / Swift / Kotlin | Done | Docker smoke available |
 | C# / C++ | Done | OSS generic wrappers; Unity / Unreal official assets are separate candidates |
 | React Native / WASM | Post-v0.1 candidate | Browser / local state boundary |
-| Package publishing | Post-v0.1 candidate | npm / PyPI / Cargo / Composer / NuGet / Maven |
+| Nimble package publishing | Done | `nimble install rochedb` is available. Non-Nim registries remain future work |
 
 ## Benchmarks / Demos
 

--- a/docs/rochedb-status.md
+++ b/docs/rochedb-status.md
@@ -90,7 +90,7 @@ Translations:
 | Kotlin-first JVM | Done | JNI / C ABI wrapper with Docker smoke |
 | React Native / WASM local state | Post-v0.1 candidate | Browser / React Native state boundary; handled with the WASM line, not before Kotlin |
 | Driver compatibility test suite | Partial | `scripts/driver_compat.sh`; Docker-backed PHP / Swift / Kotlin are opt-in and verified |
-| Package publishing workflow | Post-v0.1 candidate | npm / PyPI / Cargo / Go / Composer / SwiftPM / NuGet / Maven |
+| Nimble package publishing | Done | `nimble install rochedb` is available. Non-Nim registries remain future work |
 
 ## Benchmarks / Demos
 

--- a/docs/rochedb-status.zh.md
+++ b/docs/rochedb-status.zh.md
@@ -64,7 +64,7 @@ Release checklist: [release-checklist.md](./release-checklist.md)
 | PHP / Swift / Kotlin | Done | Docker smoke available |
 | C# / C++ | Done | OSS generic wrappers; Unity / Unreal official assets are separate candidates |
 | React Native / WASM | Post-v0.1 candidate | Browser / local state boundary |
-| Package publishing | Post-v0.1 candidate | npm / PyPI / Cargo / Composer / NuGet / Maven |
+| Nimble package publishing | Done | `nimble install rochedb` is available. Non-Nim registries remain future work |
 
 ## Benchmarks / Demos
 

--- a/rochedb.nimble
+++ b/rochedb.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version     = "0.2.0"
+version     = "0.2.2"
 author      = "puffball1567"
 description = "Ring-oriented NoSQL document/vector store for smaller working sets"
 license     = "Apache-2.0"

--- a/src/roched.nim
+++ b/src/roched.nim
@@ -917,7 +917,35 @@ proc handleFrame(sv: Server, sock: Socket): bool =
     sock.sendFrame("ERR unknown")
   true
 
+proc printUsage() =
+  echo "RocheDB node server"
+  echo ""
+  echo "Usage:"
+  echo "  roched --id=N --peers=host:port[,host:port...] [options]"
+  echo ""
+  echo "Options:"
+  echo "  --data=DIR                    Enable WAL-backed persistence"
+  echo "  --slow-tick=SECONDS           Background maintenance interval"
+  echo "  --durability=buffered|strong  Buffered WAL or fsync-on-write durability"
+  echo "  --user=NAME                   Username for cluster auth"
+  echo "  --password=TEXT               Password for cluster auth"
+  echo "  --auth-token=TEXT             Token-style auth shortcut"
+  echo "  --secret-key=TEXT             Additional secret-key gate"
+  echo "  --galaxy=NAME                 Expected galaxy name"
+  echo "  --allow-ring=PREFIX[,PREFIX]  Ring-prefix authorization"
+  echo "  --role=user:password:role[:prefixes]"
+  echo "                                Role entry: reader, writer, or admin"
+  echo "  -h, --help                    Show this help"
+  echo ""
+  echo "Example:"
+  echo "  roched --id=0 --peers=127.0.0.1:7301 --data=/var/lib/roche"
+
 proc main() =
+  for arg in commandLineParams():
+    if arg == "--help" or arg == "-h":
+      printUsage()
+      return
+
   var id = -1
   var peersStr = ""
   var dataDir = ""


### PR DESCRIPTION
Updates installation docs now that RocheDB is available through Nimble. Also adds a proper roched --help path so documented verification commands work.\n\nVerification:\n- nimble search rochedb\n- nimble --nimbleDir:/tmp/roche-nimble-install-test install -y rochedb\n- nimble --nimbleDir:/tmp/roche-nimble-local-v022 install -y\n- nimble check\n- nim c -d:release --nimcache:/tmp/nimcache_roche_doc_patch -o:bin/roche src/rochecli.nim\n- nim c -d:release --nimcache:/tmp/nimcache_roched_doc_patch -o:bin/roched src/roched.nim\n- bin/roche --help\n- bin/roched --help\n- Markdown relative link check for README and docs