### PR TITLE
fix: restore cluster read-path performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## v0.2.5
+
+### Fixed
+
+- Restored the cluster read path after transaction landing-zone reads had added
+  an avoidable request before ordinary `GET` / `BGET` operations.
+- Kept read-your-writes behavior for accepted-but-not-yet-applied cluster
+  writes by tracking only the pending IDs written through the current client.
+- Fixed the benchmark stable-ring guard so full-period orbits are not
+  misclassified as stable during cluster latency tests.
+
+### Changed
+
+- Updated PostgreSQL and Redis benchmark documentation with the 2026-07-08
+  local retest results.
+- Added comparison-friendly benchmark tables.
+- Bumped package metadata to `0.2.5`.
+
+## v0.2.4
+
+### Added
+
+- Added driver discovery and installation guidance through `roche driver
+  list`, `roche driver info`, and `roche driver install`.
+- Added Rust driver install targeting for manifest path, project directory, and
+  environment-variable based setup.
+
+### Changed
+
+- Removed the Rust driver implementation from the core repository so language
+  drivers can be released from separate repositories.
+
 ## v0.2.3
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -310,15 +310,18 @@ application processing.
 | API minimum test | 2 rings / 4 vectors | `skippedVectors` and `candidateReduction` confirm pre-filtered search scope |
 
 Reference latency results are tracked in
-[docs/rochedb-bench.md](docs/rochedb-bench.md). The short version is:
+[docs/rochedb-bench.md](docs/rochedb-bench.md), with compact comparison tables
+in [docs/benchmark-comparison.md](docs/benchmark-comparison.md). The short
+version is:
 
-- RocheDB 3-node TCP with persistence enabled measured `45.6 us` per single-key
-  read and `49.2 us` per single-key write in the local smoke benchmark.
-- PostgreSQL 14 on the same machine measured `84 us` for primary-key read and
-  `77 us` for `synchronous_commit=off` single-row write in the referenced
-  comparison.
-- A Docker Redis smoke test measured RocheDB TCP `BGET` at `1.56 us/op` and
-  Redis pipeline GET at `3.56 us/op` under the documented local conditions.
+- RocheDB 3-node TCP with persistence enabled measured `45.2-46.5 us` per
+  single-key read and `48.5-49.0 us` per single-key write in repeated local
+  benchmark runs.
+- PostgreSQL 14 on the same machine measured `75 us` for primary-key read and
+  `80 us` for `synchronous_commit=off` single-row write over local TCP.
+- Local Redis 6.0.16 measured `41.23 us/op` for single GET and `3.68 us/op`
+  for pipeline GET. RocheDB TCP GET measured `44.87 us/op`; RocheDB TCP BGET
+  measured `1.47 us/op` in the same local single-client benchmark shape.
 
 These are not universal performance claims. They show that the local read path
 is already competitive enough for the working-set reduction story to matter.

--- a/docs/benchmark-comparison.md
+++ b/docs/benchmark-comparison.md
@@ -1,0 +1,51 @@
+---
+layout: page
+title: Benchmark Comparison Tables
+---
+
+# Benchmark Comparison Tables
+
+This page keeps the benchmark numbers in comparison-friendly tables. It is a
+companion to [Benchmark Notes](rochedb-bench.md), which contains the full
+conditions, reproduction notes, and interpretation.
+
+These are local measurements, not universal performance claims.
+
+## PostgreSQL Reference
+
+Environment summary: same machine as RocheDB, AMD Ryzen 5 5600H, Linux 6.8,
+Nim 2.2.10, PostgreSQL 14.23, local TCP, single client, 100-byte payload where
+applicable.
+
+| Group | Operation | us/op | Notes |
+|---|---|---:|---|
+| RocheDB | single-key read | 45.2-46.5 | Three `roched` nodes, persistence enabled |
+| RocheDB | single-row write | 48.5-49.0 | Three `roched` nodes, persistence enabled |
+| RocheDB | strong-durability write | not measured | `durStrong` / `--durability=strong` was not part of this comparison |
+| PostgreSQL 14 | primary-key `SELECT` | 75 | `pgbench -M prepared`, 13.3k tps |
+| PostgreSQL 14 | single-row write, `synchronous_commit=off` | 80 | `pgbench -M prepared`, 12.5k tps |
+| PostgreSQL 14 | single-row write, `synchronous_commit=on` | 1961 | `pgbench -M prepared`, 510 tps |
+
+## Redis Reference
+
+Environment summary: same machine as RocheDB, AMD Ryzen 5 5600H, Linux 6.8,
+Nim 2.2.10, local Redis 6.0.16, one local `roched`, persistence disabled,
+local TCP, single client, 100-byte payload, `n=1000`, Redis pipeline batch size
+256.
+
+| Group | Operation | us/op | Notes |
+|---|---|---:|---|
+| RocheDB | embedded get | 0.03 | In-process hot path; no TCP |
+| RocheDB | TCP GET | 44.87 | One request / one response |
+| RocheDB | TCP BGET | 1.47 | Batch read; comparable axis to Redis pipeline |
+| Redis 6.0.16 | localhost GET | 41.23 | Non-pipelined local Redis |
+| Redis 6.0.16 | pipeline GET | 3.68 | Batch size 256 |
+
+## Working-Set And Token Reduction
+
+| Benchmark | Setup | Result |
+|---|---|---|
+| Working-set | 100 rings / 10k docs | scanned/query `10000 -> 100` |
+| Memory-pressure | 100 rings / 100k docs / 512-byte payload | candidate memory/query `93.079 MiB -> 0.931 MiB` |
+| Synthetic RAG | fixed recall | recall `1.000`, scanned/query `8000 -> 1000`, tokens/query `3960 -> 657.8` |
+| AI/RAG case study | generated JSONL, 400 docs / 6 rings | recall `1.000`, scanned/query `400 -> 40`, tokens/query `615.2 -> 231.6` |

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@ downstream AI/RAG or application logic.
 - [How RocheDB Differs From Typical NoSQL](nosql-positioning.md)
 - [Feature Status / Roadmap](rochedb-status.md)
 - [Benchmark Notes](rochedb-bench.md)
+- [Benchmark Comparison Tables](benchmark-comparison.md)
 
 ## Core Guides
 

--- a/docs/rochedb-bench.md
+++ b/docs/rochedb-bench.md
@@ -96,32 +96,45 @@ measured layer: core `27.5 ns`, public API `54.7 ns`, and C ABI `77.7 ns`.
 
 # Cluster Mode and PostgreSQL Reference
 
-- Date: 2026-07-04, after the initial scale-out implementation
-- Environment: same machine, AMD Ryzen 5 5600H
+- Date: 2026-07-08, after the v0.2.5 read-path and benchmark-ring fixes
+- Environment: same machine, AMD Ryzen 5 5600H / Linux 6.8 / Nim 2.2.10
 - RocheDB setup: three `roched` nodes, persistence enabled, single client,
   persistent TCP connection, 100-byte payload, `n=10000`
 - Reproduction: start three `roched` processes with `--id=k --peers=...
   --data=...`, then run `roche bench --peers=... --n=10000`
-- Benchmark guard: the client chooses a stable ring whose arc ownership does not
-  cross a boundary during the run, using `locate(now) == locate(now + 60s)`
+- Benchmark guard: the client configures a long-period benchmark ring and
+  samples `locate` across the measurement horizon. The selected ring must stay
+  on one owner during the run so handoff traffic is not mixed into the local
+  request-path measurement.
 
 ## RocheDB Cluster Path
 
 | Operation | us/op | ops/s |
 |---|---:|---:|
-| put, location calculation + 1 RTT + append log | 49.2 | 20,327 |
-| get, location calculation + 1 RTT | 45.6 | 21,947 |
-| query, server-side JSON projection | 52.5 | 19,046 |
+| put, location calculation + 1 RTT + append log | 48.5-49.0 | 20,388-20,601 |
+| get, location calculation + 1 RTT | 45.2-46.5 | 21,506-22,100 |
+| query, server-side JSON projection | 50.4-52.5 | 19,051-19,856 |
 
 ## PostgreSQL 14 Reference
 
-Same machine, single connection, TCP, measured with `pgbench`.
+Same machine, temporary local PostgreSQL 14.23 cluster, single client, single
+thread, TCP endpoint `127.0.0.1:55432`, `pgbench -M prepared`.
 
-| Operation | RocheDB | PostgreSQL 14 | Ratio |
-|---|---:|---:|---:|
-| single-key read | 45.6 us | 84 us, primary-key `SELECT`, 11.9k tps | 1.8x |
-| single-row write | 49.2 us | 77 us, `synchronous_commit=off`, 13.0k tps | 1.6x |
-| single-row write, strong durability | not measured in this comparison | 2010 us, `synchronous_commit=on`, 497 tps | n/a |
+### RocheDB Measurements
+
+| Operation | us/op | Notes |
+|---|---:|---|
+| single-key read | 45.2-46.5 | Three `roched` nodes, persistence enabled |
+| single-row write | 48.5-49.0 | Three `roched` nodes, persistence enabled |
+| strong-durability write | not measured | `durStrong` / `--durability=strong` was not part of this comparison |
+
+### PostgreSQL Measurements
+
+| Operation | us/op | Notes |
+|---|---:|---|
+| primary-key `SELECT` | 75 | 13.3k tps |
+| single-row write, `synchronous_commit=off` | 80 | 12.5k tps |
+| single-row write, `synchronous_commit=on` | 1961 | 510 tps |
 
 Interpretation: this compares a thin KV/document path with a SQL RDBMS path that
 includes parsing, planning, MVCC, and index maintenance. The defensible claim is
@@ -129,7 +142,7 @@ that RocheDB's network KV path is in the same latency class as PostgreSQL
 primary-key access and is ahead under these local conditions. RocheDB's
 durability mode in this comparison was closer to `synchronous_commit=off`.
 RocheDB now has `durStrong` / `--durability=strong`, but that path was not part
-of the 2026-07-04 PostgreSQL comparison.
+of the 2026-07-08 PostgreSQL comparison.
 
 ## Optimization History
 
@@ -138,9 +151,18 @@ An early cluster `get` measured around `1276 us`. Two issues dominated:
 1. A handoff scan ran after each ready `select`, adding roughly `200 us` of orbit
    calculation per request. This was throttled with a monotonic 100 ms gate.
 2. The benchmark accidentally chose a ring whose head angle sat on an arc
-   boundary, so 10,000 records migrated during the run. The benchmark now
-   chooses a stable ring. The storm itself was valid behavior, but reads during
-   that interval pay the wake-fallback cost.
+   boundary, so 10,000 records migrated during the run. The first guard only
+   compared `locate(now)` with `locate(now + 60s)`, which can misclassify a
+   full-period orbit as stable even when it crosses other nodes in between. The
+   benchmark now uses a long-period ring and samples intermediate points across
+   the measurement horizon. The storm itself was valid behavior, but reads
+   during that interval pay the wake-fallback cost.
+3. v0.2.4 added cluster transaction landing-zone reads. A first implementation
+   checked the landing zone before ordinary cluster GET/BGET, adding an
+   avoidable request to node0 on the normal read path. v0.2.5 tracks only IDs
+   written through accepted-but-not-yet-applied operations on the current client,
+   so ordinary reads use the direct owner path while those pending IDs can still
+   read their landing intent.
 
 During this work a TOCTOU race was found: a read could check the primary, then
 the wake, while the record moved forward and missed both. A final primary
@@ -150,29 +172,38 @@ revisit fixes this because movement is forward-only.
 
 # Redis Approximation and BGET
 
-- Date: 2026-07-04
+- Date: 2026-07-08, after the v0.2.5 landing-zone read-path fix
 - Environment: same machine, AMD Ryzen 5 5600H / Linux 6.8 / Nim 2.2.10
   `-d:release`
-- Redis: Docker `redis:7-alpine`, `--network host`, endpoint `127.0.0.1:6379`
+- Redis: local `/usr/bin/redis-server`, Redis 6.0.16, endpoint
+  `127.0.0.1:6379`
 - RocheDB TCP: local one-node `roched`, endpoint `127.0.0.1:17301`,
   persistence disabled, persistent TCP connection
 - Conditions: 100-byte payload, `n=1000`, single client, Redis pipeline batch
   size 256
-- Reproduction: `ROCHED=1 N=1000 PAYLOAD_BYTES=100 examples/redis_bench.sh`
+- Reproduction: start one local `roched`, then run
+  `roche redis-bench --n=1000 --payload-bytes=100 --redis=127.0.0.1:6379
+  --peers=127.0.0.1:17301`
 - Purpose: smoke-test whether RocheDB simple read and batch read are in the same
   latency class as Redis TCP and Redis pipeline under local constraints
 
 | Operation | us/op | Interpretation |
 |---|---:|---|
-| RocheDB embedded get | 0.05 | In-process hot path; no TCP |
-| RocheDB TCP get | 44.16 | One request / one response |
-| RocheDB TCP BGET | 1.56 | Batch read; comparable axis to Redis pipeline |
-| Redis localhost GET | 41.03 | Docker Redis, non-pipelined |
-| Redis pipeline GET | 3.56 | Batch size 256 |
+| RocheDB embedded get | 0.03 | In-process hot path; no TCP |
+| RocheDB TCP get | 44.87 | One request / one response |
+| RocheDB TCP BGET | 1.47 | Batch read; comparable axis to Redis pipeline |
+
+Redis measurements under the same local benchmark shape:
+
+| Operation | us/op | Interpretation |
+|---|---:|---|
+| Redis localhost GET | 41.23 | Local Redis, non-pipelined |
+| Redis pipeline GET | 3.68 | Batch size 256 |
 
 Interpretation: RocheDB TCP get is in the same latency class as non-pipelined
-Redis GET. In this smoke test, RocheDB TCP BGET was about 2.3x faster than Redis
-pipeline GET. This is not a claim that RocheDB is always faster than Redis.
+Redis GET, but local Redis was slightly faster for single GET. In this smoke
+test, RocheDB TCP BGET was about 2.5x faster than Redis pipeline GET. This is
+not a claim that RocheDB is always faster than Redis.
 Payload size, batch size, Redis configuration, network mode, and data size need
 broader measurement.
 

--- a/rochedb.nimble
+++ b/rochedb.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version     = "0.2.3"
+version     = "0.2.5"
 author      = "puffball1567"
 description = "Ring-oriented NoSQL document/vector store for smaller working sets"
 license     = "Apache-2.0"

--- a/src/rochecli.nim
+++ b/src/rochecli.nim
@@ -389,10 +389,19 @@ proc pickStableRing(db: RocheDb, horizon: float): string =
   ## using only the public API. This works because future location is computed.
   for i in 0 .. 20:
     result = "bench" & $i
+    db.configureRing(result, max(3600.0, horizon * 10.0))
     let probe = db.put("probe", ring = result)
-    if db.locate(probe) == db.locate(probe, at = epochTime() + horizon):
+    let t0 = epochTime()
+    let node = db.locate(probe, at = t0)
+    var stable = true
+    for step in 1 .. 10:
+      if db.locate(probe, at = t0 + horizon * float(step) / 10.0) != node:
+        stable = false
+        break
+    if stable:
       return
   result = "bench"
+  db.configureRing(result, max(3600.0, horizon * 10.0))
 
 proc runBench(peers, username, password, authToken, secretKey, galaxy: string, n: int) =
   var db = connect(peers, username = username, password = password,

--- a/src/rochedb.nim
+++ b/src/rochedb.nim
@@ -169,6 +169,7 @@ type
     client: ClusterClient
     galaxy: string
     galaxyDescription: string
+    pendingLandingReads: Table[(uint64, uint32), bool]
     # delayed maintenance jobs
     nextWarpId: uint64
     warpJobs: seq[WarpJob]
@@ -900,6 +901,19 @@ proc writeAckModeForOps(db: RocheDb, ops: seq[TxWireOp]): WriteAckMode =
     if db.writeAckModeForRing(op.parent) == wamApplied:
       return wamApplied
 
+proc markPendingLandingReads(db: RocheDb, ops: seq[TxWireOp]) =
+  if db.mode != mCluster:
+    return
+  for op in ops:
+    db.pendingLandingReads[(op.parent, op.seq)] = true
+
+proc clearPendingLandingRead(db: RocheDb, id: RocheId) =
+  if db.mode == mCluster:
+    db.pendingLandingReads.del((id.parent, id.seq))
+
+proc hasPendingLandingRead(db: RocheDb, id: RocheId): bool =
+  db.mode == mCluster and db.pendingLandingReads.getOrDefault((id.parent, id.seq), false)
+
 proc waitClusterTxApplied*(db: RocheDb, txid: uint64, timeoutMs = 10_000,
                            pollMs = 20): bool =
   ## cluster landing intent が owner に apply されるまで待つ。
@@ -1056,6 +1070,8 @@ proc commit*(tx: RocheTx) =
     if tx.db.writeAckModeForOps(tx.clusterOps) == wamApplied:
       if not tx.db.waitClusterTxApplied(tx.clusterTxId):
         raise newException(IOError, "cluster transaction apply timed out")
+    else:
+      tx.db.markPendingLandingReads(tx.clusterOps)
   tx.closed = true
 
 proc commit*(tx: RocheTx, ackMode: WriteAckMode) =
@@ -1069,6 +1085,8 @@ proc commit*(tx: RocheTx, ackMode: WriteAckMode) =
     if ackMode == wamApplied:
       if not tx.db.waitClusterTxApplied(tx.clusterTxId):
         raise newException(IOError, "cluster transaction apply timed out")
+    else:
+      tx.db.markPendingLandingReads(tx.clusterOps)
     tx.closed = true
 
 proc rollback*(tx: RocheTx) =
@@ -1104,13 +1122,16 @@ proc fetchCluster(db: RocheDb, id: RocheId, selection: string, fwdDepth = 0): st
     if r.found:
       return (true, false, r.value)
     if r.deleted:
+      db.clearPendingLandingRead(id)
       return (false, true, "")
     (false, false, "")
-  let pending = landingRead()
-  if pending.deleted:
-    raise newException(KeyError, "id は cluster tx landing intent で削除済み")
-  if pending.hit:
-    return pending.value
+  if db.hasPendingLandingRead(id):
+    let pending = landingRead()
+    if pending.deleted:
+      raise newException(KeyError, "id は cluster tx landing intent で削除済み")
+    if pending.hit:
+      return pending.value
+    db.clearPendingLandingRead(id)
   for node in [primary, (primary + n - 1) mod n, primary]:
     var r: tuple[found: bool, node: int, value: string, forwarded: bool,
                  newParent: uint64, newSeq: uint32, newTWrite: float]
@@ -1164,18 +1185,7 @@ proc batchGet*(db: RocheDb, ids: seq[RocheId]): seq[string] =
     var byNode = initTable[int, seq[tuple[idx: int, id: RocheId]]]()
     let t = epochTime()
     result = newSeq[string](ids.len)
-    var resolved = newSeq[bool](ids.len)
     for i, id in ids:
-      let ri = db.rings[id.parent]
-      let pending = db.client.txGetIdReq(0, WireId(parent: id.parent,
-        epoch: id.epoch, seq: id.seq, tWrite: id.tWrite, period: ri.period,
-        head: ri.headAngle))
-      if pending.deleted:
-        raise newException(KeyError, "id は cluster tx landing intent で削除済み")
-      if pending.found:
-        result[i] = pending.value
-        resolved[i] = true
-        continue
       let node = int(db.tbl.node(db.orbitOf(id), t))
       byNode.mgetOrPut(node, @[]).add (idx: i, id: id)
     for node, entries in byNode:
@@ -1188,11 +1198,10 @@ proc batchGet*(db: RocheDb, ids: seq[RocheId]): seq[string] =
       let values = db.client.batchGetReq(node, req)
       for i, value in values:
         let idx = entries[i].idx
-        if not resolved[idx]:
-          if value.len == 0:
-            result[idx] = db.get(entries[i].id)
-          else:
-            result[idx] = value
+        if value.len == 0:
+          result[idx] = db.get(entries[i].id)
+        else:
+          result[idx] = value
 
 proc exists*(db: RocheDb, id: RocheId): bool =
   ## ORM / driver 向けの存在確認。cluster では get による確認。
@@ -1225,6 +1234,8 @@ proc remove*(db: RocheDb, id: RocheId) =
     if db.writeAckModeForOps(ops) == wamApplied:
       if not db.waitClusterTxApplied(txid):
         raise newException(IOError, "cluster delete apply timed out")
+    else:
+      db.markPendingLandingReads(ops)
 
 proc deleteById*(db: RocheDb, id: RocheId) =
   ## ORM で直感的に使うための alias。
@@ -1257,6 +1268,8 @@ proc update*(db: RocheDb, id: RocheId, payload: string,
     if db.writeAckModeForOps(ops) == wamApplied:
       if not db.waitClusterTxApplied(txid):
         raise newException(IOError, "cluster update apply timed out")
+    else:
+      db.markPendingLandingReads(ops)
 
 proc update*(db: RocheDb, id: RocheId, doc: JsonNode,
              vec: seq[float32] = @[]) =


### PR DESCRIPTION
## Summary
- restore ordinary cluster GET/BGET read paths after landing-zone transaction support
- stabilize benchmark ring selection for cluster latency runs
- update PostgreSQL/Redis benchmark docs and add comparison tables
- bump RocheDB package metadata to v0.2.5

## Verification
- scripts/test_core.sh
- scripts/cluster_tx_smoke.sh