### PR TITLE
docs: mark Rust and JS drivers as published

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ corpus size toward semantic working-set size.
 ## Installation
 
 RocheDB v0.2.x is a technical preview. The Nim package is available through
-Nimble, while non-Nim language packages are still repository-local foundations.
+Nimble. Rust and JavaScript / TypeScript drivers are published separately, while
+the remaining non-Nim language drivers are still repository-local foundations.
 
 Prerequisites:
 
@@ -230,8 +231,15 @@ high-level wire frames such as `PUTR`, `GETID`, `QRYID`, `BGET`, and
 `RETRIEVE`; they do not need to reimplement RocheDB's ring-key, orbit, or ID
 rules.
 
-The table below lists current repository-local driver foundations. Publication
-priority for language packages is tracked in
+Published external drivers:
+
+| Language / runtime | Package | Version | Repository | Mode |
+|---|---|---:|---|---|
+| Rust | [`rochedb`](https://crates.io/crates/rochedb) | `0.1.3` | [`puffball1567/rochedb-rust`](https://github.com/puffball1567/rochedb-rust) | C ABI wrapper |
+| JavaScript / TypeScript | [`rochedb`](https://www.npmjs.com/package/rochedb) | `0.1.2` | [`puffball1567/rochedb-js`](https://github.com/puffball1567/rochedb-js) | Node-API C ABI wrapper |
+
+The table below lists current core-repository driver foundations. Publication
+priority for remaining language packages is tracked in
 [docs/rochedb-driver-roadmap.md](docs/rochedb-driver-roadmap.md).
 
 | Language / runtime | Driver path | Current mode | Smoke status |
@@ -248,13 +256,11 @@ priority for language packages is tracked in
 | C++ | `drivers/cpp` | C++17 C ABI wrapper | contract smoke |
 | Kotlin/JVM | `drivers/kotlin` | JNI / C ABI wrapper | Docker smoke |
 
-Rust is the first external driver publication target and is being split out of
-the core repository. Its package link will be added when published.
-
 Detailed setup notes are in
 [docs/driver-installation.md](docs/driver-installation.md). Nimble package
-registration is complete. Package publishing to npm, PyPI, Cargo, Composer,
-NuGet, Maven, and other non-Nim registries remains a post-v0.2 roadmap item.
+registration is complete. Rust and JavaScript / TypeScript driver packages are
+published; PyPI, Composer, NuGet, Maven, Go, SwiftPM, and other registry
+packages remain roadmap items.
 
 ## Cluster Mode
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -94,9 +94,10 @@ For Rust it resolves the target `Cargo.toml` in this order:
 4. `ROCHE_DRIVER_PROJECT`
 5. `Cargo.toml` in the current directory
 
-Pass `--execute` to run the package-manager command after the driver package is
-published. Until then, RocheDB refuses to execute `cargo add` for unpublished
-drivers and prints the command instead.
+Pass `--execute` to run the package-manager command when the selected driver is
+published and the target project can be resolved. RocheDB refuses to execute
+package-manager commands for unpublished drivers and prints the command
+instead.
 
 | Command | Purpose |
 |---|---|

--- a/docs/driver-installation.md
+++ b/docs/driver-installation.md
@@ -22,8 +22,9 @@ For Rust, target selection is shell-friendly: use `--manifest-path=FILE`,
 `--project-dir=DIR`, `ROCHE_DRIVER_MANIFEST`, or `ROCHE_DRIVER_PROJECT`.
 It does not execute package-manager commands unless `--execute` is passed.
 
-The Nim package is available through Nimble. Non-Nim drivers are still
-repository-local foundations, so the driver examples below assume a local clone
+The Nim package is available through Nimble. Rust and JavaScript / TypeScript
+drivers are also published as language-native packages. Other non-Nim drivers
+are still repository-local foundations, so those examples assume a local clone
 of this repository.
 
 ## Optional FAISS Setup
@@ -114,9 +115,25 @@ db.close()
 
 For package-style local development, add `drivers/python` to `PYTHONPATH`.
 
-## Node.js / TypeScript / Bun
+## JavaScript / TypeScript
 
-The Node/Bun driver is a native TCP wire driver.
+The published JavaScript / TypeScript driver is a Node-API wrapper over the
+RocheDB C ABI:
+
+- npm: [`rochedb` v0.1.2](https://www.npmjs.com/package/rochedb)
+- repository: [`puffball1567/rochedb-js`](https://github.com/puffball1567/rochedb-js)
+
+Install it in an application:
+
+```sh
+npm install rochedb
+```
+
+Build the RocheDB core shared library first and set `ROCHEDB_CORE_DIR` during
+install/rebuild. See the driver repository README for the full setup flow.
+
+The core repository also keeps a repository-local native TCP wire driver used
+for protocol smoke tests:
 
 ```sh
 nim c -d:release --nimcache:/tmp/nimcache_roched -o:src/roched src/roched.nim
@@ -124,7 +141,7 @@ node --test drivers/node/test/*.test.js
 bun test drivers/node/test-bun/*.test.ts
 ```
 
-Use the local package path until npm publication exists:
+Repository-local wire-driver example:
 
 ```js
 import { RocheClient } from "./drivers/node/src/index.js";
@@ -137,13 +154,26 @@ await db.close();
 
 ## Rust
 
-The Rust driver is being split out into a separate driver package and
-repository. It is the first external driver publication target in the driver
-roadmap. The Cargo package link and installation command will be added here
-when it is published.
+The Rust driver is published as a C ABI wrapper:
 
-Until then, Rust integrations can bind to the stable C ABI exposed through
-`include/rochedb.h` and `lib/librochedb.so`.
+- crates.io: [`rochedb` v0.1.3](https://crates.io/crates/rochedb)
+- repository: [`puffball1567/rochedb-rust`](https://github.com/puffball1567/rochedb-rust)
+
+Install it in a Rust project:
+
+```sh
+cargo add rochedb
+```
+
+Or ask the RocheDB CLI to print the official setup command:
+
+```sh
+roche driver install rust --manifest-path=/path/to/Cargo.toml
+```
+
+Build the RocheDB core shared library first and set `ROCHEDB_CORE_DIR` or
+`ROCHEDB_LIB_DIR` when building/testing the Rust project. See the Rust driver
+repository README for the full setup flow.
 
 ## Go
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -106,7 +106,7 @@ These are important, but should not block the first technical preview:
 - WASM browser build
 - FlowBrigade / FlowLogbook adapter
 - enterprise plugin features
-- package publication to npm / PyPI / Cargo / Composer / NuGet / Maven
+- remaining package publication to PyPI / Composer / NuGet / Maven / Go / SwiftPM
 - fault-tolerance improvements
 - cluster repair and integrity verification
 

--- a/docs/rochedb-driver-roadmap.md
+++ b/docs/rochedb-driver-roadmap.md
@@ -39,8 +39,8 @@ and atlas access.
 
 | Priority | Target | Reason | Status |
 |---:|---|---|---|
-| 1 | Rust driver | High-performance infrastructure, gateway, and systems integration path | Split out of core repo; external package in preparation |
-| 2 | Node.js / TypeScript / Bun native wire driver | Web API, SaaS, Studio, GUI, and local AI client entry point | Minimal done; Bun smoke added |
+| 1 | Rust driver | High-performance infrastructure, gateway, and systems integration path | Published: crates.io [`rochedb` v0.1.3](https://crates.io/crates/rochedb), repository [`puffball1567/rochedb-rust`](https://github.com/puffball1567/rochedb-rust) |
+| 2 | JavaScript / TypeScript driver | Web API, SaaS, Studio, GUI, and local AI client entry point | Published: npm [`rochedb` v0.1.2](https://www.npmjs.com/package/rochedb), repository [`puffball1567/rochedb-js`](https://github.com/puffball1567/rochedb-js). Bun remains experimental on the same Node-API path |
 | 3 | PHP driver | Laravel and existing business web systems | Minimal FFI / C ABI wrapper done. Docker smoke added |
 | 4 | C++ driver | Generic native and engine integration base. Unreal plugin stays separate | Minimal C ABI wrapper done |
 | 5 | Python native wire driver | AI/RAG and broad scripting entry point without making big-data positioning the first message | Minimal done |

--- a/docs/rochedb-status.de.md
+++ b/docs/rochedb-status.de.md
@@ -60,14 +60,14 @@ Release checklist: [release-checklist.md](./release-checklist.md)
 | Nim API | Done | Native public API |
 | C ABI | Done | ABI version / last error / put/get/retrieve/batch/atlas |
 | Python | Done | Native wire minimal |
-| Node.js / TypeScript / Bun | Done | ESM native wire minimal |
-| Rust | In progress | Split out of core repo; external driver package planned first |
+| Node.js / TypeScript / Bun | Partially published | npm `rochedb` v0.1.2. Bun remains experimental |
+| Rust | Published | crates.io `rochedb` v0.1.3; see the English canonical document for links |
 | Go | Done | C ABI wrapper minimal |
 | PHP / Swift / Kotlin | Done | Docker smoke available |
 | C# / C++ | Done | OSS generic wrappers; Unity / Unreal official assets are separate candidates |
 | React Native / WASM | Post-v0.1 candidate | Browser / local state boundary |
 | Driver discovery CLI | Done | `roche driver list/info/install` prints official driver metadata and setup commands without executing remote scripts |
-| Nimble package publishing | Done | `nimble install rochedb` is available. Non-Nim registries remain future work |
+| Package publishing | Partial | `nimble install rochedb`, `cargo add rochedb`, and `npm install rochedb` are available. Other registries remain future work |
 
 ## Benchmarks / Demos
 

--- a/docs/rochedb-status.fr.md
+++ b/docs/rochedb-status.fr.md
@@ -60,14 +60,14 @@ Release checklist: [release-checklist.md](./release-checklist.md)
 | Nim API | Done | Native public API |
 | C ABI | Done | ABI version / last error / put/get/retrieve/batch/atlas |
 | Python | Done | Native wire minimal |
-| Node.js / TypeScript / Bun | Done | ESM native wire minimal |
-| Rust | In progress | Split out of core repo; external driver package planned first |
+| Node.js / TypeScript / Bun | Partially published | npm `rochedb` v0.1.2. Bun remains experimental |
+| Rust | Published | crates.io `rochedb` v0.1.3; see the English canonical document for links |
 | Go | Done | C ABI wrapper minimal |
 | PHP / Swift / Kotlin | Done | Docker smoke available |
 | C# / C++ | Done | OSS generic wrappers; Unity / Unreal official assets are separate candidates |
 | React Native / WASM | Post-v0.1 candidate | Browser / local state boundary |
 | Driver discovery CLI | Done | `roche driver list/info/install` prints official driver metadata and setup commands without executing remote scripts |
-| Nimble package publishing | Done | `nimble install rochedb` is available. Non-Nim registries remain future work |
+| Package publishing | Partial | `nimble install rochedb`, `cargo add rochedb`, and `npm install rochedb` are available. Other registries remain future work |
 
 ## Benchmarks / Demos
 

--- a/docs/rochedb-status.ja.md
+++ b/docs/rochedb-status.ja.md
@@ -59,14 +59,14 @@
 | Nim API | 完了 | Native public API |
 | C ABI | 完了 | ABI version / last error / put/get/retrieve/batch/atlas |
 | Python | 完了 | Native wire minimal |
-| Node.js / TypeScript / Bun | 完了 | ESM native wire minimal |
-| Rust | 進行中 | core repo から分離中。外部 driver package を優先予定 |
+| Node.js / TypeScript / Bun | 一部公開済み | npm `rochedb` v0.1.2。Bun は実験的 |
+| Rust | 公開済み | crates.io `rochedb` v0.1.3。詳細は英語正本を参照 |
 | Go | 完了 | C ABI wrapper minimal |
 | PHP / Swift / Kotlin | 完了 | Docker smoke あり |
 | C# / C++ | 完了 | OSS generic wrappers。Unity / Unreal 公式 asset は別候補 |
 | React Native / WASM | v0.1 後の候補 | Browser / local state boundary |
 | Driver discovery CLI | 完了 | `roche driver list/info/install` が公式 driver metadata と setup command を表示。remote script は実行しない |
-| Nimble package publishing | 完了 | `nimble install rochedb` が利用可能。非Nimレジストリは今後の作業 |
+| Package publishing | 一部完了 | `nimble install rochedb`, `cargo add rochedb`, `npm install rochedb` が利用可能。その他のレジストリは今後 |
 
 ## Benchmarks / Demos
 

--- a/docs/rochedb-status.ko.md
+++ b/docs/rochedb-status.ko.md
@@ -59,14 +59,14 @@ Release checklist: [release-checklist.md](./release-checklist.md)
 | Nim API | Done | Native public API |
 | C ABI | Done | ABI version / last error / put/get/retrieve/batch/atlas |
 | Python | Done | Native wire minimal |
-| Node.js / TypeScript / Bun | Done | ESM native wire minimal |
-| Rust | In progress | Split out of core repo; external driver package planned first |
+| Node.js / TypeScript / Bun | Partially published | npm `rochedb` v0.1.2. Bun remains experimental |
+| Rust | Published | crates.io `rochedb` v0.1.3; see the English canonical document for links |
 | Go | Done | C ABI wrapper minimal |
 | PHP / Swift / Kotlin | Done | Docker smoke available |
 | C# / C++ | Done | OSS generic wrappers; Unity / Unreal official assets are separate candidates |
 | React Native / WASM | Post-v0.1 candidate | Browser / local state boundary |
 | Driver discovery CLI | Done | `roche driver list/info/install` prints official driver metadata and setup commands without executing remote scripts |
-| Nimble package publishing | Done | `nimble install rochedb` is available. Non-Nim registries remain future work |
+| Package publishing | Partial | `nimble install rochedb`, `cargo add rochedb`, and `npm install rochedb` are available. Other registries remain future work |
 
 ## Benchmarks / Demos
 

--- a/docs/rochedb-status.md
+++ b/docs/rochedb-status.md
@@ -79,9 +79,9 @@ Translations:
 | Nim API | Done | Native public API |
 | C ABI | Done | ABI version / last error / put/get/retrieve/batch/atlas; C ABI vectors are host-native float arrays, while TCP wire vectors are canonical little-endian float32 |
 | Python | Done | Native wire minimal |
-| Node.js / TypeScript | Done | ESM native wire minimal |
-| Bun | Done | TypeScript smoke test |
-| Rust | In progress | Split out of core repo; external driver package planned first |
+| JavaScript / TypeScript | Published | npm [`rochedb` v0.1.2](https://www.npmjs.com/package/rochedb); repository [`puffball1567/rochedb-js`](https://github.com/puffball1567/rochedb-js); Node-API C ABI wrapper with TypeScript API |
+| Bun | Partial | The npm package uses Node-API and includes Bun compatibility verification, but Bun support remains experimental |
+| Rust | Published | crates.io [`rochedb` v0.1.3](https://crates.io/crates/rochedb); repository [`puffball1567/rochedb-rust`](https://github.com/puffball1567/rochedb-rust); C ABI wrapper |
 | Go | Done | C ABI wrapper minimal |
 | PHP | Done | FFI / C ABI wrapper with Docker smoke |
 | Swift | Done | SwiftPM C ABI wrapper with Linux Docker smoke |
@@ -91,7 +91,7 @@ Translations:
 | React Native / WASM local state | Post-v0.1 candidate | Browser / React Native state boundary; handled with the WASM line, not before Kotlin |
 | Driver discovery CLI | Done | `roche driver list/info/install` prints official driver metadata and setup commands without executing remote scripts |
 | Driver compatibility test suite | Partial | `scripts/driver_compat.sh`; Docker-backed PHP / Swift / Kotlin are opt-in and verified |
-| Nimble package publishing | Done | `nimble install rochedb` is available. Non-Nim registries remain future work |
+| Package publishing | Partial | `nimble install rochedb`, `cargo add rochedb`, and `npm install rochedb` are available. PyPI, Composer, NuGet, Maven, Go, SwiftPM, and other registry packages remain future work |
 
 ## Benchmarks / Demos
 
@@ -138,7 +138,7 @@ single v0.2.0 milestone.
 - React Native / WASM local state module
 - Unity official asset
 - Unreal official plugin
-- package publishing workflows for language drivers
+- package publishing workflows for remaining language drivers
 - API reference documentation
 - Prometheus / OpenMetrics and Datadog metrics adapters
 - Fault-tolerance improvements

--- a/docs/rochedb-status.zh.md
+++ b/docs/rochedb-status.zh.md
@@ -59,14 +59,14 @@ Release checklist: [release-checklist.md](./release-checklist.md)
 | Nim API | Done | Native public API |
 | C ABI | Done | ABI version / last error / put/get/retrieve/batch/atlas |
 | Python | Done | Native wire minimal |
-| Node.js / TypeScript / Bun | Done | ESM native wire minimal |
-| Rust | In progress | Split out of core repo; external driver package planned first |
+| Node.js / TypeScript / Bun | Partially published | npm `rochedb` v0.1.2. Bun remains experimental |
+| Rust | Published | crates.io `rochedb` v0.1.3; see the English canonical document for links |
 | Go | Done | C ABI wrapper minimal |
 | PHP / Swift / Kotlin | Done | Docker smoke available |
 | C# / C++ | Done | OSS generic wrappers; Unity / Unreal official assets are separate candidates |
 | React Native / WASM | Post-v0.1 candidate | Browser / local state boundary |
 | Driver discovery CLI | Done | `roche driver list/info/install` prints official driver metadata and setup commands without executing remote scripts |
-| Nimble package publishing | Done | `nimble install rochedb` is available. Non-Nim registries remain future work |
+| Package publishing | Partial | `nimble install rochedb`, `cargo add rochedb`, and `npm install rochedb` are available. Other registries remain future work |
 
 ## Benchmarks / Demos
 

--- a/src/rochecli.nim
+++ b/src/rochecli.nim
@@ -36,21 +36,21 @@ proc driverRegistry(): seq[DriverInfo] =
   @[
     DriverInfo(
       name: "rust",
-      status: "externalizing",
+      status: "published",
       mode: "C ABI wrapper first; native wire later",
-      repository: "https://github.com/rochedb/rochedb-rust",
+      repository: "https://github.com/puffball1567/rochedb-rust",
       packageName: "rochedb",
       installHint: "cargo add rochedb",
-      notes: "First external driver publication target. Link is provisional until the package is published."
+      notes: "Published on crates.io as rochedb v0.1.3. Wraps the RocheDB C ABI."
     ),
     DriverInfo(
       name: "node",
-      status: "repository-local",
-      mode: "native TCP wire driver, ESM",
-      repository: "drivers/node",
-      packageName: "@rochedb/rochedb",
-      installHint: "npm install @rochedb/rochedb",
-      notes: "Repository-local foundation. Package publication is future work."
+      status: "published",
+      mode: "Node-API C ABI wrapper, TypeScript API",
+      repository: "https://github.com/puffball1567/rochedb-js",
+      packageName: "rochedb",
+      installHint: "npm install rochedb",
+      notes: "Published on npm as rochedb v0.1.2. Bun compatibility is tested on the Node-API path, but remains experimental."
     ),
     DriverInfo(
       name: "php",
@@ -187,6 +187,8 @@ proc runDriver(args: seq[string], manifestPath = "", projectDir = "",
         echo "Next steps:"
         if driver.status == "repository-local":
           echo "  Use the repository-local driver path until package publication."
+        elif driver.status == "published":
+          echo "  Run the printed package-manager command in your target project."
         else:
           echo "  Use the package command after the driver package is published."
         echo "  Run the driver smoke test described in docs/driver-installation.md."


### PR DESCRIPTION
## Summary
- add published Rust and JavaScript/TypeScript driver links to README and driver docs
- update driver status and roadmap tables with crates.io/npm versions
- update Roche driver CLI metadata for published Rust and Node drivers
- remove stale wording that treated Cargo/npm publication as future work

## Verification
- git diff --check
- built src/rochecli.nim successfully
- checked driver info output for rust and node
- checked driver list output