### PR TITLE
docs: mark Python driver as published

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ corpus size toward semantic working-set size.
 ## Installation
 
 RocheDB v0.2.x is a technical preview. The Nim package is available through
-Nimble. Rust, JavaScript / TypeScript, and PHP drivers are published as
+Nimble. Rust, JavaScript / TypeScript, PHP, and Python drivers are published as
 language packages, while the remaining non-Nim language drivers are still
 repository-local foundations.
 
@@ -240,6 +240,7 @@ Published external drivers:
 | JavaScript / TypeScript | [`rochedb`](https://www.npmjs.com/package/rochedb) | `0.1.2` | [`puffball1567/rochedb-js`](https://github.com/puffball1567/rochedb-js) | Node-API C ABI wrapper |
 | PHP | [`rochedb/rochedb`](https://packagist.org/packages/rochedb/rochedb) | `0.1.1` | [`puffball1567/rochedb-php`](https://github.com/puffball1567/rochedb-php) | FFI / C ABI wrapper |
 | C++ | GitHub / CMake source package | `0.1.0` | [`puffball1567/rochedb-cpp`](https://github.com/puffball1567/rochedb-cpp) | C++17 C ABI wrapper |
+| Python | [`rochedb`](https://pypi.org/project/rochedb/) | `0.1.2` | [`puffball1567/rochedb-python`](https://github.com/puffball1567/rochedb-python) | Native TCP wire driver |
 
 The table below lists current core-repository driver foundations. Publication
 priority for remaining language packages is tracked in
@@ -249,7 +250,6 @@ priority for remaining language packages is tracked in
 |---|---|---|---|
 | Nim | `src/rochedb.nim` | Native embedded and cluster API | core tests |
 | C ABI | `include/rochedb.h` | Embedded / cluster foundation for bindings | contract smoke |
-| Python | `drivers/python` | Native TCP wire driver | unittest wire smoke |
 | Node.js / TypeScript | `drivers/node` | Native TCP wire driver, ESM | `node --test` |
 | Bun | `drivers/node` | Node-compatible TCP wire driver | `bun test` |
 | Go | `drivers/go` | C ABI wrapper | `go test` |
@@ -259,9 +259,9 @@ priority for remaining language packages is tracked in
 
 Detailed setup notes are in
 [docs/driver-installation.md](docs/driver-installation.md). Nimble package
-registration is complete. Rust, JavaScript / TypeScript, and PHP driver
-packages are published; PyPI, NuGet, Maven, Go, SwiftPM, and other registry
-packages remain roadmap items.
+registration is complete. Rust, JavaScript / TypeScript, PHP, and Python
+packages are published; NuGet, Maven, Go, SwiftPM, and other registry packages
+remain roadmap items.
 
 ## Cluster Mode
 

--- a/docs/driver-installation.md
+++ b/docs/driver-installation.md
@@ -22,10 +22,10 @@ For Rust, target selection is shell-friendly: use `--manifest-path=FILE`,
 `--project-dir=DIR`, `ROCHE_DRIVER_MANIFEST`, or `ROCHE_DRIVER_PROJECT`.
 It does not execute package-manager commands unless `--execute` is passed.
 
-The Nim package is available through Nimble. Rust, JavaScript / TypeScript, and
-PHP drivers are also published as language-native packages. Other non-Nim
-drivers are still repository-local foundations, so those examples assume a
-local clone of this repository.
+The Nim package is available through Nimble. Rust, JavaScript / TypeScript, PHP,
+and Python drivers are also published as language-native packages. Other
+non-Nim drivers are still repository-local foundations, so those examples
+assume a local clone of this repository.
 
 ## Optional FAISS Setup
 
@@ -95,25 +95,27 @@ LD_LIBRARY_PATH=lib bin/cabi_contract
 
 ## Python
 
-The Python driver is a native TCP wire driver.
+The Python driver is released as a separate native TCP wire driver:
+
+- repository: [`puffball1567/rochedb-python` v0.1.2](https://github.com/puffball1567/rochedb-python)
+- mode: pure Python TCP driver for `roched`
+- PyPI: [`rochedb` v0.1.2](https://pypi.org/project/rochedb/)
 
 ```sh
-nim c -d:release --nimcache:/tmp/nimcache_roched -o:src/roched src/roched.nim
-python3 drivers/python/tests/test_driver.py
+python3 -m pip install rochedb
+ROCHEDB_CORE_DIR=/path/to/rochedb python3 -m unittest discover -s tests
 ```
 
-From an application in this repository:
+Example:
 
 ```python
-from drivers.python.rochedb import RocheClient
+from rochedb import RocheClient
 
 db = RocheClient.connect("127.0.0.1:17301")
 doc_id = db.put("docs", b'{"title":"hello"}')
 print(db.get(doc_id))
 db.close()
 ```
-
-For package-style local development, add `drivers/python` to `PYTHONPATH`.
 
 ## JavaScript / TypeScript
 

--- a/docs/rochedb-driver-roadmap.md
+++ b/docs/rochedb-driver-roadmap.md
@@ -43,7 +43,7 @@ and atlas access.
 | 2 | JavaScript / TypeScript driver | Web API, SaaS, Studio, GUI, and local AI client entry point | Published: npm [`rochedb` v0.1.2](https://www.npmjs.com/package/rochedb), repository [`puffball1567/rochedb-js`](https://github.com/puffball1567/rochedb-js). Bun remains experimental on the same Node-API path |
 | 3 | PHP driver | Laravel and existing business web systems | Published: Packagist [`rochedb/rochedb` v0.1.1](https://packagist.org/packages/rochedb/rochedb), repository [`puffball1567/rochedb-php`](https://github.com/puffball1567/rochedb-php) |
 | 4 | C++ driver | Generic native and engine integration base. Unreal plugin stays separate | Repository released: [`puffball1567/rochedb-cpp` v0.1.0](https://github.com/puffball1567/rochedb-cpp); CMake smoke passes in CI |
-| 5 | Python native wire driver | AI/RAG and broad scripting entry point without making big-data positioning the first message | Minimal done |
+| 5 | Python native wire driver | AI/RAG and broad scripting entry point without making big-data positioning the first message | Published: PyPI [`rochedb` v0.1.2](https://pypi.org/project/rochedb/), repository [`puffball1567/rochedb-python`](https://github.com/puffball1567/rochedb-python) |
 | 6 | Swift driver | Apple local AI client, browser companion, and app state path | Minimal C ABI wrapper done. Docker smoke added |
 | 7 | Kotlin-first JVM driver | JVM backend and Android path, Java-compatible | Minimal JNI / C ABI wrapper done |
 | 8 | Go driver | Cloud backend and ops tooling; lower initial priority than Rust/Node/PHP for RocheDB positioning | Minimal C ABI wrapper done. Native wire comes later |

--- a/docs/rochedb-status.md
+++ b/docs/rochedb-status.md
@@ -78,10 +78,10 @@ Translations:
 |---|---|---|
 | Nim API | Done | Native public API |
 | C ABI | Done | ABI version / last error / put/get/retrieve/batch/atlas; C ABI vectors are host-native float arrays, while TCP wire vectors are canonical little-endian float32 |
-| Python | Done | Native wire minimal |
 | JavaScript / TypeScript | Published | npm [`rochedb` v0.1.2](https://www.npmjs.com/package/rochedb); repository [`puffball1567/rochedb-js`](https://github.com/puffball1567/rochedb-js); Node-API C ABI wrapper with TypeScript API |
 | Bun | Partial | The npm package uses Node-API and includes Bun compatibility verification, but Bun support remains experimental |
 | Rust | Published | crates.io [`rochedb` v0.1.3](https://crates.io/crates/rochedb); repository [`puffball1567/rochedb-rust`](https://github.com/puffball1567/rochedb-rust); C ABI wrapper |
+| Python | Published | PyPI [`rochedb` v0.1.2](https://pypi.org/project/rochedb/); repository [`puffball1567/rochedb-python`](https://github.com/puffball1567/rochedb-python); native TCP wire driver |
 | Go | Done | C ABI wrapper minimal |
 | PHP | Published | Packagist [`rochedb/rochedb` v0.1.1](https://packagist.org/packages/rochedb/rochedb); repository [`puffball1567/rochedb-php`](https://github.com/puffball1567/rochedb-php); FFI / C ABI wrapper with Docker smoke |
 | Swift | Done | SwiftPM C ABI wrapper with Linux Docker smoke |
@@ -91,7 +91,7 @@ Translations:
 | React Native / WASM local state | Post-v0.1 candidate | Browser / React Native state boundary; handled with the WASM line, not before Kotlin |
 | Driver discovery CLI | Done | `roche driver list/info/install` prints official driver metadata and setup commands without executing remote scripts |
 | Driver compatibility test suite | Partial | `scripts/driver_compat.sh`; Docker-backed PHP / Swift / Kotlin are opt-in and verified |
-| Package publishing | Partial | `nimble install rochedb`, `cargo add rochedb`, `npm install rochedb`, and `composer require rochedb/rochedb` are available. PyPI, NuGet, Maven, Go, SwiftPM, and other registry packages remain future work |
+| Package publishing | Partial | `nimble install rochedb`, `cargo add rochedb`, `npm install rochedb`, `composer require rochedb/rochedb`, and `python3 -m pip install rochedb` are available. NuGet, Maven, Go, SwiftPM, and other registry packages remain future work |
 
 ## Benchmarks / Demos
 

--- a/src/rochecli.nim
+++ b/src/rochecli.nim
@@ -72,12 +72,12 @@ proc driverRegistry(): seq[DriverInfo] =
     ),
     DriverInfo(
       name: "python",
-      status: "repository-local",
+      status: "published",
       mode: "native TCP wire driver",
-      repository: "drivers/python",
+      repository: "https://github.com/puffball1567/rochedb-python",
       packageName: "rochedb",
-      installHint: "pip install rochedb",
-      notes: "Repository-local foundation. Package publication is future work."
+      installHint: "python3 -m pip install rochedb",
+      notes: "Published on PyPI as rochedb v0.1.2. Pure Python TCP driver."
     ),
     DriverInfo(
       name: "go",


### PR DESCRIPTION
## Summary
- mark the Python driver as published on PyPI
- update driver installation docs, status, and README tables
- update roche driver metadata for Python

## Verification
- nim c --nimcache:/tmp/nimcache_roche_cli_py_published -o:/tmp/roche_cli_py_published src/rochecli.nim
- /tmp/roche_cli_py_published driver info python
- /tmp/roche_cli_py_published driver install python
- python3 -m pip install rochedb==0.1.2 in an isolated venv
- import RocheClient, RocheId, RocheError from the PyPI package