### PR TITLE
Remove roched selector warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.2.3
+
+### Fixed
+
+- Removed the `roched` selector `getData` path that triggered Nim's
+  `ProveInit` warning during server builds.
+- Bumped package metadata to `0.2.3`.
+
 ## v0.2.2
 
 ### Changed

--- a/rochedb.nimble
+++ b/rochedb.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version     = "0.2.2"
+version     = "0.2.3"
 author      = "puffball1567"
 description = "Ring-oriented NoSQL document/vector store for smaller working sets"
 license     = "Apache-2.0"

--- a/src/roched.nim
+++ b/src/roched.nim
@@ -1030,7 +1030,9 @@ proc main() =
         else: " auth=off")
 
   var sel = newSelector[int]()
-  sel.registerHandle(listener.getFd, {Event.Read}, -1)
+  let listenerFd = listener.getFd
+  let listenerFdInt = listenerFd.int
+  sel.registerHandle(listenerFd, {Event.Read}, 0)
   var conns = initTable[int, Socket]()
 
   var lastTick = getMonoTime()
@@ -1040,7 +1042,7 @@ proc main() =
       if ev.errorCode.int != 0:
         continue
       let fd = ev.fd
-      if sel.getData(fd) == -1:
+      if fd == listenerFdInt:
         var client: Socket
         listener.accept(client)
         client.setSockOpt(OptNoDelay, true, level = IPPROTO_TCP.cint)


### PR DESCRIPTION
Removes the selector getData path in roched that triggered Nim's ProveInit warning during server builds, then bumps package metadata to v0.2.3.\n\nVerification:\n- nim c -d:release --nimcache:/tmp/nimcache_roched_no_getdata -o:bin/roched src/roched.nim\n- bin/roched --help\n- scripts/cli_crud_smoke.sh\n- nimble check\n- nimble --nimbleDir:/tmp/roche-nimble-local-v023 install -y\n- git diff --check