### PR TITLE
docs: mark PHP driver as Packagist published

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,9 @@ corpus size toward semantic working-set size.
 ## Installation
 
 RocheDB v0.2.x is a technical preview. The Nim package is available through
-Nimble. Rust and JavaScript / TypeScript drivers are published as language
-packages. The PHP driver is released as a separate Composer/VCS repository,
-while the remaining non-Nim language drivers are still repository-local
-foundations.
+Nimble. Rust, JavaScript / TypeScript, and PHP drivers are published as
+language packages, while the remaining non-Nim language drivers are still
+repository-local foundations.
 
 Prerequisites:
 
@@ -239,7 +238,7 @@ Published external drivers:
 |---|---|---:|---|---|
 | Rust | [`rochedb`](https://crates.io/crates/rochedb) | `0.1.3` | [`puffball1567/rochedb-rust`](https://github.com/puffball1567/rochedb-rust) | C ABI wrapper |
 | JavaScript / TypeScript | [`rochedb`](https://www.npmjs.com/package/rochedb) | `0.1.2` | [`puffball1567/rochedb-js`](https://github.com/puffball1567/rochedb-js) | Node-API C ABI wrapper |
-| PHP | Composer VCS package `rochedb/rochedb` | `0.1.0` | [`puffball1567/rochedb-php`](https://github.com/puffball1567/rochedb-php) | FFI / C ABI wrapper |
+| PHP | [`rochedb/rochedb`](https://packagist.org/packages/rochedb/rochedb) | `0.1.1` | [`puffball1567/rochedb-php`](https://github.com/puffball1567/rochedb-php) | FFI / C ABI wrapper |
 
 The table below lists current core-repository driver foundations. Publication
 priority for remaining language packages is tracked in
@@ -260,10 +259,9 @@ priority for remaining language packages is tracked in
 
 Detailed setup notes are in
 [docs/driver-installation.md](docs/driver-installation.md). Nimble package
-registration is complete. Rust and JavaScript / TypeScript driver packages are
-published; the PHP driver is available as a Composer VCS repository. PyPI,
-Packagist, NuGet, Maven, Go, SwiftPM, and other registry packages remain
-roadmap items.
+registration is complete. Rust, JavaScript / TypeScript, and PHP driver
+packages are published; PyPI, NuGet, Maven, Go, SwiftPM, and other registry
+packages remain roadmap items.
 
 ## Cluster Mode
 

--- a/docs/driver-installation.md
+++ b/docs/driver-installation.md
@@ -22,11 +22,10 @@ For Rust, target selection is shell-friendly: use `--manifest-path=FILE`,
 `--project-dir=DIR`, `ROCHE_DRIVER_MANIFEST`, or `ROCHE_DRIVER_PROJECT`.
 It does not execute package-manager commands unless `--execute` is passed.
 
-The Nim package is available through Nimble. Rust and JavaScript / TypeScript
-drivers are also published as language-native packages. The PHP driver is
-released as a Composer VCS repository. Other non-Nim drivers are still
-repository-local foundations, so those examples assume a local clone of this
-repository.
+The Nim package is available through Nimble. Rust, JavaScript / TypeScript, and
+PHP drivers are also published as language-native packages. Other non-Nim
+drivers are still repository-local foundations, so those examples assume a
+local clone of this repository.
 
 ## Optional FAISS Setup
 
@@ -195,29 +194,16 @@ replace github.com/rochedb/rochedb-go => ../drivers/go
 ## PHP
 
 The PHP driver uses FFI over the C ABI. Local PHP must have `ext-ffi` enabled.
-It is released as a separate repository:
+It is published on Packagist:
 
-- repository: [`puffball1567/rochedb-php` v0.1.0](https://github.com/puffball1567/rochedb-php)
+- Packagist: [`rochedb/rochedb` v0.1.1](https://packagist.org/packages/rochedb/rochedb)
+- repository: [`puffball1567/rochedb-php`](https://github.com/puffball1567/rochedb-php)
 - package name: `rochedb/rochedb`
-- registry status: Composer VCS install now; Packagist publication later
 
-Install from the GitHub repository in a Composer project:
-
-```json
-{
-  "repositories": [
-    { "type": "vcs", "url": "https://github.com/puffball1567/rochedb-php" }
-  ],
-  "require": {
-    "rochedb/rochedb": "^0.1"
-  }
-}
-```
-
-Then run:
+Install it in a Composer project:
 
 ```sh
-composer update rochedb/rochedb
+composer require rochedb/rochedb:^0.1
 ```
 
 Build the RocheDB core shared library first and point the PHP driver at it:

--- a/docs/rochedb-driver-roadmap.md
+++ b/docs/rochedb-driver-roadmap.md
@@ -41,7 +41,7 @@ and atlas access.
 |---:|---|---|---|
 | 1 | Rust driver | High-performance infrastructure, gateway, and systems integration path | Published: crates.io [`rochedb` v0.1.3](https://crates.io/crates/rochedb), repository [`puffball1567/rochedb-rust`](https://github.com/puffball1567/rochedb-rust) |
 | 2 | JavaScript / TypeScript driver | Web API, SaaS, Studio, GUI, and local AI client entry point | Published: npm [`rochedb` v0.1.2](https://www.npmjs.com/package/rochedb), repository [`puffball1567/rochedb-js`](https://github.com/puffball1567/rochedb-js). Bun remains experimental on the same Node-API path |
-| 3 | PHP driver | Laravel and existing business web systems | Repository released: [`puffball1567/rochedb-php` v0.1.0](https://github.com/puffball1567/rochedb-php). Composer VCS install works; Packagist publication remains future work |
+| 3 | PHP driver | Laravel and existing business web systems | Published: Packagist [`rochedb/rochedb` v0.1.1](https://packagist.org/packages/rochedb/rochedb), repository [`puffball1567/rochedb-php`](https://github.com/puffball1567/rochedb-php) |
 | 4 | C++ driver | Generic native and engine integration base. Unreal plugin stays separate | Minimal C ABI wrapper done |
 | 5 | Python native wire driver | AI/RAG and broad scripting entry point without making big-data positioning the first message | Minimal done |
 | 6 | Swift driver | Apple local AI client, browser companion, and app state path | Minimal C ABI wrapper done. Docker smoke added |

--- a/docs/rochedb-status.md
+++ b/docs/rochedb-status.md
@@ -83,7 +83,7 @@ Translations:
 | Bun | Partial | The npm package uses Node-API and includes Bun compatibility verification, but Bun support remains experimental |
 | Rust | Published | crates.io [`rochedb` v0.1.3](https://crates.io/crates/rochedb); repository [`puffball1567/rochedb-rust`](https://github.com/puffball1567/rochedb-rust); C ABI wrapper |
 | Go | Done | C ABI wrapper minimal |
-| PHP | Released | Composer VCS repository [`puffball1567/rochedb-php` v0.1.0](https://github.com/puffball1567/rochedb-php); FFI / C ABI wrapper with Docker smoke; Packagist publication remains future work |
+| PHP | Published | Packagist [`rochedb/rochedb` v0.1.1](https://packagist.org/packages/rochedb/rochedb); repository [`puffball1567/rochedb-php`](https://github.com/puffball1567/rochedb-php); FFI / C ABI wrapper with Docker smoke |
 | Swift | Done | SwiftPM C ABI wrapper with Linux Docker smoke |
 | C# minimal | Done | OSS generic C# wrapper. Unity official asset is separate |
 | C++ minimal | Done | OSS generic C++ wrapper. Unreal official plugin is separate |
@@ -91,7 +91,7 @@ Translations:
 | React Native / WASM local state | Post-v0.1 candidate | Browser / React Native state boundary; handled with the WASM line, not before Kotlin |
 | Driver discovery CLI | Done | `roche driver list/info/install` prints official driver metadata and setup commands without executing remote scripts |
 | Driver compatibility test suite | Partial | `scripts/driver_compat.sh`; Docker-backed PHP / Swift / Kotlin are opt-in and verified |
-| Package publishing | Partial | `nimble install rochedb`, `cargo add rochedb`, and `npm install rochedb` are available. PyPI, Composer, NuGet, Maven, Go, SwiftPM, and other registry packages remain future work |
+| Package publishing | Partial | `nimble install rochedb`, `cargo add rochedb`, `npm install rochedb`, and `composer require rochedb/rochedb` are available. PyPI, NuGet, Maven, Go, SwiftPM, and other registry packages remain future work |
 
 ## Benchmarks / Demos
 

--- a/src/rochecli.nim
+++ b/src/rochecli.nim
@@ -54,12 +54,12 @@ proc driverRegistry(): seq[DriverInfo] =
     ),
     DriverInfo(
       name: "php",
-      status: "repository-released",
+      status: "published",
       mode: "FFI / C ABI wrapper",
       repository: "https://github.com/puffball1567/rochedb-php",
       packageName: "rochedb/rochedb",
       installHint: "composer require rochedb/rochedb",
-      notes: "Released as rochedb-php v0.1.0 for Composer VCS installs. Packagist publication is future work."
+      notes: "Published on Packagist as rochedb/rochedb v0.1.1. Wraps the RocheDB C ABI through PHP FFI."
     ),
     DriverInfo(
       name: "python",
@@ -189,8 +189,6 @@ proc runDriver(args: seq[string], manifestPath = "", projectDir = "",
           echo "  Use the repository-local driver path until package publication."
         elif driver.status == "published":
           echo "  Run the printed package-manager command in your target project."
-        elif driver.status == "repository-released":
-          echo "  Add the printed repository as a VCS/path dependency in your target project."
         else:
           echo "  Use the package command after the driver package is published."
         echo "  Run the driver smoke test described in docs/driver-installation.md."


### PR DESCRIPTION
## Summary
- mark the PHP driver as published on Packagist
- update README, status, roadmap, and driver installation docs
- update `roche driver info/install php` metadata to point at Packagist v0.1.1

## Verification
- `nim c --nimcache:/tmp/nimcache_roche_cli_php_packagist -o:/tmp/roche_cli_php_packagist src/rochecli.nim`
- `/tmp/roche_cli_php_packagist driver info php`
- `/tmp/roche_cli_php_packagist driver install php`
