### PR TITLE
docs: mark PHP driver repository as released

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,10 @@ corpus size toward semantic working-set size.
 ## Installation
 
 RocheDB v0.2.x is a technical preview. The Nim package is available through
-Nimble. Rust and JavaScript / TypeScript drivers are published separately, while
-the remaining non-Nim language drivers are still repository-local foundations.
+Nimble. Rust and JavaScript / TypeScript drivers are published as language
+packages. The PHP driver is released as a separate Composer/VCS repository,
+while the remaining non-Nim language drivers are still repository-local
+foundations.
 
 Prerequisites:
 
@@ -237,6 +239,7 @@ Published external drivers:
 |---|---|---:|---|---|
 | Rust | [`rochedb`](https://crates.io/crates/rochedb) | `0.1.3` | [`puffball1567/rochedb-rust`](https://github.com/puffball1567/rochedb-rust) | C ABI wrapper |
 | JavaScript / TypeScript | [`rochedb`](https://www.npmjs.com/package/rochedb) | `0.1.2` | [`puffball1567/rochedb-js`](https://github.com/puffball1567/rochedb-js) | Node-API C ABI wrapper |
+| PHP | Composer VCS package `rochedb/rochedb` | `0.1.0` | [`puffball1567/rochedb-php`](https://github.com/puffball1567/rochedb-php) | FFI / C ABI wrapper |
 
 The table below lists current core-repository driver foundations. Publication
 priority for remaining language packages is tracked in
@@ -250,7 +253,6 @@ priority for remaining language packages is tracked in
 | Node.js / TypeScript | `drivers/node` | Native TCP wire driver, ESM | `node --test` |
 | Bun | `drivers/node` | Node-compatible TCP wire driver | `bun test` |
 | Go | `drivers/go` | C ABI wrapper | `go test` |
-| PHP | `drivers/php` | FFI / C ABI wrapper | Docker smoke |
 | Swift | `drivers/swift` | SwiftPM C ABI wrapper | Linux Docker smoke |
 | C# | `drivers/csharp` | Generic .NET C ABI wrapper | contract smoke |
 | C++ | `drivers/cpp` | C++17 C ABI wrapper | contract smoke |
@@ -259,8 +261,9 @@ priority for remaining language packages is tracked in
 Detailed setup notes are in
 [docs/driver-installation.md](docs/driver-installation.md). Nimble package
 registration is complete. Rust and JavaScript / TypeScript driver packages are
-published; PyPI, Composer, NuGet, Maven, Go, SwiftPM, and other registry
-packages remain roadmap items.
+published; the PHP driver is available as a Composer VCS repository. PyPI,
+Packagist, NuGet, Maven, Go, SwiftPM, and other registry packages remain
+roadmap items.
 
 ## Cluster Mode
 

--- a/docs/driver-installation.md
+++ b/docs/driver-installation.md
@@ -23,9 +23,10 @@ For Rust, target selection is shell-friendly: use `--manifest-path=FILE`,
 It does not execute package-manager commands unless `--execute` is passed.
 
 The Nim package is available through Nimble. Rust and JavaScript / TypeScript
-drivers are also published as language-native packages. Other non-Nim drivers
-are still repository-local foundations, so those examples assume a local clone
-of this repository.
+drivers are also published as language-native packages. The PHP driver is
+released as a Composer VCS repository. Other non-Nim drivers are still
+repository-local foundations, so those examples assume a local clone of this
+repository.
 
 ## Optional FAISS Setup
 
@@ -194,18 +195,51 @@ replace github.com/rochedb/rochedb-go => ../drivers/go
 ## PHP
 
 The PHP driver uses FFI over the C ABI. Local PHP must have `ext-ffi` enabled.
+It is released as a separate repository:
 
-```sh
-nim c --app:lib -d:release --nimcache:/tmp/nimcache_roche_capi -o:lib/librochedb.so src/rochedb_capi.nim
-drivers/php/docker-test.sh
-```
+- repository: [`puffball1567/rochedb-php` v0.1.0](https://github.com/puffball1567/rochedb-php)
+- package name: `rochedb/rochedb`
+- registry status: Composer VCS install now; Packagist publication later
 
-For Composer path development:
+Install from the GitHub repository in a Composer project:
 
 ```json
 {
   "repositories": [
-    { "type": "path", "url": "../drivers/php" }
+    { "type": "vcs", "url": "https://github.com/puffball1567/rochedb-php" }
+  ],
+  "require": {
+    "rochedb/rochedb": "^0.1"
+  }
+}
+```
+
+Then run:
+
+```sh
+composer update rochedb/rochedb
+```
+
+Build the RocheDB core shared library first and point the PHP driver at it:
+
+```sh
+nim c --app:lib -d:release --nimcache:/tmp/nimcache_roche_capi -o:lib/librochedb.so src/rochedb_capi.nim
+export ROCHEDB_CORE_DIR=/path/to/rochedb
+```
+
+For local driver development from a checkout of `rochedb-php`, use the Docker
+smoke test:
+
+```sh
+ROCHEDB_CORE_DIR=/path/to/rochedb ./docker-test.sh
+```
+
+For Composer path development against a local `rochedb-php` checkout:
+
+```json
+{
+  "repositories": [
+    { "type": "path", "url": "../rochedb-php" }
   ],
   "require": {
     "rochedb/rochedb": "*"

--- a/docs/rochedb-driver-roadmap.md
+++ b/docs/rochedb-driver-roadmap.md
@@ -41,7 +41,7 @@ and atlas access.
 |---:|---|---|---|
 | 1 | Rust driver | High-performance infrastructure, gateway, and systems integration path | Published: crates.io [`rochedb` v0.1.3](https://crates.io/crates/rochedb), repository [`puffball1567/rochedb-rust`](https://github.com/puffball1567/rochedb-rust) |
 | 2 | JavaScript / TypeScript driver | Web API, SaaS, Studio, GUI, and local AI client entry point | Published: npm [`rochedb` v0.1.2](https://www.npmjs.com/package/rochedb), repository [`puffball1567/rochedb-js`](https://github.com/puffball1567/rochedb-js). Bun remains experimental on the same Node-API path |
-| 3 | PHP driver | Laravel and existing business web systems | Minimal FFI / C ABI wrapper done. Docker smoke added |
+| 3 | PHP driver | Laravel and existing business web systems | Repository released: [`puffball1567/rochedb-php` v0.1.0](https://github.com/puffball1567/rochedb-php). Composer VCS install works; Packagist publication remains future work |
 | 4 | C++ driver | Generic native and engine integration base. Unreal plugin stays separate | Minimal C ABI wrapper done |
 | 5 | Python native wire driver | AI/RAG and broad scripting entry point without making big-data positioning the first message | Minimal done |
 | 6 | Swift driver | Apple local AI client, browser companion, and app state path | Minimal C ABI wrapper done. Docker smoke added |

--- a/docs/rochedb-status.md
+++ b/docs/rochedb-status.md
@@ -83,7 +83,7 @@ Translations:
 | Bun | Partial | The npm package uses Node-API and includes Bun compatibility verification, but Bun support remains experimental |
 | Rust | Published | crates.io [`rochedb` v0.1.3](https://crates.io/crates/rochedb); repository [`puffball1567/rochedb-rust`](https://github.com/puffball1567/rochedb-rust); C ABI wrapper |
 | Go | Done | C ABI wrapper minimal |
-| PHP | Done | FFI / C ABI wrapper with Docker smoke |
+| PHP | Released | Composer VCS repository [`puffball1567/rochedb-php` v0.1.0](https://github.com/puffball1567/rochedb-php); FFI / C ABI wrapper with Docker smoke; Packagist publication remains future work |
 | Swift | Done | SwiftPM C ABI wrapper with Linux Docker smoke |
 | C# minimal | Done | OSS generic C# wrapper. Unity official asset is separate |
 | C++ minimal | Done | OSS generic C++ wrapper. Unreal official plugin is separate |

--- a/src/rochecli.nim
+++ b/src/rochecli.nim
@@ -54,12 +54,12 @@ proc driverRegistry(): seq[DriverInfo] =
     ),
     DriverInfo(
       name: "php",
-      status: "repository-local",
+      status: "repository-released",
       mode: "FFI / C ABI wrapper",
-      repository: "drivers/php",
+      repository: "https://github.com/puffball1567/rochedb-php",
       packageName: "rochedb/rochedb",
       installHint: "composer require rochedb/rochedb",
-      notes: "Repository-local foundation. Package publication is future work."
+      notes: "Released as rochedb-php v0.1.0 for Composer VCS installs. Packagist publication is future work."
     ),
     DriverInfo(
       name: "python",
@@ -189,6 +189,8 @@ proc runDriver(args: seq[string], manifestPath = "", projectDir = "",
           echo "  Use the repository-local driver path until package publication."
         elif driver.status == "published":
           echo "  Run the printed package-manager command in your target project."
+        elif driver.status == "repository-released":
+          echo "  Add the printed repository as a VCS/path dependency in your target project."
         else:
           echo "  Use the package command after the driver package is published."
         echo "  Run the driver smoke test described in docs/driver-installation.md."


### PR DESCRIPTION
## Summary
- mark the PHP driver as a released Composer/VCS repository
- link the new rochedb-php repository from README, status, roadmap, and installation docs
- update the CLI driver registry for `roche driver info/install php`

## Verification
- `nim c --nimcache:/tmp/nimcache_roche_cli_php -o:/tmp/roche_cli_php src/rochecli.nim`
- `/tmp/roche_cli_php driver info php`
- `/tmp/roche_cli_php driver install php`
