### PR TITLE
docs: mark C++ driver repository as released

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Published external drivers:
 | Rust | [`rochedb`](https://crates.io/crates/rochedb) | `0.1.3` | [`puffball1567/rochedb-rust`](https://github.com/puffball1567/rochedb-rust) | C ABI wrapper |
 | JavaScript / TypeScript | [`rochedb`](https://www.npmjs.com/package/rochedb) | `0.1.2` | [`puffball1567/rochedb-js`](https://github.com/puffball1567/rochedb-js) | Node-API C ABI wrapper |
 | PHP | [`rochedb/rochedb`](https://packagist.org/packages/rochedb/rochedb) | `0.1.1` | [`puffball1567/rochedb-php`](https://github.com/puffball1567/rochedb-php) | FFI / C ABI wrapper |
+| C++ | GitHub / CMake source package | `0.1.0` | [`puffball1567/rochedb-cpp`](https://github.com/puffball1567/rochedb-cpp) | C++17 C ABI wrapper |
 
 The table below lists current core-repository driver foundations. Publication
 priority for remaining language packages is tracked in
@@ -254,7 +255,6 @@ priority for remaining language packages is tracked in
 | Go | `drivers/go` | C ABI wrapper | `go test` |
 | Swift | `drivers/swift` | SwiftPM C ABI wrapper | Linux Docker smoke |
 | C# | `drivers/csharp` | Generic .NET C ABI wrapper | contract smoke |
-| C++ | `drivers/cpp` | C++17 C ABI wrapper | contract smoke |
 | Kotlin/JVM | `drivers/kotlin` | JNI / C ABI wrapper | Docker smoke |
 
 Detailed setup notes are in

--- a/docs/driver-installation.md
+++ b/docs/driver-installation.md
@@ -272,12 +272,17 @@ separate from this generic OSS driver.
 
 ## C++
 
-The C++ driver is a C++17 wrapper over the C ABI.
+The C++ driver is released as a separate C++17 wrapper over the C ABI:
+
+- repository: [`puffball1567/rochedb-cpp` v0.1.0](https://github.com/puffball1567/rochedb-cpp)
+- mode: C++17 RAII wrapper over `librochedb.so`
 
 ```sh
-nim c --app:lib -d:release --nimcache:/tmp/nimcache_roche_capi -o:lib/librochedb.so src/rochedb_capi.nim
-g++ -std=c++17 -Iinclude -Idrivers/cpp/include drivers/cpp/examples/contract_smoke.cpp -Llib -lrochedb -o /tmp/roche_cpp_smoke
-LD_LIBRARY_PATH=lib /tmp/roche_cpp_smoke
+git clone https://github.com/puffball1567/rochedb-cpp.git
+cd rochedb-cpp
+cmake -S . -B build -DROCHEDB_CORE_DIR=/path/to/rochedb
+cmake --build build
+./build/rochedb_cpp_contract_smoke
 ```
 
 Unreal-specific module packaging, Blueprint bindings, editor tooling, and

--- a/docs/rochedb-driver-roadmap.md
+++ b/docs/rochedb-driver-roadmap.md
@@ -42,7 +42,7 @@ and atlas access.
 | 1 | Rust driver | High-performance infrastructure, gateway, and systems integration path | Published: crates.io [`rochedb` v0.1.3](https://crates.io/crates/rochedb), repository [`puffball1567/rochedb-rust`](https://github.com/puffball1567/rochedb-rust) |
 | 2 | JavaScript / TypeScript driver | Web API, SaaS, Studio, GUI, and local AI client entry point | Published: npm [`rochedb` v0.1.2](https://www.npmjs.com/package/rochedb), repository [`puffball1567/rochedb-js`](https://github.com/puffball1567/rochedb-js). Bun remains experimental on the same Node-API path |
 | 3 | PHP driver | Laravel and existing business web systems | Published: Packagist [`rochedb/rochedb` v0.1.1](https://packagist.org/packages/rochedb/rochedb), repository [`puffball1567/rochedb-php`](https://github.com/puffball1567/rochedb-php) |
-| 4 | C++ driver | Generic native and engine integration base. Unreal plugin stays separate | Minimal C ABI wrapper done |
+| 4 | C++ driver | Generic native and engine integration base. Unreal plugin stays separate | Repository released: [`puffball1567/rochedb-cpp` v0.1.0](https://github.com/puffball1567/rochedb-cpp); CMake smoke passes in CI |
 | 5 | Python native wire driver | AI/RAG and broad scripting entry point without making big-data positioning the first message | Minimal done |
 | 6 | Swift driver | Apple local AI client, browser companion, and app state path | Minimal C ABI wrapper done. Docker smoke added |
 | 7 | Kotlin-first JVM driver | JVM backend and Android path, Java-compatible | Minimal JNI / C ABI wrapper done |

--- a/docs/rochedb-status.md
+++ b/docs/rochedb-status.md
@@ -86,7 +86,7 @@ Translations:
 | PHP | Published | Packagist [`rochedb/rochedb` v0.1.1](https://packagist.org/packages/rochedb/rochedb); repository [`puffball1567/rochedb-php`](https://github.com/puffball1567/rochedb-php); FFI / C ABI wrapper with Docker smoke |
 | Swift | Done | SwiftPM C ABI wrapper with Linux Docker smoke |
 | C# minimal | Done | OSS generic C# wrapper. Unity official asset is separate |
-| C++ minimal | Done | OSS generic C++ wrapper. Unreal official plugin is separate |
+| C++ | Released | Repository [`puffball1567/rochedb-cpp` v0.1.0](https://github.com/puffball1567/rochedb-cpp); C++17 C ABI wrapper with CMake smoke; Unreal official plugin is separate |
 | Kotlin-first JVM | Done | JNI / C ABI wrapper with Docker smoke |
 | React Native / WASM local state | Post-v0.1 candidate | Browser / React Native state boundary; handled with the WASM line, not before Kotlin |
 | Driver discovery CLI | Done | `roche driver list/info/install` prints official driver metadata and setup commands without executing remote scripts |

--- a/src/rochecli.nim
+++ b/src/rochecli.nim
@@ -62,6 +62,15 @@ proc driverRegistry(): seq[DriverInfo] =
       notes: "Published on Packagist as rochedb/rochedb v0.1.1. Wraps the RocheDB C ABI through PHP FFI."
     ),
     DriverInfo(
+      name: "cpp",
+      status: "repository-released",
+      mode: "C++17 C ABI wrapper",
+      repository: "https://github.com/puffball1567/rochedb-cpp",
+      packageName: "rochedb-cpp",
+      installHint: "git clone https://github.com/puffball1567/rochedb-cpp.git",
+      notes: "Released as rochedb-cpp v0.1.0. CMake smoke passes in CI; Conan/vcpkg publication is future work."
+    ),
+    DriverInfo(
       name: "python",
       status: "repository-local",
       mode: "native TCP wire driver",
@@ -189,6 +198,8 @@ proc runDriver(args: seq[string], manifestPath = "", projectDir = "",
           echo "  Use the repository-local driver path until package publication."
         elif driver.status == "published":
           echo "  Run the printed package-manager command in your target project."
+        elif driver.status == "repository-released":
+          echo "  Use the printed repository URL and the setup notes in docs/driver-installation.md."
         else:
           echo "  Use the package command after the driver package is published."
         echo "  Run the driver smoke test described in docs/driver-installation.md."


### PR DESCRIPTION
## Summary
- mark the C++ driver repository as released
- link `puffball1567/rochedb-cpp` v0.1.0 from README, status, roadmap, and installation docs
- add C++ metadata to `roche driver info/install cpp`

## Verification
- `nim c --nimcache:/tmp/nimcache_roche_cli_cpp -o:/tmp/roche_cli_cpp src/rochecli.nim`
- `/tmp/roche_cli_cpp driver info cpp`
- `/tmp/roche_cli_cpp driver install cpp`
