### PR TITLE
docs: add redis benchmark helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,14 +401,13 @@ examples/ai_rag_case_study.sh
 Use an existing local Redis server:
 
 ```sh
-roche redis-bench --n=100000 --payload-bytes=100 --redis=127.0.0.1:6379
+N=1000 examples/redis_local_bench.sh
 ```
 
-Or use the Docker-based smoke comparison:
+Or compare Redis and RocheDB inside the same Docker network:
 
 ```sh
-examples/redis_bench.sh
-ROCHED=1 examples/redis_bench.sh
+N=1000 examples/redis_docker_bench.sh
 ```
 
 ### Server Options

--- a/docs/benchmark-comparison.md
+++ b/docs/benchmark-comparison.md
@@ -35,12 +35,16 @@ Nim 2.2.10, local Redis 6.0.16, one local `roched`, persistence disabled,
 local TCP, single client, 100-byte payload, `n=1000`, Redis pipeline batch size
 256.
 
+Local reproduction helper: `N=1000 examples/redis_local_bench.sh`.
+
+Docker reproduction helper: `N=1000 examples/redis_docker_bench.sh`.
+
 | Group | Operation | us/op | Notes |
 |---|---|---:|---|
 | RocheDB | embedded get | 0.03 | In-process hot path; no TCP |
 | RocheDB | TCP GET | 44.87 | One request / one response |
 | RocheDB | TCP BGET | 1.47 | Batch read; comparable axis to Redis pipeline |
-| Redis 6.0.16 | localhost GET | 41.23 | Non-pipelined local Redis |
+| Redis 6.0.16 | TCP GET | 41.23 | Non-pipelined local Redis |
 | Redis 6.0.16 | pipeline GET | 3.68 | Batch size 256 |
 
 ## Working-Set And Token Reduction

--- a/docs/rochedb-bench.md
+++ b/docs/rochedb-bench.md
@@ -188,6 +188,11 @@ revisit fixes this because movement is forward-only.
 - Reproduction: start one local `roched`, then run
   `roche redis-bench --n=1000 --payload-bytes=100 --redis=127.0.0.1:6379
   --peers=127.0.0.1:17301`
+- Local reproduction helper: `N=1000 examples/redis_local_bench.sh` starts one
+  local `roched` and compares it with an existing local Redis endpoint.
+- Docker reproduction helper: `N=1000 examples/redis_docker_bench.sh` builds a
+  RocheDB Docker image, starts Redis and RocheDB on the same Docker network, and
+  runs the benchmark from inside that network.
 - Purpose: smoke-test whether RocheDB simple read and batch read are in the same
   latency class as Redis TCP and Redis pipeline under local constraints
 
@@ -201,7 +206,7 @@ Redis measurements under the same local benchmark shape:
 
 | Operation | us/op | Interpretation |
 |---|---:|---|
-| Redis localhost GET | 41.23 | Local Redis, non-pipelined |
+| Redis TCP GET | 41.23 | Local Redis, non-pipelined |
 | Redis pipeline GET | 3.68 | Batch size 256 |
 
 Interpretation: RocheDB TCP get is in the same latency class as non-pipelined

--- a/examples/redis_docker_bench.sh
+++ b/examples/redis_docker_bench.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+N="${N:-1000}"
+PAYLOAD_BYTES="${PAYLOAD_BYTES:-100}"
+REDIS_IMAGE="${REDIS_IMAGE:-redis:7-alpine}"
+ROCHED_IMAGE="${ROCHED_IMAGE:-rochedb-bench:local}"
+NETWORK="${NETWORK:-rochedb-redis-bench-$$}"
+REDIS_CONTAINER="${REDIS_CONTAINER:-roche-redis-bench-$$}"
+ROCHED_CONTAINER="${ROCHED_CONTAINER:-roche-roched-bench-$$}"
+BUILD_IMAGE="${BUILD_IMAGE:-1}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cleanup() {
+  docker rm -f "$REDIS_CONTAINER" "$ROCHED_CONTAINER" >/dev/null 2>&1 || true
+  docker network rm "$NETWORK" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "missing required command: docker" >&2
+  exit 127
+fi
+
+cd "$ROOT"
+
+if [[ "$BUILD_IMAGE" == "1" ]]; then
+  echo "[redis-docker-bench] build RocheDB image $ROCHED_IMAGE"
+  docker build -f examples/compose/Dockerfile -t "$ROCHED_IMAGE" .
+fi
+
+cleanup
+docker network create "$NETWORK" >/dev/null
+
+echo "[redis-docker-bench] start Redis container"
+docker run -d --rm --network "$NETWORK" --name "$REDIS_CONTAINER" "$REDIS_IMAGE" >/dev/null
+
+for _ in $(seq 1 50); do
+  if docker exec "$REDIS_CONTAINER" redis-cli ping >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.1
+done
+docker exec "$REDIS_CONTAINER" redis-cli ping >/dev/null
+
+echo "[redis-docker-bench] start RocheDB container"
+docker run -d --rm --network "$NETWORK" --name "$ROCHED_CONTAINER" \
+  "$ROCHED_IMAGE" --id=0 --peers=0.0.0.0:17301 >/dev/null
+
+for _ in $(seq 1 50); do
+  if docker run --rm --network "$NETWORK" --entrypoint /usr/local/bin/rochecli \
+    "$ROCHED_IMAGE" health --peers="$ROCHED_CONTAINER:17301" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.1
+done
+docker run --rm --network "$NETWORK" --entrypoint /usr/local/bin/rochecli \
+  "$ROCHED_IMAGE" health --peers="$ROCHED_CONTAINER:17301" >/dev/null
+
+echo "[redis-docker-bench] run RocheDB/Redis benchmark inside Docker network"
+docker run --rm --network "$NETWORK" --entrypoint /usr/local/bin/rochecli \
+  "$ROCHED_IMAGE" redis-bench \
+  --n="$N" \
+  --payload-bytes="$PAYLOAD_BYTES" \
+  --redis="$REDIS_CONTAINER:6379" \
+  --peers="$ROCHED_CONTAINER:17301"

--- a/examples/redis_local_bench.sh
+++ b/examples/redis_local_bench.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+N="${N:-1000}"
+PAYLOAD_BYTES="${PAYLOAD_BYTES:-100}"
+REDIS_ENDPOINT="${REDIS_ENDPOINT:-127.0.0.1:6379}"
+ROCHED_PEERS="${ROCHED_PEERS:-127.0.0.1:17301}"
+DATA="${TMPDIR:-/tmp}/rochedb-redis-local-bench-$$"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROCHED_PID=""
+
+cleanup() {
+  if [[ -n "$ROCHED_PID" ]]; then
+    kill "$ROCHED_PID" >/dev/null 2>&1 || true
+    wait "$ROCHED_PID" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$DATA"
+}
+trap cleanup EXIT
+
+if ! command -v nim >/dev/null 2>&1; then
+  echo "missing required command: nim" >&2
+  exit 127
+fi
+if command -v redis-cli >/dev/null 2>&1; then
+  redis-cli -h "${REDIS_ENDPOINT%:*}" -p "${REDIS_ENDPOINT##*:}" ping >/dev/null
+fi
+
+cd "$ROOT"
+mkdir -p "$DATA" bin
+
+echo "[redis-local-bench] build RocheDB binaries"
+nim c -d:release --nimcache:/tmp/nimcache_roched -o:bin/roched src/roched.nim
+nim c -d:release --nimcache:/tmp/nimcache_rochecli -o:bin/roche src/rochecli.nim
+
+echo "[redis-local-bench] start one local roched on $ROCHED_PEERS"
+bin/roched --id=0 --peers="$ROCHED_PEERS" --data="$DATA/node0" &
+ROCHED_PID="$!"
+
+for _ in $(seq 1 50); do
+  if bin/roche health --peers="$ROCHED_PEERS" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.1
+done
+bin/roche health --peers="$ROCHED_PEERS" >/dev/null
+
+echo "[redis-local-bench] run RocheDB/Redis benchmark"
+bin/roche redis-bench \
+  --n="$N" \
+  --payload-bytes="$PAYLOAD_BYTES" \
+  --redis="$REDIS_ENDPOINT" \
+  --peers="$ROCHED_PEERS"

--- a/src/rochecli.nim
+++ b/src/rochecli.nim
@@ -811,8 +811,8 @@ proc runRedisBench(n, payloadBytes: int, redisEndpoint, peers, username,
     echo &"  RocheDB TCP put      {rocheTcpPutUs:8.2f} µs/op ({1e6 / rocheTcpPutUs:9.0f} ops/s)"
     echo &"  RocheDB TCP get      {rocheTcpGetUs:8.2f} µs/op ({1e6 / rocheTcpGetUs:9.0f} ops/s)"
     echo &"  RocheDB TCP batch get{rocheTcpBatchGetUs:8.2f} µs/op ({1e6 / rocheTcpBatchGetUs:9.0f} ops/s)"
-  echo &"  Redis localhost SET  {redisSetUs:8.2f} µs/op ({1e6 / redisSetUs:9.0f} ops/s)"
-  echo &"  Redis localhost GET  {redisGetUs:8.2f} µs/op ({1e6 / redisGetUs:9.0f} ops/s)"
+  echo &"  Redis TCP SET        {redisSetUs:8.2f} µs/op ({1e6 / redisSetUs:9.0f} ops/s)"
+  echo &"  Redis TCP GET        {redisGetUs:8.2f} µs/op ({1e6 / redisGetUs:9.0f} ops/s)"
   echo &"  Redis pipeline SET   {redisPipeSetUs:8.2f} µs/op ({1e6 / redisPipeSetUs:9.0f} ops/s)"
   echo &"  Redis pipeline GET   {redisPipeGetUs:8.2f} µs/op ({1e6 / redisPipeGetUs:9.0f} ops/s)"
   if peers.len > 0:


### PR DESCRIPTION
## Summary
- add local-local Redis/RocheDB benchmark helper
- add Docker-Docker Redis/RocheDB benchmark helper
- document both reproduction paths
- rename Redis benchmark output from localhost to TCP so Docker runs are not misleading

## Verification
- N=20 ROCHED_PEERS=127.0.0.1:17521 examples/redis_local_bench.sh
- N=10 NETWORK=rochedb-redis-bench-test REDIS_CONTAINER=roche-redis-bench-test ROCHED_CONTAINER=roche-roched-bench-test examples/redis_docker_bench.sh