### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## v0.3.0
+
+### Added
+
+- Added the C ABI v2 `roche_read_ring_json` entry point so external drivers can
+  read ring-shaped pages with JSON filters, optional projection, sorting,
+  cursor/page options, codec metadata, and a stable JSON response shape.
+- Added explicit CLI examples for JSON, NIF, BIF, raw, and ring-profile
+  `--codec=auto` payload workflows.
+- Added `docs/test-coverage.md` to track the current unit, smoke, contract,
+  recovery, cluster, universe sync, and driver compatibility test matrix.
+
+### Changed
+
+- Unified recent ring-oriented CLI read behavior around one page-shaped result
+  for single and multiple records.
+- Bumped package metadata to `0.3.0`.
+
+### Fixed / Hardened
+
+- Expanded public API coverage for `readRing` filtering, ID lookup, pagination,
+  sorting defaults, sort aliases, empty-result behavior, and invalid sort
+  rejection.
+- Expanded codec coverage for JSON-compatible projection and NIF/BIF projection
+  rejection.
+- Expanded CLI smoke coverage for codec display, BIF base64/hex/adapter views,
+  invalid filters, invalid sort fields, and invalid projection requests.
+- Expanded the C ABI contract smoke with JSON projection, NIF/BIF metadata,
+  invalid filter, invalid sort, and null-ring error checks.
+
 ## v0.2.5
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RocheDB
 
-**v0.2.0 Technical Preview / research OSS.** RocheDB is not yet presented as a
+**v0.3.0 Technical Preview / research OSS.** RocheDB is not yet presented as a
 production replacement for Redis, PostgreSQL, MongoDB, Apache Arrow, or a
 dedicated vector database. The current release target is a measurable prototype
 of ring/galaxy-oriented storage, retrieval, persistence, drivers, and cluster
@@ -56,7 +56,7 @@ corpus size toward semantic working-set size.
 - Detailed design: [docs/rochedb-design.md](docs/rochedb-design.md)
 - Feature status / roadmap: [docs/rochedb-status.md](docs/rochedb-status.md)
 - Release checklist: [docs/release-checklist.md](docs/release-checklist.md)
-- GitHub release draft: [docs/github-release-v0.2.0.md](docs/github-release-v0.2.0.md)
+- GitHub release draft: [docs/github-release-v0.3.0.md](docs/github-release-v0.3.0.md)
 - Driver / FFI roadmap: [docs/rochedb-driver-roadmap.md](docs/rochedb-driver-roadmap.md)
 - Driver installation guide: [docs/driver-installation.md](docs/driver-installation.md)
 - FAISS versioning policy: [docs/faiss-versioning.md](docs/faiss-versioning.md)
@@ -77,7 +77,7 @@ corpus size toward semantic working-set size.
 
 ## Installation
 
-RocheDB v0.2.x is a technical preview. The Nim package is available through
+RocheDB v0.3.x is a technical preview. The Nim package is available through
 Nimble. Rust, JavaScript / TypeScript, PHP, and Python drivers are published as
 language packages, while the remaining non-Nim language drivers are still
 repository-local foundations.

--- a/README.md
+++ b/README.md
@@ -493,7 +493,9 @@ RocheDB core stores and transports `raw`, `json`, `nif`, and `bif` payloads as
 codec-tagged bytes. NIF/BIF conversion stays outside the core; use the optional
 [`rochedb-nif`](https://github.com/puffball1567/rochedb-nif) adapter backed by
 [`nifkit`](https://github.com/puffball1567/nifkit) when applications need NIF
-text / BIF byte roundtrips.
+text / BIF byte roundtrips. The CLI `get --view=auto` automatically uses a
+compatible adapter when `ROCHEDB_NIF_TOOL`, `rochedb-nif`, or `nif_file_tool`
+is available; otherwise BIF falls back to base64 display.
 
 ### C ABI
 

--- a/README.md
+++ b/README.md
@@ -142,10 +142,14 @@ nim c -d:release --nimcache:/tmp/nimcache_roched -o:bin/roched src/roched.nim
 Basic CLI document workflow:
 
 ```sh
-roche put --data=data --ring=docs/japan --payload='{"title":"Hello"}'
-roche list-ring --data=data --ring=docs/japan
-roche get --data=data --ring=docs/japan --id=RAW_ID
+roche put --ring=docs/japan --payload='{"title":"Hello"}'
+roche list-ring --ring=docs/japan
+roche get --ring=docs/japan --where='{"id":"RAW_ID"}'
 ```
+
+When `--data=DIR` is omitted, the CLI uses `ROCHE_DATA` if set, otherwise
+`./data`. Use `--peers=host:port,...` instead when talking to a running
+`roched` cluster.
 
 Optional FAISS vector backend:
 
@@ -493,9 +497,11 @@ RocheDB core stores and transports `raw`, `json`, `nif`, and `bif` payloads as
 codec-tagged bytes. NIF/BIF conversion stays outside the core; use the optional
 [`rochedb-nif`](https://github.com/puffball1567/rochedb-nif) adapter backed by
 [`nifkit`](https://github.com/puffball1567/nifkit) when applications need NIF
-text / BIF byte roundtrips. The CLI `get --view=auto` automatically uses a
-compatible adapter when `ROCHEDB_NIF_TOOL`, `rochedb-nif`, or `nif_file_tool`
-is available; otherwise BIF falls back to base64 display.
+text / BIF byte roundtrips. CLI `get` uses codec metadata automatically: when
+`ROCHEDB_NIF_TOOL`, `rochedb-nif`, or `nif_file_tool` is available, BIF is
+decoded to NIF text; otherwise BIF falls back to base64 display. Use
+`--view=raw`, `--view=base64`, or `--view=hex` only when you want to override
+that default.
 
 ### C ABI
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ corpus size toward semantic working-set size.
 - FAISS versioning policy: [docs/faiss-versioning.md](docs/faiss-versioning.md)
 - Vector backend selection: [docs/vector-backends.md](docs/vector-backends.md)
 - Protocol compatibility: [docs/protocol-compatibility.md](docs/protocol-compatibility.md)
+- Payload codecs and prepared selections: [docs/payload-codecs.md](docs/payload-codecs.md)
 - Universe sync: [docs/universe-sync.md](docs/universe-sync.md)
 - Threat model: [docs/threat-model.md](docs/threat-model.md)
 - Benchmark notes: [docs/rochedb-bench.md](docs/rochedb-bench.md)
@@ -480,6 +481,19 @@ This shows a WAL-backed eventual sync outbox, idempotent apply, ack/prune, and
 the CLI handoff boundary between two local data directories or a remote RocheDB
 server. See [docs/topology-examples.md](docs/topology-examples.md) for topology
 patterns.
+
+Payload codec and prepared selection demos:
+
+```sh
+examples/payload_codecs_demo.sh
+examples/payload_codecs_cluster_demo.sh
+```
+
+RocheDB core stores and transports `raw`, `json`, `nif`, and `bif` payloads as
+codec-tagged bytes. NIF/BIF conversion stays outside the core; use the optional
+[`rochedb-nif`](https://github.com/puffball1567/rochedb-nif) adapter backed by
+[`nifkit`](https://github.com/puffball1567/nifkit) when applications need NIF
+text / BIF byte roundtrips.
 
 ### C ABI
 

--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ Basic CLI document workflow:
 
 ```sh
 roche put --ring=docs/japan --payload='{"title":"Hello"}'
-roche list-ring --ring=docs/japan
-roche get --ring=docs/japan --where='{"id":"RAW_ID"}'
+roche get --ring=docs/japan
+roche get --ring=docs/japan --filter='{"id":"RAW_ID"}' --selection='{ title }'
 ```
 
 When `--data=DIR` is omitted, the CLI uses `ROCHE_DATA` if set, otherwise

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Basic CLI document workflow:
 ```sh
 roche put --data=data --ring=docs/japan --payload='{"title":"Hello"}'
 roche list-ring --data=data --ring=docs/japan
-roche get --data=data --id=RAW_ID
+roche get --data=data --ring=docs/japan --id=RAW_ID
 ```
 
 Optional FAISS vector backend:

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -108,40 +108,40 @@ instead.
 ## Document Commands
 
 These commands work with `--data=DIR` for embedded mode and `--peers=...` for a
-running cluster.
+running cluster. When `--data=DIR` is omitted, embedded commands use
+`ROCHE_DATA` if set, otherwise `./data`.
 
 ```sh
-roche put --data=data --ring=docs/japan --payload='{"title":"Hello"}' --codec=json
-roche list-ring --data=data --ring=docs/japan
-roche get --data=data --ring=docs/japan --id=RAW_ID
-roche get --data=data --ring=docs/japan --id=RAW_ID --view=auto
-roche query --data=data --ring=docs/japan --id=RAW_ID --selection='{ title }'
-roche count-ring --data=data --ring=docs/japan
+roche put --ring=docs/japan --payload='{"title":"Hello"}' --codec=json
+roche list-ring --ring=docs/japan
+roche get --ring=docs/japan --where='{"id":"RAW_ID"}'
+roche query --ring=docs/japan --where='{"id":"RAW_ID"}' --selection='{ title }'
+roche count-ring --ring=docs/japan
 ```
 
 | Command | Required flags | Purpose |
 |---|---|---|
 | `put` | `--ring=RING` plus `--payload=TEXT` or `--in=FILE`; optional `--codec=auto|raw|json|nif|bif` | Store a document and print `id`, `rawId`, and codec. `auto` uses the ring profile. |
-| `get` | `--ring=RING --id=ID`; optional `--view=raw|auto|base64|hex` | Fetch one document in the selected ring. `auto` labels text/NIF and decodes BIF to NIF text when a compatible adapter is available; otherwise it renders BIF as base64. Embedded mode accepts ID-only reads as a compatibility shortcut. |
-| `query` | `--ring=RING --id=ID --selection=SEL` | Fetch a JSON projection in the selected ring. Embedded mode accepts ID-only reads as a compatibility shortcut. |
+| `get` | `--ring=RING --where='{"id":"ID"}'`; optional `--id=ID`, `--view=raw|auto|base64|hex` | Fetch one document in the selected ring. The default view is `auto`: it labels text/NIF and decodes BIF to NIF text when a compatible adapter is available; otherwise it renders BIF as base64. Use `--view=raw` for byte-exact output. `--id` is a low-level shortcut for scripts. |
+| `query` | `--ring=RING --where='{"id":"ID"}' --selection=SEL`; optional `--id=ID` | Fetch a JSON projection in the selected ring. `--id` is a low-level shortcut for scripts. |
 | `list-ring` | `--ring=RING` | List records in one ring. |
 | `count-ring` | `--ring=RING` | Count records in one ring. |
-| `ring-profile` | `--data=DIR --ring=RING` | Read or update the persisted `defaultCodec`, `charset`, and `formatVersion` declaration. |
+| `ring-profile` | `--ring=RING` | Read or update the persisted `defaultCodec`, `charset`, and `formatVersion` declaration. |
 
 For example:
 
 ```sh
-roche ring-profile --data=data --ring=docs/nif --codec=nif --charset=UTF-8 --format-version=1
-roche put --data=data --ring=docs/nif --payload='(example)' # codec=nif via the profile
+roche ring-profile --ring=docs/nif --codec=nif --charset=UTF-8 --format-version=1
+roche put --ring=docs/nif --payload='(example)' # codec=nif via the profile
 ```
 
 The profile is advisory. Every record keeps its explicit codec, so a later
 profile change does not reinterpret existing bytes. Remote profile
 administration is not available in this release.
 
-For BIF payloads, `--view=auto` looks for an optional adapter in this order:
-`ROCHEDB_NIF_TOOL`, `rochedb-nif`, then `nif_file_tool`. The adapter command
-must support:
+For BIF payloads, the default `auto` view looks for an optional adapter in this
+order: `ROCHEDB_NIF_TOOL`, `rochedb-nif`, then `nif_file_tool`. The adapter
+command must support:
 
 ```sh
 ADAPTER decode --in=input.bif --out=output.nif
@@ -160,7 +160,7 @@ Use the `rawId` printed by `put` for scripts and reproducible examples.
 exploration:
 
 ```sh
-roche shell --data=data
+roche shell
 ```
 
 Minimal shell commands:

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -113,17 +113,17 @@ running cluster.
 ```sh
 roche put --data=data --ring=docs/japan --payload='{"title":"Hello"}' --codec=json
 roche list-ring --data=data --ring=docs/japan
-roche get --data=data --id=RAW_ID
-roche get --data=data --id=RAW_ID --view=auto
-roche query --data=data --id=RAW_ID --selection='{ title }'
+roche get --data=data --ring=docs/japan --id=RAW_ID
+roche get --data=data --ring=docs/japan --id=RAW_ID --view=auto
+roche query --data=data --ring=docs/japan --id=RAW_ID --selection='{ title }'
 roche count-ring --data=data --ring=docs/japan
 ```
 
 | Command | Required flags | Purpose |
 |---|---|---|
 | `put` | `--ring=RING` plus `--payload=TEXT` or `--in=FILE`; optional `--codec=auto|raw|json|nif|bif` | Store a document and print `id`, `rawId`, and codec. `auto` uses the ring profile. |
-| `get` | `--id=ID`; optional `--view=raw|auto|base64|hex` | Fetch one document by ID. `auto` labels text/NIF and decodes BIF to NIF text when a compatible adapter is available; otherwise it renders BIF as base64. Cluster mode also requires `--ring=RING`. |
-| `query` | `--id=ID --selection=SEL` | Fetch a JSON projection. Cluster mode also requires `--ring=RING`. |
+| `get` | `--ring=RING --id=ID`; optional `--view=raw|auto|base64|hex` | Fetch one document in the selected ring. `auto` labels text/NIF and decodes BIF to NIF text when a compatible adapter is available; otherwise it renders BIF as base64. Embedded mode accepts ID-only reads as a compatibility shortcut. |
+| `query` | `--ring=RING --id=ID --selection=SEL` | Fetch a JSON projection in the selected ring. Embedded mode accepts ID-only reads as a compatibility shortcut. |
 | `list-ring` | `--ring=RING` | List records in one ring. |
 | `count-ring` | `--ring=RING` | Count records in one ring. |
 | `ring-profile` | `--data=DIR --ring=RING` | Read or update the persisted `defaultCodec`, `charset`, and `formatVersion` declaration. |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -121,6 +121,30 @@ roche get --ring=docs/japan --filter='{"status":"draft"}' --selection='{ title }
 roche count-ring --ring=docs/japan
 ```
 
+Codec is explicit at write time. If you do not pass a codec, RocheDB stores the
+payload as `raw` bytes unless `--codec=auto` resolves to a ring profile.
+
+```sh
+# JSON document: projection and JSON filters can be used later.
+roche put --ring=docs/japan --payload='{"title":"Hello","status":"draft"}' --codec=json
+roche get --ring=docs/japan --filter='{"status":"draft"}' --selection='{ title }'
+
+# NIF text: stored as NIF-tagged bytes. RocheDB does not parse it as JSON.
+roche put --ring=docs/nif --in=sample.nif --codec=nif
+roche get --ring=docs/nif --limit=1
+
+# BIF binary: stored as BIF-tagged bytes. `auto` view decodes through an
+# optional adapter when available; otherwise it returns base64.
+roche put --ring=docs/bif --in=sample.bif --codec=bif
+roche get --ring=docs/bif --limit=1
+roche get --ring=docs/bif --limit=1 --view=base64
+roche get --ring=docs/bif --limit=1 --view=hex
+
+# Plain raw bytes or text.
+roche put --ring=logs/raw --payload='plain text payload' --codec=raw
+roche get --ring=logs/raw --limit=1
+```
+
 | Command | Required flags | Purpose |
 |---|---|---|
 | `put` | `--ring=RING` plus `--payload=TEXT` or `--in=FILE`; optional `--codec=auto|raw|json|nif|bif` | Store a document and print `id`, `rawId`, and codec. `auto` uses the ring profile. |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -111,20 +111,33 @@ These commands work with `--data=DIR` for embedded mode and `--peers=...` for a
 running cluster.
 
 ```sh
-roche put --data=data --ring=docs/japan --payload='{"title":"Hello"}'
+roche put --data=data --ring=docs/japan --payload='{"title":"Hello"}' --codec=json
 roche list-ring --data=data --ring=docs/japan
 roche get --data=data --id=RAW_ID
+roche get --data=data --id=RAW_ID --view=auto
 roche query --data=data --id=RAW_ID --selection='{ title }'
 roche count-ring --data=data --ring=docs/japan
 ```
 
 | Command | Required flags | Purpose |
 |---|---|---|
-| `put` | `--ring=RING` plus `--payload=TEXT` or `--in=FILE` | Store a document and print `id` plus `rawId`. |
-| `get` | `--id=ID` | Fetch one document by ID. Cluster mode also requires `--ring=RING`. |
+| `put` | `--ring=RING` plus `--payload=TEXT` or `--in=FILE`; optional `--codec=auto|raw|json|nif|bif` | Store a document and print `id`, `rawId`, and codec. `auto` uses the ring profile. |
+| `get` | `--id=ID`; optional `--view=raw|auto|base64|hex` | Fetch one document by ID. `auto` labels text/NIF and renders BIF as base64. Cluster mode also requires `--ring=RING`. |
 | `query` | `--id=ID --selection=SEL` | Fetch a JSON projection. Cluster mode also requires `--ring=RING`. |
 | `list-ring` | `--ring=RING` | List records in one ring. |
 | `count-ring` | `--ring=RING` | Count records in one ring. |
+| `ring-profile` | `--data=DIR --ring=RING` | Read or update the persisted `defaultCodec`, `charset`, and `formatVersion` declaration. |
+
+For example:
+
+```sh
+roche ring-profile --data=data --ring=docs/nif --codec=nif --charset=UTF-8 --format-version=1
+roche put --data=data --ring=docs/nif --payload='(example)' # codec=nif via the profile
+```
+
+The profile is advisory. Every record keeps its explicit codec, so a later
+profile change does not reinterpret existing bytes. Remote profile
+administration is not available in this release.
 
 ID formats accepted by `get` and `query`:
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -114,7 +114,8 @@ running cluster. When `--data=DIR` is omitted, embedded commands use
 ```sh
 roche put --ring=docs/japan --payload='{"title":"Hello"}' --codec=json
 roche get --ring=docs/japan
-roche get --ring=docs/japan --limit=1 --order=write-desc
+roche get --ring=docs/japan --limit=1 --rsort=time
+roche get --ring=docs/japan --pagination=on --page=2 --pagelimit=20 --sort=id
 roche get --ring=docs/japan --filter='{"id":"RAW_ID"}' --selection='{ title }'
 roche get --ring=docs/japan --filter='{"status":"draft"}' --selection='{ title }'
 roche count-ring --ring=docs/japan
@@ -123,7 +124,7 @@ roche count-ring --ring=docs/japan
 | Command | Required flags | Purpose |
 |---|---|---|
 | `put` | `--ring=RING` plus `--payload=TEXT` or `--in=FILE`; optional `--codec=auto|raw|json|nif|bif` | Store a document and print `id`, `rawId`, and codec. `auto` uses the ring profile. |
-| `get` | `--ring=RING`; optional `--filter=JSON`, `--selection=SEL`, `--limit=N`, `--cursor=CURSOR`, `--order=write-desc|write-asc|id-asc|id-desc`, `--view=raw|auto|base64|hex` | Read from one ring. It always returns an `items` array with `count` and `nextCursor`; use `--limit=1` when you only want one item. Ordering is applied to the fetched page/filter window, not as a global full-ring sort. The default view is `auto`: payload codec is inferred from stored metadata. |
+| `get` | `--ring=RING`; optional `--filter=JSON`, `--selection=SEL`, `--limit=N`, `--cursor=CURSOR`, `--sort=id|time`, `--rsort=id|time`, `--pagination=on|off`, `--page=N`, `--pagelimit=N`, `--view=raw|auto|base64|hex` | Read from one ring. It always returns an `items` array with returned-item `count` and `nextCursor`; use `--limit=1` when you only want one item. Sorting is applied to the fetched page/filter window, not as a global full-ring sort. The default view is `auto`: payload codec is inferred from stored metadata. |
 | `query` | `--ring=RING --filter='{"id":"ID"}' --selection=SEL`; optional `--id=ID` | Compatibility command for JSON projection by ID. Prefer `get --selection=...` for new CLI use. |
 | `list-ring` | `--ring=RING` | Compatibility command for listing records in one ring. Prefer `get --ring=...` for new CLI use. |
 | `count-ring` | `--ring=RING` | Count records in one ring. |
@@ -143,6 +144,13 @@ administration is not available in this release.
 `--filter` is a JSON object. `{"id":"RAW_ID"}` performs an exact read, while
 other top-level fields filter JSON records in the selected ring. `--where` is
 accepted as a compatibility alias for `--filter`.
+
+`--sort=FIELD` sorts ascending and `--rsort=FIELD` sorts descending. Supported
+fields are `id` and `time` (`write` is accepted as a compatibility alias for
+`time`). The default is `--rsort=time`. `--pagination=on --page=N
+--pagelimit=N` is a human-friendly page interface. For high-volume scans,
+prefer cursor-based reads with `--cursor` because deep pages must skip earlier
+filtered matches.
 
 For BIF payloads, the default `auto` view looks for an optional adapter in this
 order: `ROCHEDB_NIF_TOOL`, `rochedb-nif`, then `nif_file_tool`. The adapter

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -113,18 +113,18 @@ running cluster. When `--data=DIR` is omitted, embedded commands use
 
 ```sh
 roche put --ring=docs/japan --payload='{"title":"Hello"}' --codec=json
-roche list-ring --ring=docs/japan
-roche get --ring=docs/japan --where='{"id":"RAW_ID"}'
-roche query --ring=docs/japan --where='{"id":"RAW_ID"}' --selection='{ title }'
+roche get --ring=docs/japan
+roche get --ring=docs/japan --filter='{"id":"RAW_ID"}' --selection='{ title }'
+roche get --ring=docs/japan --filter='{"status":"draft"}' --selection='{ title }'
 roche count-ring --ring=docs/japan
 ```
 
 | Command | Required flags | Purpose |
 |---|---|---|
 | `put` | `--ring=RING` plus `--payload=TEXT` or `--in=FILE`; optional `--codec=auto|raw|json|nif|bif` | Store a document and print `id`, `rawId`, and codec. `auto` uses the ring profile. |
-| `get` | `--ring=RING --where='{"id":"ID"}'`; optional `--id=ID`, `--view=raw|auto|base64|hex` | Fetch one document in the selected ring. The default view is `auto`: it labels text/NIF and decodes BIF to NIF text when a compatible adapter is available; otherwise it renders BIF as base64. Use `--view=raw` for byte-exact output. `--id` is a low-level shortcut for scripts. |
-| `query` | `--ring=RING --where='{"id":"ID"}' --selection=SEL`; optional `--id=ID` | Fetch a JSON projection in the selected ring. `--id` is a low-level shortcut for scripts. |
-| `list-ring` | `--ring=RING` | List records in one ring. |
+| `get` | `--ring=RING`; optional `--filter=JSON`, `--selection=SEL`, `--limit=N`, `--cursor=CURSOR`, `--view=raw|auto|base64|hex` | Read from one ring. Without a filter, it returns the ring contents; if the ring has exactly one item, it returns that item directly. The default view is `auto`: payload codec is inferred from stored metadata. |
+| `query` | `--ring=RING --filter='{"id":"ID"}' --selection=SEL`; optional `--id=ID` | Compatibility command for JSON projection by ID. Prefer `get --selection=...` for new CLI use. |
+| `list-ring` | `--ring=RING` | Compatibility command for listing records in one ring. Prefer `get --ring=...` for new CLI use. |
 | `count-ring` | `--ring=RING` | Count records in one ring. |
 | `ring-profile` | `--ring=RING` | Read or update the persisted `defaultCodec`, `charset`, and `formatVersion` declaration. |
 
@@ -138,6 +138,10 @@ roche put --ring=docs/nif --payload='(example)' # codec=nif via the profile
 The profile is advisory. Every record keeps its explicit codec, so a later
 profile change does not reinterpret existing bytes. Remote profile
 administration is not available in this release.
+
+`--filter` is a JSON object. `{"id":"RAW_ID"}` performs an exact read, while
+other top-level fields filter JSON records in the selected ring. `--where` is
+accepted as a compatibility alias for `--filter`.
 
 For BIF payloads, the default `auto` view looks for an optional adapter in this
 order: `ROCHEDB_NIF_TOOL`, `rochedb-nif`, then `nif_file_tool`. The adapter

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -122,7 +122,7 @@ roche count-ring --data=data --ring=docs/japan
 | Command | Required flags | Purpose |
 |---|---|---|
 | `put` | `--ring=RING` plus `--payload=TEXT` or `--in=FILE`; optional `--codec=auto|raw|json|nif|bif` | Store a document and print `id`, `rawId`, and codec. `auto` uses the ring profile. |
-| `get` | `--id=ID`; optional `--view=raw|auto|base64|hex` | Fetch one document by ID. `auto` labels text/NIF and renders BIF as base64. Cluster mode also requires `--ring=RING`. |
+| `get` | `--id=ID`; optional `--view=raw|auto|base64|hex` | Fetch one document by ID. `auto` labels text/NIF and decodes BIF to NIF text when a compatible adapter is available; otherwise it renders BIF as base64. Cluster mode also requires `--ring=RING`. |
 | `query` | `--id=ID --selection=SEL` | Fetch a JSON projection. Cluster mode also requires `--ring=RING`. |
 | `list-ring` | `--ring=RING` | List records in one ring. |
 | `count-ring` | `--ring=RING` | Count records in one ring. |
@@ -138,6 +138,14 @@ roche put --data=data --ring=docs/nif --payload='(example)' # codec=nif via the 
 The profile is advisory. Every record keeps its explicit codec, so a later
 profile change does not reinterpret existing bytes. Remote profile
 administration is not available in this release.
+
+For BIF payloads, `--view=auto` looks for an optional adapter in this order:
+`ROCHEDB_NIF_TOOL`, `rochedb-nif`, then `nif_file_tool`. The adapter command
+must support:
+
+```sh
+ADAPTER decode --in=input.bif --out=output.nif
+```
 
 ID formats accepted by `get` and `query`:
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -114,6 +114,7 @@ running cluster. When `--data=DIR` is omitted, embedded commands use
 ```sh
 roche put --ring=docs/japan --payload='{"title":"Hello"}' --codec=json
 roche get --ring=docs/japan
+roche get --ring=docs/japan --limit=1 --order=write-desc
 roche get --ring=docs/japan --filter='{"id":"RAW_ID"}' --selection='{ title }'
 roche get --ring=docs/japan --filter='{"status":"draft"}' --selection='{ title }'
 roche count-ring --ring=docs/japan
@@ -122,7 +123,7 @@ roche count-ring --ring=docs/japan
 | Command | Required flags | Purpose |
 |---|---|---|
 | `put` | `--ring=RING` plus `--payload=TEXT` or `--in=FILE`; optional `--codec=auto|raw|json|nif|bif` | Store a document and print `id`, `rawId`, and codec. `auto` uses the ring profile. |
-| `get` | `--ring=RING`; optional `--filter=JSON`, `--selection=SEL`, `--limit=N`, `--cursor=CURSOR`, `--view=raw|auto|base64|hex` | Read from one ring. Without a filter, it returns the ring contents; if the ring has exactly one item, it returns that item directly. The default view is `auto`: payload codec is inferred from stored metadata. |
+| `get` | `--ring=RING`; optional `--filter=JSON`, `--selection=SEL`, `--limit=N`, `--cursor=CURSOR`, `--order=write-desc|write-asc|id-asc|id-desc`, `--view=raw|auto|base64|hex` | Read from one ring. It always returns an `items` array with `count` and `nextCursor`; use `--limit=1` when you only want one item. Ordering is applied to the fetched page/filter window, not as a global full-ring sort. The default view is `auto`: payload codec is inferred from stored metadata. |
 | `query` | `--ring=RING --filter='{"id":"ID"}' --selection=SEL`; optional `--id=ID` | Compatibility command for JSON projection by ID. Prefer `get --selection=...` for new CLI use. |
 | `list-ring` | `--ring=RING` | Compatibility command for listing records in one ring. Prefer `get --ring=...` for new CLI use. |
 | `count-ring` | `--ring=RING` | Count records in one ring. |

--- a/docs/github-release-v0.3.0.md
+++ b/docs/github-release-v0.3.0.md
@@ -1,0 +1,80 @@
+# RocheDB v0.3.0 Technical Preview
+
+RocheDB v0.3.0 expands the driver-facing and codec-aware read surface. The
+notable change is C ABI v2 with `roche_read_ring_json`, which gives external
+drivers a stable ring-read page shape similar to the CLI `roche get --ring=...`
+workflow.
+
+This is still a technical preview / research OSS release. Do not present it as
+a production replacement for Redis, PostgreSQL, MongoDB, Apache Arrow, or a
+mature vector database. The defensible claim remains narrower: RocheDB can
+reduce working-set size and downstream retrieval input when data is placed in
+meaningful rings, while the implementation is gaining the operational checks
+needed for broader evaluation.
+
+## Highlights
+
+- C ABI v2 with `roche_read_ring_json` for JSON filters, optional projection,
+  cursor/page reads, sorting, codec metadata, and stable page-shaped JSON
+  responses.
+- Unified ring-oriented CLI read behavior around one result shape for one or
+  many records.
+- Explicit CLI and documentation paths for JSON, NIF, BIF, raw, and
+  ring-profile `--codec=auto` payload workflows.
+- Expanded C ABI contract smoke coverage for JSON projection, NIF/BIF metadata,
+  invalid filters, invalid sort fields, and null-ring errors.
+- Expanded embedded API coverage for `readRing` filtering, pagination, sorting,
+  defaulting, and codec-aware projection rejection.
+- Expanded CLI smoke coverage for codec display, BIF base64/hex/adapter views,
+  invalid filters, invalid sort fields, invalid projection requests, shell, and
+  user-facing auth errors.
+- Added `docs/test-coverage.md` to make the release validation matrix explicit.
+
+## Validation Run
+
+The v0.3.0 pre-release verification pass included:
+
+- `scripts/test_core.sh`
+- `scripts/cli_crud_smoke.sh`
+- `scripts/test_all_smoke.sh`
+- C ABI shared-library build
+- `gcc examples/cabi_contract.c ...`
+- `LD_LIBRARY_PATH=lib bin/cabi_contract`
+- `nimble check`
+- `git diff --check`
+
+`scripts/test_all_smoke.sh` covers core tests, CLI CRUD, cluster transactions,
+cluster failure, authz/RBAC, wire fuzz, recovery, universe sync failure, and
+remote universe sync. Driver compatibility remains optional through
+`ROCHE_TEST_DRIVERS=1`.
+
+## Known Gaps
+
+- TLS is not implemented; do not expose `roched` directly on untrusted
+  networks.
+- Cluster membership is static.
+- node0 remains the cluster transaction landing coordinator.
+- Cluster coordinator redundancy, dynamic membership, and epoch migration are
+  not implemented.
+- Universe sync is durable eventual sync, not immediate global serializability.
+- Long-running cluster soak, mixed-version protocol, larger universe backlog,
+  and multi-environment validation are expected to grow through external
+  evaluation and reports.
+
+## Links
+
+- README: `README.md`
+- Test coverage: `docs/test-coverage.md`
+- Status / roadmap: `docs/rochedb-status.md`
+- Public API: `docs/public-api.md`
+- Configuration reference: `docs/config-reference.md`
+- CLI reference: `docs/cli-reference.md`
+- Payload codecs: `docs/payload-codecs.md`
+- Universe sync: `docs/universe-sync.md`
+- Topology examples: `docs/topology-examples.md`
+- Benchmarks: `docs/rochedb-bench.md`
+- Release checklist: `docs/release-checklist.md`
+- Driver installation guide: `docs/driver-installation.md`
+- Threat model: `docs/threat-model.md`
+- Third-party notices: `THIRD_PARTY_NOTICES.md`
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,7 @@ downstream AI/RAG or application logic.
 - [Driver Installation](driver-installation.md)
 - [Driver / FFI Roadmap](rochedb-driver-roadmap.md)
 - [Protocol Compatibility](protocol-compatibility.md)
+- [Payload Codecs](payload-codecs.md)
 - [Vector Backend Selection](vector-backends.md)
 - [FAISS Versioning Policy](faiss-versioning.md)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,4 +44,4 @@ downstream AI/RAG or application logic.
 ## Release
 
 - [Release Checklist](release-checklist.md)
-- [GitHub Release Draft](github-release-v0.2.0.md)
+- [GitHub Release Draft](github-release-v0.3.0.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,7 @@ downstream AI/RAG or application logic.
 - [Universe Sync](universe-sync.md)
 - [Cloud Operations Metrics](cloud-operations.md)
 - [Threat Model](threat-model.md)
+- [Test Coverage](test-coverage.md)
 
 ## Drivers And Protocol
 

--- a/docs/payload-codecs.md
+++ b/docs/payload-codecs.md
@@ -84,7 +84,7 @@ the legacy three-field `VAL` header.
 ```sh
 roche put --ring=docs --in=document.bif --codec=bif
 roche put --ring=docs --payload='{"title":"RocheDB"}' --codec=json
-roche get --ring=docs --where='{"id":"RAW_ID"}'
+roche get --ring=docs --filter='{"id":"RAW_ID"}'
 ```
 
 These examples use the default embedded data directory. Set `ROCHE_DATA` or

--- a/docs/payload-codecs.md
+++ b/docs/payload-codecs.md
@@ -1,0 +1,148 @@
+---
+layout: default
+title: Payload Codecs
+---
+
+# Payload Codecs
+
+RocheDB stores payloads as binary-safe byte strings and records a format
+identifier with each document. The supported identifiers are:
+
+| Codec | Intended use | Core behavior |
+|---|---|---|
+| `raw` | Text or arbitrary application bytes | Stored without interpretation |
+| `json` | JSON documents and projections | Stored as bytes; eligible for JSON projection and patch APIs |
+| `nif` | Pre-encoded NIF text/token data | Stored without conversion |
+| `bif` | Pre-encoded BIF binary data | Stored without conversion |
+
+NIF/BIF support in the core means format-aware storage, WAL persistence,
+cluster transport, handoff, transaction apply, Universe sync, list, get, and
+retrieval. RocheDB does not bundle a NIF/BIF encoder or decoder into the core.
+Applications can provide already encoded bytes directly, or use the optional
+[`rochedb-nif`](https://github.com/puffball1567/rochedb-nif) adapter backed by
+[`nifkit`](https://github.com/puffball1567/nifkit). This keeps the database
+independent of one codec implementation while still providing an official OSS
+adapter path.
+
+## Ring payload profiles
+
+A ring can declare the payload format normally used within it. This declaration
+is persisted separately from records and is available to applications, CLI
+tools, and optional format adapters:
+
+```bash
+roche ring-profile --data=/var/lib/roche --ring=artifacts \
+  --codec=bif --format-version=1
+roche ring-profile --data=/var/lib/roche --ring=documents \
+  --codec=nif --charset=UTF-8 --format-version=1
+```
+
+The profile contains `defaultCodec`, `charset`, and `formatVersion`. `charset`
+describes text encodings such as NIF text; it does not apply to BIF binary
+payloads. A record's explicit codec always wins over the ring default, so a
+profile change never reinterprets bytes already stored. `roche put` defaults to
+`--codec=auto` and uses the ring default; pass an explicit codec to override it.
+
+## Embedded API
+
+```nim
+import rochedb
+import std/json
+
+var db = open()
+
+let jsonId = db.put(%*{"title": "RocheDB"}, ring = "docs")
+let bifId = db.put(encodedPayload(bifBytes, pcBif), ring = "docs")
+
+let stored = db.getEncoded(bifId)
+doAssert stored.codec == pcBif
+doAssert stored.data == bifBytes
+
+db.close()
+```
+
+The string overload of `put` remains backward compatible and uses `raw`. The
+`JsonNode` overload uses `json` automatically.
+
+## Runnable Demos
+
+From a RocheDB source checkout:
+
+```sh
+examples/payload_codecs_demo.sh
+examples/payload_codecs_cluster_demo.sh
+```
+
+The embedded demo writes JSON, NIF-tagged bytes, and BIF-tagged bytes, reopens
+the persistent store, reuses a prepared selection, and shows that JSON
+projection is rejected for NIF/BIF records. The cluster demo shows negotiated
+codec metadata and verifies that a connection which does not opt in still sees
+the legacy three-field `VAL` header.
+
+## CLI
+
+```sh
+roche put --data=/var/lib/roche --ring=docs --in=document.bif --codec=bif
+roche put --data=/var/lib/roche --ring=docs --payload='{"title":"RocheDB"}' --codec=json
+roche get --data=/var/lib/roche --id=RAW_ID --view=auto
+```
+
+`--view=auto` prints text/NIF with codec metadata and prints BIF as base64.
+Use `--view=hex` for byte-level inspection or omit `--view` for the original
+raw payload bytes. Decoding BIF back into NIF text is intentionally adapter-side;
+the published `rochedb-nif` adapter provides that path without making NIF/BIF
+parsing a RocheDB core dependency.
+
+## C ABI
+
+The additive C ABI functions preserve the existing `roche_put` and `roche_get`
+contract while exposing format metadata to C/C++ and FFI consumers:
+
+```c
+roche_id id;
+roche_put_codec(db, "artifacts/bif", bytes, byte_len, ROCHE_CODEC_BIF, &id);
+
+size_t len;
+int codec;
+void *stored = roche_get_codec(db, id, &len, &codec);
+/* codec == ROCHE_CODEC_BIF; release stored with roche_free(stored). */
+```
+
+`roche_put_vec_codec` is the equivalent vector-bearing write call. The C ABI
+contract smoke verifies this path in `examples/cabi_contract.c`.
+
+## Projection Boundary
+
+`query`, `patch`, and prepared selections are JSON operations. RocheDB rejects
+their use on explicitly tagged `nif` and `bif` records instead of attempting to
+interpret those bytes as JSON. `raw` remains projection-compatible for legacy
+records and older drivers that stored JSON before codec metadata existed.
+
+## Prepared Selections
+
+RocheDB does not execute SQL, so its prepared-statement-like API compiles the
+GraphQL-style projection rather than preparing an SQL string:
+
+```nim
+let fields = prepareSelection("{ title author { name } }")
+let first = db.query(firstId, fields)
+let second = db.query(secondId, fields)
+```
+
+`prepareSelection` validates and parses the selection once. Embedded queries
+reuse that parsed tree directly. Cluster nodes also keep a bounded cache of
+validated selection trees. The selection grammar contains field names only;
+payload values are never interpolated into it.
+
+## Compatibility And Byte Order
+
+The codec name is optional on the wire and in older WAL records. Missing codec
+metadata is interpreted as `raw`, so existing data and drivers remain readable.
+Clients can call the additive `CODECS` wire command to discover the identifiers
+accepted by a node. `CODECMETA ON` opts the connection into codec fields on
+response headers; clients that do not negotiate keep the original header shape.
+
+RocheDB treats NIF/BIF payload bytes as opaque. Their byte order is therefore a
+property of the selected format specification, not the host CPU. This is
+separate from RocheDB vector bytes, which are always canonical little-endian
+IEEE-754 `float32` on the TCP wire.

--- a/docs/payload-codecs.md
+++ b/docs/payload-codecs.md
@@ -91,6 +91,59 @@ These examples use the default embedded data directory. Set `ROCHE_DATA` or
 pass `--data=DIR` when you want a specific local store, or pass
 `--peers=host:port,...` when talking to a `roched` cluster.
 
+### Put and get examples
+
+Use an explicit codec when writing payloads whose type matters. Without an
+explicit codec, `put` stores the payload as `raw` unless `--codec=auto` resolves
+to the ring's payload profile.
+
+```sh
+# JSON: filter and projection work because the record is tagged as json.
+roche put --ring=docs/japan \
+  --payload='{"title":"Hello","status":"draft"}' \
+  --codec=json
+roche get --ring=docs/japan \
+  --filter='{"status":"draft"}' \
+  --selection='{ title }'
+
+# NIF text: RocheDB stores the bytes and keeps codec=nif metadata.
+roche put --ring=docs/nif --in=sample.nif --codec=nif
+roche get --ring=docs/nif --limit=1
+
+# BIF binary: RocheDB stores the bytes and keeps codec=bif metadata.
+roche put --ring=docs/bif --in=sample.bif --codec=bif
+roche get --ring=docs/bif --limit=1
+
+# Debug or transport-safe BIF views.
+roche get --ring=docs/bif --limit=1 --view=base64
+roche get --ring=docs/bif --limit=1 --view=hex
+
+# Raw: plain bytes/text with no format interpretation.
+roche put --ring=logs/raw --payload='plain text payload' --codec=raw
+roche get --ring=logs/raw --limit=1
+```
+
+`get` always returns the same page shape. Use `--limit=1` when you only want one
+record:
+
+```json
+{
+  "ring": "docs/bif",
+  "count": 1,
+  "items": [
+    {
+      "codec": "bif",
+      "encoding": "base64",
+      "payload": "AQIDBA=="
+    }
+  ]
+}
+```
+
+The stored codec metadata drives display. NIF text is returned as text. BIF
+uses the optional adapter when available and falls back to base64 when it is
+not.
+
 The default view is `auto`, which prints text/NIF with codec metadata. For BIF,
 it first tries to use an optional adapter and prints decoded NIF text when one
 is available. The lookup order is `ROCHEDB_NIF_TOOL`, `rochedb-nif`, then
@@ -100,6 +153,23 @@ falls back to base64. Use `--view=hex` for byte-level inspection or
 `--view=raw` for the original raw payload bytes. Decoding BIF back into NIF text
 is intentionally adapter-side; the published `rochedb-nif` adapter provides
 that path without making NIF/BIF parsing a RocheDB core dependency.
+
+### Ring profile and auto codec
+
+Ring profiles are useful when one ring is intended to contain one payload
+format. The profile does not rewrite existing records; it only supplies a
+default for future `--codec=auto` writes.
+
+```sh
+roche ring-profile --data=./data \
+  --ring=docs/nif \
+  --codec=nif \
+  --charset=UTF-8 \
+  --format-version=1
+
+roche put --data=./data --ring=docs/nif --in=sample.nif --codec=auto
+roche get --data=./data --ring=docs/nif --limit=1
+```
 
 ## C ABI
 

--- a/docs/payload-codecs.md
+++ b/docs/payload-codecs.md
@@ -82,20 +82,24 @@ the legacy three-field `VAL` header.
 ## CLI
 
 ```sh
-roche put --data=/var/lib/roche --ring=docs --in=document.bif --codec=bif
-roche put --data=/var/lib/roche --ring=docs --payload='{"title":"RocheDB"}' --codec=json
-roche get --data=/var/lib/roche --ring=docs --id=RAW_ID --view=auto
+roche put --ring=docs --in=document.bif --codec=bif
+roche put --ring=docs --payload='{"title":"RocheDB"}' --codec=json
+roche get --ring=docs --where='{"id":"RAW_ID"}'
 ```
 
-`--view=auto` prints text/NIF with codec metadata. For BIF, it first tries to
-use an optional adapter and prints decoded NIF text when one is available. The
-lookup order is `ROCHEDB_NIF_TOOL`, `rochedb-nif`, then `nif_file_tool`. The
-adapter command must support `decode --in=input.bif --out=output.nif`. If no
-adapter is available, `--view=auto` falls back to base64. Use `--view=hex` for
-byte-level inspection or omit `--view` for the original raw payload bytes.
-Decoding BIF back into NIF text is intentionally adapter-side; the published
-`rochedb-nif` adapter provides that path without making NIF/BIF parsing a
-RocheDB core dependency.
+These examples use the default embedded data directory. Set `ROCHE_DATA` or
+pass `--data=DIR` when you want a specific local store, or pass
+`--peers=host:port,...` when talking to a `roched` cluster.
+
+The default view is `auto`, which prints text/NIF with codec metadata. For BIF,
+it first tries to use an optional adapter and prints decoded NIF text when one
+is available. The lookup order is `ROCHEDB_NIF_TOOL`, `rochedb-nif`, then
+`nif_file_tool`. The adapter command must support
+`decode --in=input.bif --out=output.nif`. If no adapter is available, `auto`
+falls back to base64. Use `--view=hex` for byte-level inspection or
+`--view=raw` for the original raw payload bytes. Decoding BIF back into NIF text
+is intentionally adapter-side; the published `rochedb-nif` adapter provides
+that path without making NIF/BIF parsing a RocheDB core dependency.
 
 ## C ABI
 

--- a/docs/payload-codecs.md
+++ b/docs/payload-codecs.md
@@ -87,11 +87,15 @@ roche put --data=/var/lib/roche --ring=docs --payload='{"title":"RocheDB"}' --co
 roche get --data=/var/lib/roche --id=RAW_ID --view=auto
 ```
 
-`--view=auto` prints text/NIF with codec metadata and prints BIF as base64.
-Use `--view=hex` for byte-level inspection or omit `--view` for the original
-raw payload bytes. Decoding BIF back into NIF text is intentionally adapter-side;
-the published `rochedb-nif` adapter provides that path without making NIF/BIF
-parsing a RocheDB core dependency.
+`--view=auto` prints text/NIF with codec metadata. For BIF, it first tries to
+use an optional adapter and prints decoded NIF text when one is available. The
+lookup order is `ROCHEDB_NIF_TOOL`, `rochedb-nif`, then `nif_file_tool`. The
+adapter command must support `decode --in=input.bif --out=output.nif`. If no
+adapter is available, `--view=auto` falls back to base64. Use `--view=hex` for
+byte-level inspection or omit `--view` for the original raw payload bytes.
+Decoding BIF back into NIF text is intentionally adapter-side; the published
+`rochedb-nif` adapter provides that path without making NIF/BIF parsing a
+RocheDB core dependency.
 
 ## C ABI
 

--- a/docs/payload-codecs.md
+++ b/docs/payload-codecs.md
@@ -84,7 +84,7 @@ the legacy three-field `VAL` header.
 ```sh
 roche put --data=/var/lib/roche --ring=docs --in=document.bif --codec=bif
 roche put --data=/var/lib/roche --ring=docs --payload='{"title":"RocheDB"}' --codec=json
-roche get --data=/var/lib/roche --id=RAW_ID --view=auto
+roche get --data=/var/lib/roche --ring=docs --id=RAW_ID --view=auto
 ```
 
 `--view=auto` prints text/NIF with codec metadata. For BIF, it first tries to

--- a/docs/protocol-compatibility.md
+++ b/docs/protocol-compatibility.md
@@ -30,6 +30,23 @@ Rules:
 - Drivers should prefer high-level named-ring commands such as `PUTR`, `GETID`,
   `QRYID`, `BGET`, `UAPPLY`, and `USTATUS` instead of constructing internal
   placement metadata themselves.
+- `CODECS` reports the payload format identifiers accepted by the node.
+
+## Payload Codec Metadata
+
+`PUT`, `PUTR`, transaction apply, and handoff frames may append one codec name:
+`raw`, `json`, `nif`, or `bif`. Clients that need response metadata first send
+`CODECMETA ON`; negotiated `VAL`, `ITEM`, and `HIT` response headers then append
+the stored codec where applicable. Clients that do not negotiate retain the
+original response shape. Missing metadata is interpreted as `raw` for
+compatibility with existing WAL records and drivers.
+
+NIF/BIF bytes are opaque to RocheDB core. The core preserves them across WAL
+replay, cluster transfer, and retrieval but does not bundle a NIF/BIF encoder
+or decoder. Use the optional
+[`rochedb-nif`](https://github.com/puffball1567/rochedb-nif) adapter when an
+application needs NIF text / BIF byte conversion. See
+[Payload Codecs](payload-codecs.md).
 
 ## Vector Byte Order
 

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -83,8 +83,11 @@ For application-facing tuning, prefer `SearchProfile` over raw numeric knobs:
 |---|---|
 | `put(payload, ring = "default", vec = @[])` | Store a string payload in a ring. |
 | `put(doc: JsonNode, ring = "default", vec = @[])` | Store a JSON document. |
+| `put(encodedPayload(bytes, codec), ring, vec)` | Store `raw`, `json`, `nif`, or `bif` bytes with format metadata. |
 | `get(id)` | Fetch by RocheDB ID. |
+| `getEncoded(id)` | Fetch payload bytes together with their `PayloadCodec`. |
 | `query(id, selection)` | Fetch a JSON projection using GraphQL-style selection syntax. |
+| `prepareSelection(selection)` / `query(id, prepared)` | Validate and compile a reusable projection before execution. |
 | `exists(id)` / `contains(id)` | Check whether an ID exists. |
 | `update(id, payload)` / `update(id, doc)` | Replace an existing document. |
 | `patch(id, patchDoc)` | Apply a JSON merge patch. |
@@ -92,6 +95,9 @@ For application-facing tuning, prefer `SearchProfile` over raw numeric knobs:
 | `batchPut(payloads, ring, vecs)` | Insert multiple records. |
 | `batchGet(ids)` | Fetch multiple IDs. |
 | `batchDelete(ids)` | Delete multiple IDs. |
+
+The C ABI exposes matching additive functions: `roche_put_codec`,
+`roche_put_vec_codec`, and `roche_get_codec`. See [Payload Codecs](payload-codecs.md).
 
 ## Ring Reads
 

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -18,6 +18,8 @@ technical preview. The canonical Nim definitions live in `src/rochedb.nim`.
 | `GalaxyRouter` | opaque router handle | Holds named galaxy connections for applications that access multiple galaxies. |
 | `RocheRecord` | `id`, `payload` | Lightweight record returned by `listByRing`. |
 | `RocheListPage` | `items`, `nextCursor` | Cursor-paginated list result. Empty `nextCursor` means there is no next page. |
+| `RocheReadOptions` | `filter`, `selection`, `limit`, `cursor`, `pagination`, `page`, `pageLimit`, `sortField`, `sortDirection` | Ring read options shared with CLI semantics. |
+| `RocheReadPage` | `ring`, `count`, `items`, `nextCursor`, `pagination`, `page`, `pageLimit`, `sortField`, `sortDirection` | Ring read result. `count` is the number of returned items; use `countByRing` for the total ring size. |
 | `RocheHit` | `id`, `score`, `payload` | Retrieval hit. `score` is cosine similarity, higher is closer. |
 
 `RocheId` should normally be treated as opaque. `toRaw` and `fromRaw` exist for
@@ -104,6 +106,7 @@ The C ABI exposes matching additive functions: `roche_put_codec`,
 | API | Purpose |
 |---|---|
 | `listByRing(ring, limit = 100, cursor = "")` | List records in one ring with cursor pagination. |
+| `readRing(ring, options = defaultReadOptions())` | Read one ring with filter, selection, cursor/page limit, and page-local sort. |
 | `countByRing(ring)` | Count records in one ring. |
 | `retrieve(queryVec, ring = "", budget = 8, ...)` | Vector/RAG-style retrieval with ring-aware planning. |
 | `retrievalPlan(...)` | Build a readable retrieval plan without executing it. |

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,6 +1,8 @@
 # RocheDB Release Checklist
 
 This is the canonical release checklist for the public RocheDB repository.
+The current automated test coverage matrix is tracked in
+[Test Coverage](test-coverage.md).
 
 ## v0.2.0 Positioning
 

--- a/docs/rochedb-status.md
+++ b/docs/rochedb-status.md
@@ -22,6 +22,8 @@ Translations:
 | ORM foundation API | Done | Embedded APIs plus cluster PoC for `update`, JSON `patch`, `deleteById`, `listByRing`, `countByRing`; canonical data is expected to live in one galaxy/ring, with alternate views handled by ring hierarchy, naming, import rules, and retrieval profiles; driver exposure is still pending |
 | Warp belt | PoC | WAL-backed delayed patch queue: `enqueueWarp`, `warpStep`, `warpDrain`; scans specified rings in registration order and drops merge patches onto matching JSON documents; includes minimal attempts / retryAt / maxAttempts / ack / dead-letter state plus acked-job cleanup; FlowBrigade and FlowLogbook adapters are planned instead of core dependencies; server scheduling is still pending |
 | JSON document query | Done | GraphQL-style selection |
+| Payload codecs | PoC | Per-record `raw` / `json` / `nif` / `bif` metadata survives WAL, cluster transport, handoff, transactions, Universe sync, and retrieval. NIF/BIF encoding/decoding remains outside the core; optional adapter: [`rochedb-nif`](https://github.com/puffball1567/rochedb-nif) backed by [`nifkit`](https://github.com/puffball1567/nifkit) |
+| Prepared selection | Done | Reusable validated projection tree in embedded mode plus a bounded server-side parse cache for cluster queries |
 | Vector retrieve | Done | FAISS bridge is the intended production vector path. Exact backend remains for small datasets, tests, and fallback |
 | Ring / hierarchy | Done | `ring = "a/b/c"` and child-ring expansion |
 | Galaxy isolation | Done | Separate data dir / peer list / credential boundary |
@@ -60,7 +62,7 @@ Translations:
 | Static cluster | Done | `roched --id --peers` |
 | Deterministic locate | Done | `E(id,t) -> node` |
 | Handoff / forwarder | PoC | Slow tick integration exists. Fully distributed forwarder placement is not done |
-| Driver-friendly wire | Done | `PUTR/GETID/QRYID`; `WIREVER` exposes the current protocol version. Compatibility policy is documented in `docs/protocol-compatibility.md` |
+| Driver-friendly wire | Done | `PUTR/GETID/QRYID`; `WIREVER` exposes the current protocol version and `CODECS` exposes payload formats. Compatibility policy is documented in `docs/protocol-compatibility.md` |
 | Health / metrics / rings | Done | CLI and wire protocol; metrics include uptime, request/error/auth counters, connection counts, WAL bytes, warp backlog, universe apply counters, cluster tx backlog, and storage/ring counts |
 | Authn + secret key | Done | username/password/secret-key |
 | TLS | Planned | Required for public-network deployments |
@@ -77,7 +79,7 @@ Translations:
 | Target | Status | Notes |
 |---|---|---|
 | Nim API | Done | Native public API |
-| C ABI | Done | ABI version / last error / put/get/retrieve/batch/atlas; C ABI vectors are host-native float arrays, while TCP wire vectors are canonical little-endian float32 |
+| C ABI | Done | ABI version / last error / put/get/retrieve/batch/atlas plus additive codec-aware put/get calls; C ABI vectors are host-native float arrays, while TCP wire vectors are canonical little-endian float32 |
 | JavaScript / TypeScript | Published | npm [`rochedb` v0.1.2](https://www.npmjs.com/package/rochedb); repository [`puffball1567/rochedb-js`](https://github.com/puffball1567/rochedb-js); Node-API C ABI wrapper with TypeScript API |
 | Bun | Partial | The npm package uses Node-API and includes Bun compatibility verification, but Bun support remains experimental |
 | Rust | Published | crates.io [`rochedb` v0.1.3](https://crates.io/crates/rochedb); repository [`puffball1567/rochedb-rust`](https://github.com/puffball1567/rochedb-rust); C ABI wrapper |
@@ -108,6 +110,7 @@ Translations:
 | Cluster transaction smoke | Partial | `scripts/cluster_tx_smoke.sh` starts 3 local nodes and verifies apply / retrieve |
 | Cluster failure retry smoke | Partial | `scripts/cluster_failure_smoke.sh` kills the owner node, verifies the intent remains pending, restarts the owner, and verifies retry apply |
 | Universe sync demo | Done | `examples/universe_sync_demo.sh` builds a small source/target pair, demonstrates API-level sync, then demonstrates the CLI export/sync/prune boundary. `scripts/universe_sync_failure_smoke.sh` verifies malformed JSONL handling, replay idempotency, and explicit ack/prune. `scripts/universe_sync_remote_smoke.sh` verifies remote `--peers` delivery and target-down retry behavior |
+| Payload codec demos | Done | `examples/payload_codecs_demo.sh` covers embedded persistence and prepared selection; `examples/payload_codecs_cluster_demo.sh` covers codec negotiation and legacy wire-header compatibility |
 | Crash / failure case study | Partial | Store-level WAL tail repair, compact interruption, partial commit, and cluster owner crash/restart retry are covered |
 | Multi-node cloud case study | Planned | VM/AZ, latency, failover behavior |
 | Prometheus / Datadog exporter | Post-v0.1 candidate | Core exposes key/value metrics now; OpenMetrics / Datadog collector should be added outside the core server loop |

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -1,0 +1,57 @@
+# Test Coverage
+
+This document tracks RocheDB's test coverage by product surface. It is not a
+claim of exhaustive production certification; it is the current engineering
+matrix used before releases.
+
+## Coverage Matrix
+
+| Area | Primary checks | Current status |
+| --- | --- | --- |
+| Orbital placement core | `tests/tcore.nim` | Unit-covered: angle wrapping, ownership, future arrival, conjunctions |
+| Field / halo movement | `tests/tfield.nim` | Unit-covered: field state and ring movement behavior |
+| Selection parser | `tests/tselect.nim` | Unit-covered: GraphQL-like selection parsing and projection basics |
+| Store / WAL | `tests/tstore.nim` | Unit-covered: codec persistence, torn-tail repair, transaction replay, compact, backup/restore |
+| Public embedded API | `tests/tapi.nim` | Unit-covered: put/get, codec-aware projection, ring profiles, readRing filtering, pagination, sorting, warp, universe sync |
+| CLI embedded usage | `scripts/cli_crud_smoke.sh` | Smoke-covered: help, put/get/query/list/count, readRing options, codec display, ring profile auto codec, shell, auth error text |
+| C ABI | `examples/cabi_contract.c`, `scripts/driver_compat.sh` | Contract-covered: ABI version, put/get, codec metadata, read ring page shape, validation errors, atlas |
+| Wire protocol | `tests/twire_driver.nim`, `scripts/cluster_wire_fuzz_smoke.sh` | Smoke-covered: driver-facing PUTR/GETID/QRYID, codec metadata negotiation, malformed frame behavior |
+| Cluster transactions | `tests/tcluster_tx.nim`, `scripts/cluster_tx_smoke.sh` | Smoke-covered: landing intent, apply retry, basic owner failure path |
+| Cluster auth / RBAC | `tests/tcluster_authz.nim`, `tests/tcluster_rbac.nim`, related scripts | Smoke-covered: username/password/secret key and role/ring-prefix authorization |
+| Cluster failure | `tests/tcluster_failure.nim`, `scripts/cluster_failure_smoke.sh` | Smoke-covered: owner restart and retry boundaries |
+| Universe sync | `examples/universe_sync_demo.nim`, `scripts/universe_sync_*_smoke.sh` | Smoke-covered: local export/apply, remote apply, idempotency, malformed JSONL handling |
+| Recovery | `scripts/recovery_smoke.sh` | Smoke-covered: backup/restore and recovery status paths |
+| Driver compatibility | `scripts/driver_compat.sh` | Optional smoke: C, C++, and published driver-facing C ABI paths when enabled |
+
+## Release Gate
+
+For a normal core release, run:
+
+```sh
+scripts/test_core.sh
+scripts/cli_crud_smoke.sh
+scripts/cluster_tx_smoke.sh
+scripts/cluster_failure_smoke.sh
+scripts/cluster_authz_smoke.sh
+scripts/cluster_rbac_smoke.sh
+scripts/cluster_wire_fuzz_smoke.sh
+scripts/recovery_smoke.sh
+scripts/universe_sync_failure_smoke.sh
+scripts/universe_sync_remote_smoke.sh
+```
+
+`scripts/test_all_smoke.sh` runs the same sequence and skips driver
+compatibility by default. Set `ROCHE_TEST_DRIVERS=1` when the local driver
+toolchains are available.
+
+## Remaining Depth Targets
+
+The following areas are intentionally tracked as deeper follow-up work rather
+than hidden assumptions:
+
+- long-running cluster soak tests with node restarts during active traffic;
+- mixed-version wire protocol compatibility tests;
+- TLS deployment tests once transport TLS is added;
+- larger universe sync replay and backlog-pressure tests;
+- driver matrix CI across all published language repositories.
+

--- a/examples/cabi_contract.c
+++ b/examples/cabi_contract.c
@@ -33,6 +33,18 @@ int main(void) {
   if (roche_put_vec(db, "docs/api", payload, strlen(payload), vec, 2, &id) != ROCHE_OK)
     return fail("put_vec failed");
 
+  roche_id bif_id;
+  const unsigned char bif[] = {1, 0, 0, 0};
+  if (roche_put_codec(db, "artifacts/bif", bif, sizeof(bif), ROCHE_CODEC_BIF, &bif_id) != ROCHE_OK)
+    return fail("put_codec failed");
+  size_t bif_len = 0;
+  int bif_codec = -1;
+  void *bif_out = roche_get_codec(db, bif_id, &bif_len, &bif_codec);
+  if (!bif_out || bif_len != sizeof(bif) || bif_codec != ROCHE_CODEC_BIF)
+    return fail("get_codec failed");
+  if (memcmp(bif_out, bif, sizeof(bif)) != 0) return fail("get_codec bytes differ");
+  roche_free(bif_out);
+
   size_t atlas_len = 0;
   char *atlas = roche_atlas(db, vec, 2, 8, &atlas_len);
   if (!atlas || atlas_len == 0) return fail("atlas failed");

--- a/examples/cabi_contract.c
+++ b/examples/cabi_contract.c
@@ -14,6 +14,8 @@ static int fail(const char *msg) {
 }
 
 int main(void) {
+  const char *err;
+
   roche_init();
 
   if (roche_abi_version() != ROCHE_ABI_VERSION) return fail("ABI version mismatch");
@@ -45,6 +47,125 @@ int main(void) {
   if (memcmp(bif_out, bif, sizeof(bif)) != 0) return fail("get_codec bytes differ");
   roche_free(bif_out);
 
+  roche_id json_id;
+  const char *json_payload = "{\"title\":\"C ABI\",\"status\":\"draft\"}";
+  if (roche_put_codec(db, "docs/api", json_payload, strlen(json_payload),
+                      ROCHE_CODEC_JSON, &json_id) != ROCHE_OK)
+    return fail("put_codec json failed");
+
+  size_t read_len = 0;
+  char *read_page = roche_read_ring_json(
+    db,
+    "docs/api",
+    "{\"status\":\"draft\"}",
+    "{ title }",
+    1,
+    "",
+    0,
+    1,
+    20,
+    "time",
+    1,
+    &read_len);
+  if (!read_page || read_len == 0) return fail("read_ring_json failed");
+  if (strstr(read_page, "\"items\"") == NULL) return fail("read_ring_json misses items");
+  if (strstr(read_page, "\"count\":1") == NULL) return fail("read_ring_json misses count");
+  if (strstr(read_page, "\"title\":\"C ABI\"") == NULL)
+    return fail("read_ring_json misses selected JSON payload");
+  roche_free(read_page);
+
+  read_page = roche_read_ring_json(
+    db,
+    "artifacts/bif",
+    "",
+    "",
+    10,
+    "",
+    0,
+    1,
+    20,
+    "time",
+    1,
+    &read_len);
+  if (!read_page || strstr(read_page, "\"codec\":\"bif\"") == NULL ||
+      strstr(read_page, "\"encoding\":\"base64\"") == NULL)
+    return fail("read_ring_json should base64 encode binary payloads");
+  roche_free(read_page);
+
+  roche_id nif_id;
+  const char *nif_payload = "(object (title RocheDB))";
+  if (roche_put_codec(db, "artifacts/nif", nif_payload, strlen(nif_payload),
+                      ROCHE_CODEC_NIF, &nif_id) != ROCHE_OK)
+    return fail("put_codec nif failed");
+  read_page = roche_read_ring_json(
+    db,
+    "artifacts/nif",
+    "",
+    "",
+    10,
+    "",
+    0,
+    1,
+    20,
+    "time",
+    1,
+    &read_len);
+  if (!read_page || strstr(read_page, "\"codec\":\"nif\"") == NULL ||
+      strstr(read_page, "\"encoding\":\"base64\"") == NULL)
+    return fail("read_ring_json should preserve NIF metadata");
+  roche_free(read_page);
+
+  read_page = roche_read_ring_json(
+    db,
+    "docs/api",
+    "[]",
+    "",
+    10,
+    "",
+    0,
+    1,
+    20,
+    "time",
+    1,
+    &read_len);
+  if (read_page != NULL) return fail("read_ring_json should reject non-object filter");
+  err = roche_last_error();
+  if (!err || strstr(err, "filter") == NULL) return fail("last_error should mention filter");
+
+  read_page = roche_read_ring_json(
+    db,
+    "docs/api",
+    "",
+    "",
+    10,
+    "",
+    0,
+    1,
+    20,
+    "payload",
+    1,
+    &read_len);
+  if (read_page != NULL) return fail("read_ring_json should reject invalid sort field");
+  err = roche_last_error();
+  if (!err || strstr(err, "sort field") == NULL) return fail("last_error should mention sort field");
+
+  read_page = roche_read_ring_json(
+    db,
+    NULL,
+    "",
+    "",
+    10,
+    "",
+    0,
+    1,
+    20,
+    "time",
+    1,
+    &read_len);
+  if (read_page != NULL) return fail("read_ring_json should reject NULL ring");
+  err = roche_last_error();
+  if (!err || strstr(err, "ring") == NULL) return fail("last_error should mention read ring");
+
   size_t atlas_len = 0;
   char *atlas = roche_atlas(db, vec, 2, 8, &atlas_len);
   if (!atlas || atlas_len == 0) return fail("atlas failed");
@@ -55,7 +176,7 @@ int main(void) {
   roche_id dummy;
   if (roche_put(db, NULL, payload, strlen(payload), &dummy) != ROCHE_ERR)
     return fail("NULL ring should fail");
-  const char *err = roche_last_error();
+  err = roche_last_error();
   if (!err || strstr(err, "ring") == NULL) return fail("last_error should mention ring");
 
   roche_close(db);

--- a/examples/payload_codecs_cluster_demo.nim
+++ b/examples/payload_codecs_cluster_demo.nim
@@ -1,0 +1,36 @@
+## Cluster payload codec and legacy wire-header compatibility demo.
+
+import std/[net, os, sequtils, strutils]
+import ../src/roche/core
+import ../src/roche/[wire]
+
+proc requireArg(name: string): string =
+  let prefix = "--" & name & "="
+  for arg in commandLineParams():
+    if arg.startsWith(prefix):
+      return arg[prefix.len .. ^1]
+  raise newException(ValueError, "missing " & prefix & "...")
+
+when isMainModule:
+  let peers = parsePeers(requireArg("peers"))
+  var client = newClusterClient(peers)
+  try:
+    echo "node codecs: ", client.codecsReq(0).mapIt(it.payloadCodecName).join(", ")
+    let id = client.putRingReq(0, "demo/codec", "\x01\x00\x00\x00", @[], pcBif)
+    let stored = client.getIdReq(0, id)
+    echo "negotiated get: codec=", stored.codec.payloadCodecName,
+         " bytes=", stored.value.len
+
+    # No CODECMETA negotiation: this models released legacy wire drivers.
+    let owner = int(ArcTable(epoch: id.epoch, nNodes: uint16(peers.len)).owner(id.head))
+    var legacy = newSocket()
+    legacy.connect(peers[owner].host, Port(peers[owner].port))
+    legacy.sendFrame("GETID " & $id.parent & " " & $id.epoch & " " &
+                     $id.seq & " " & $id.tWrite & " " & $id.period & " " &
+                     $id.head)
+    let header = legacy.readHeader()
+    discard legacy.readExact(parseInt(header[2]))
+    legacy.close()
+    echo "legacy get header fields: ", header.len, " (VAL node length)"
+  finally:
+    client.close()

--- a/examples/payload_codecs_cluster_demo.sh
+++ b/examples/payload_codecs_cluster_demo.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BASE_PORT="${ROCHE_PAYLOAD_CODECS_BASE_PORT:-18011}"
+PEERS="127.0.0.1:${BASE_PORT},127.0.0.1:$((BASE_PORT + 1))"
+WORK="${TMPDIR:-/tmp}/rochedb-payload-codecs-cluster-demo-$$"
+PIDS=()
+
+cleanup() {
+  if ((${#PIDS[@]} > 0)); then
+    kill "${PIDS[@]}" >/dev/null 2>&1 || true
+    wait "${PIDS[@]}" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+cd "$ROOT"
+mkdir -p "$WORK" bin
+nim c -d:release --nimcache:/tmp/nimcache_roched_payload_codecs_demo \
+  -o:src/roched src/roched.nim
+nim c -d:release --nimcache:/tmp/nimcache_roche_payload_codecs_cluster_demo \
+  -o:bin/payload_codecs_cluster_demo examples/payload_codecs_cluster_demo.nim
+
+for id in 0 1; do
+  src/roched --id="$id" --peers="$PEERS" --data="$WORK/node$id" --slow-tick=0.05 &
+  PIDS+=("$!")
+done
+
+for _ in $(seq 1 50); do
+  if bin/payload_codecs_cluster_demo --peers="$PEERS" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.1
+done
+
+bin/payload_codecs_cluster_demo --peers="$PEERS"

--- a/examples/payload_codecs_demo.nim
+++ b/examples/payload_codecs_demo.nim
@@ -1,0 +1,48 @@
+## Embedded payload codec and prepared selection demo.
+
+import std/[json, os, strutils]
+import ../src/rochedb
+
+proc argValue(name, defaultValue: string): string =
+  let prefix = "--" & name & "="
+  for arg in commandLineParams():
+    if arg.startsWith(prefix):
+      return arg[prefix.len .. ^1]
+  defaultValue
+
+when isMainModule:
+  let dataDir = argValue("data", "")
+  var db = open(dataDir = dataDir)
+  try:
+    let jsonId = db.put(%*{
+      "title": "RocheDB",
+      "kind": "document",
+      "author": {"name": "Ada", "team": "storage"}
+    }, ring = "docs/codec")
+    let nifBytes = "(object (title RocheDB) (kind artifact))"
+    let nifId = db.put(encodedPayload(nifBytes, pcNif), ring = "artifacts/nif")
+    let bifBytes = "\x01\x00\x00\x00\x7f"
+    let bifId = db.put(encodedPayload(bifBytes, pcBif), ring = "artifacts/bif")
+
+    let fields = prepareSelection("{ title author { name } }")
+    echo "JSON projection: ", $db.query(jsonId, fields)
+    for id in [jsonId, nifId, bifId]:
+      let value = db.getEncoded(id)
+      echo "stored codec=", value.codec.payloadCodecName,
+           " bytes=", value.data.len
+
+    try:
+      discard db.query(nifId, fields)
+    except ValueError as err:
+      echo "NIF projection rejected: ", err.msg
+  finally:
+    db.close()
+
+  if dataDir.len > 0:
+    var reopened = open(dataDir = dataDir)
+    try:
+      let page = reopened.listByRing("artifacts/bif", limit = 1)
+      echo "reopen codec=", page.items[0].codec.payloadCodecName,
+           " bytes=", page.items[0].payload.len
+    finally:
+      reopened.close()

--- a/examples/payload_codecs_demo.sh
+++ b/examples/payload_codecs_demo.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="${TMPDIR:-/tmp}/rochedb-payload-codecs-demo-$$"
+mkdir -p "$WORK"
+trap 'rm -rf "$WORK"' EXIT
+
+cd "$ROOT"
+nim c -d:release --nimcache:/tmp/nimcache_roche_payload_codecs_demo \
+  -o:bin/payload_codecs_demo examples/payload_codecs_demo.nim
+bin/payload_codecs_demo --data="$WORK/data"

--- a/include/rochedb.h
+++ b/include/rochedb.h
@@ -63,6 +63,11 @@ typedef struct roche_batch_result {
 
 #define ROCHE_ABI_VERSION 1
 
+#define ROCHE_CODEC_RAW  0
+#define ROCHE_CODEC_JSON 1
+#define ROCHE_CODEC_NIF  2
+#define ROCHE_CODEC_BIF  3
+
 /* ABI バージョンと直近エラー。last_error はスレッドローカル相当で、所有権は呼び出し側にない。 */
 int         roche_abi_version(void);
 const char *roche_last_error(void);
@@ -97,6 +102,10 @@ int    roche_set_ring_description(void *db, const char *ring, const char *descri
 /* 書き込み。out_id に不透明IDが入る。以後この ID だけで所在計算が閉じる。 */
 int    roche_put(void *db, const char *ring,
                  const void *data, size_t len, roche_id *out_id);
+/* Codec-aware variants are additive. NIF/BIF bytes are application-encoded. */
+int    roche_put_codec(void *db, const char *ring,
+                       const void *data, size_t len, int codec,
+                       roche_id *out_id);
 /* vector 付き書き込み。vec は呼び出しプロセスの通常の float32 配列、
  * vec_len は要素数。C ABI 境界では host-native float を受け取る。
  * TCP wire protocol は別契約で、vector bytes は canonical little-endian
@@ -105,10 +114,16 @@ int    roche_put_vec(void *db, const char *ring,
                      const void *data, size_t len,
                      const float *vec, size_t vec_len,
                      roche_id *out_id);
+int    roche_put_vec_codec(void *db, const char *ring,
+                           const void *data, size_t len, int codec,
+                           const float *vec, size_t vec_len,
+                           roche_id *out_id);
 
 /* 読み出し。NUL 終端付きの複製バッファを返す（roche_free で解放）。
  * 見つからなければ NULL。 */
 void  *roche_get(void *db, roche_id id, size_t *out_len);
+/* Returns payload bytes and persisted codec. Buffer ownership matches roche_get. */
+void  *roche_get_codec(void *db, roche_id id, size_t *out_len, int *out_codec);
 void   roche_free(void *p);
 /* 複数 ID のまとめ読み。戻り値は roche_batch_get_free で解放。 */
 roche_batch_result *roche_batch_get(void *db, const roche_id *ids, size_t ids_len);

--- a/include/rochedb.h
+++ b/include/rochedb.h
@@ -61,7 +61,7 @@ typedef struct roche_batch_result {
 #define ROCHE_OK   0
 #define ROCHE_ERR -1
 
-#define ROCHE_ABI_VERSION 1
+#define ROCHE_ABI_VERSION 2
 
 #define ROCHE_CODEC_RAW  0
 #define ROCHE_CODEC_JSON 1
@@ -132,6 +132,31 @@ void   roche_batch_get_free(roche_batch_result *r);
 /* 選択取得（GraphQL 風）: selection 例 "{ title author { name } }"。
  * 選択した部分の JSON 文字列を返す（roche_free で解放）。失敗時 NULL。 */
 void  *roche_query(void *db, roche_id id, const char *selection, size_t *out_len);
+
+/* Ring read page as JSON. This is the driver-friendly counterpart of
+ * `roche get --ring=...`: it returns one stable shape for one or many records.
+ *
+ * filter_json: JSON object string, or NULL/"" for no filter.
+ * selection: optional JSON projection selection.
+ * pagination: 0 = cursor/limit mode, non-zero = page/page_limit mode.
+ * sort_desc: 0 = ascending, non-zero = descending.
+ *
+ * JSON/non-binary payloads are returned as JSON values when possible.
+ * Other payloads are base64 encoded and marked with "encoding": "base64".
+ * Returned buffer ownership matches roche_get: call roche_free.
+ */
+void  *roche_read_ring_json(void *db,
+                            const char *ring,
+                            const char *filter_json,
+                            const char *selection,
+                            int limit,
+                            const char *cursor,
+                            int pagination,
+                            int page,
+                            int page_limit,
+                            const char *sort_field,
+                            int sort_desc,
+                            size_t *out_len);
 
 /* vector 近傍検索。ring は NULL/空文字で global。戻り値は roche_retrieve_free で解放。 */
 roche_retrieve_result *roche_retrieve(void *db,

--- a/rochedb.nimble
+++ b/rochedb.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version     = "0.2.5"
+version     = "0.3.0"
 author      = "puffball1567"
 description = "Ring-oriented NoSQL document/vector store for smaller working sets"
 license     = "Apache-2.0"

--- a/scripts/cli_crud_smoke.sh
+++ b/scripts/cli_crud_smoke.sh
@@ -17,6 +17,7 @@ cleanup() {
 trap cleanup EXIT
 
 mkdir -p "$WORK" "$ROOT/bin"
+export ROCHE_DATA="$WORK/data"
 
 echo "[cli-crud] build roche"
 nim c -d:release --nimcache:/tmp/nimcache_roche_cli_crud \
@@ -28,7 +29,7 @@ echo "[cli-crud] help"
 bin/roche --help | grep -q "roche put"
 
 echo "[cli-crud] put"
-put_out="$(bin/roche put --data="$WORK/data" --ring=docs/japan \
+put_out="$(bin/roche put --ring=docs/japan \
   --payload='{"title":"Hello","status":"draft"}')"
 grep -q "put OK" <<<"$put_out"
 raw_id="$(sed -n 's/.*rawId=\([^ ]*\).*/\1/p' <<<"$put_out")"
@@ -38,21 +39,21 @@ if [[ -z "$raw_id" ]]; then
 fi
 
 echo "[cli-crud] count/list/get/query"
-bin/roche count-ring --data="$WORK/data" --ring=docs/japan |
+bin/roche count-ring --ring=docs/japan |
   grep -q "count=1"
-bin/roche list-ring --data="$WORK/data" --ring=docs/japan |
+bin/roche list-ring --ring=docs/japan |
   grep -q '"rawId"'
-bin/roche get --data="$WORK/data" --ring=docs/japan --id="$raw_id" |
+bin/roche get --ring=docs/japan --where="{\"id\":\"$raw_id\"}" |
   grep -q '"status":"draft"'
-bin/roche query --data="$WORK/data" --ring=docs/japan --id="$raw_id" --selection='{ title }' |
+bin/roche query --ring=docs/japan --where="{\"id\":\"$raw_id\"}" --selection='{ title }' |
   grep -q '"title": "Hello"'
 
 echo "[cli-crud] binary codec display"
 printf '\001\002\003\004' >"$WORK/payload.bif"
-bif_out="$(bin/roche put --data="$WORK/data" --ring=artifacts/bif \
+bif_out="$(bin/roche put --ring=artifacts/bif \
   --in="$WORK/payload.bif" --codec=bif)"
 bif_id="$(sed -n 's/.*rawId=\([^ ]*\).*/\1/p' <<<"$bif_out")"
-bin/roche get --data="$WORK/data" --ring=artifacts/bif --id="$bif_id" --view=auto |
+bin/roche get --ring=artifacts/bif --where="{\"id\":\"$bif_id\"}" |
   grep -q 'codec=bif encoding=base64'
 cat >"$WORK/fake_nif_tool" <<'TOOL'
 #!/usr/bin/env bash
@@ -73,10 +74,10 @@ printf '(decoded "from adapter")' >"$out"
 TOOL
 chmod +x "$WORK/fake_nif_tool"
 ROCHEDB_NIF_TOOL="$WORK/fake_nif_tool" \
-  bin/roche get --data="$WORK/data" --ring=artifacts/bif --id="$bif_id" --view=auto |
+  bin/roche get --ring=artifacts/bif --where="{\"id\":\"$bif_id\"}" |
   grep -q 'codec=bif encoding=nif adapter=nif'
 ROCHEDB_NIF_TOOL="$WORK/fake_nif_tool" \
-  bin/roche get --data="$WORK/data" --ring=artifacts/bif --id="$bif_id" --view=auto |
+  bin/roche get --ring=artifacts/bif --where="{\"id\":\"$bif_id\"}" |
   grep -q '(decoded "from adapter")'
 
 echo "[cli-crud] shell"

--- a/scripts/cli_crud_smoke.sh
+++ b/scripts/cli_crud_smoke.sh
@@ -47,6 +47,14 @@ bin/roche get --data="$WORK/data" --id="$raw_id" |
 bin/roche query --data="$WORK/data" --id="$raw_id" --selection='{ title }' |
   grep -q '"title": "Hello"'
 
+echo "[cli-crud] binary codec display"
+printf '\001\002\003\004' >"$WORK/payload.bif"
+bif_out="$(bin/roche put --data="$WORK/data" --ring=artifacts/bif \
+  --in="$WORK/payload.bif" --codec=bif)"
+bif_id="$(sed -n 's/.*rawId=\([^ ]*\).*/\1/p' <<<"$bif_out")"
+bin/roche get --data="$WORK/data" --id="$bif_id" --view=auto |
+  grep -q 'codec=bif encoding=base64'
+
 echo "[cli-crud] shell"
 shell_out="$(bin/roche shell --data="$WORK/shell" <<'SHELL'
 put docs/japan {"title":"Shell","status":"ok"}

--- a/scripts/cli_crud_smoke.sh
+++ b/scripts/cli_crud_smoke.sh
@@ -41,11 +41,15 @@ fi
 echo "[cli-crud] count/list/get/query"
 bin/roche count-ring --ring=docs/japan |
   grep -q "count=1"
+bin/roche get --ring=docs/japan |
+  grep -q '"status": "draft"'
 bin/roche list-ring --ring=docs/japan |
   grep -q '"rawId"'
-bin/roche get --ring=docs/japan --where="{\"id\":\"$raw_id\"}" |
-  grep -q '"status":"draft"'
-bin/roche query --ring=docs/japan --where="{\"id\":\"$raw_id\"}" --selection='{ title }' |
+bin/roche get --ring=docs/japan --filter="{\"id\":\"$raw_id\"}" |
+  grep -q '"status": "draft"'
+bin/roche get --ring=docs/japan --filter='{"status":"draft"}' --selection='{ title }' |
+  grep -q '"title": "Hello"'
+bin/roche query --ring=docs/japan --filter="{\"id\":\"$raw_id\"}" --selection='{ title }' |
   grep -q '"title": "Hello"'
 
 echo "[cli-crud] binary codec display"
@@ -53,7 +57,7 @@ printf '\001\002\003\004' >"$WORK/payload.bif"
 bif_out="$(bin/roche put --ring=artifacts/bif \
   --in="$WORK/payload.bif" --codec=bif)"
 bif_id="$(sed -n 's/.*rawId=\([^ ]*\).*/\1/p' <<<"$bif_out")"
-bin/roche get --ring=artifacts/bif --where="{\"id\":\"$bif_id\"}" |
+bin/roche get --ring=artifacts/bif --filter="{\"id\":\"$bif_id\"}" |
   grep -q 'codec=bif encoding=base64'
 cat >"$WORK/fake_nif_tool" <<'TOOL'
 #!/usr/bin/env bash
@@ -74,10 +78,10 @@ printf '(decoded "from adapter")' >"$out"
 TOOL
 chmod +x "$WORK/fake_nif_tool"
 ROCHEDB_NIF_TOOL="$WORK/fake_nif_tool" \
-  bin/roche get --ring=artifacts/bif --where="{\"id\":\"$bif_id\"}" |
+  bin/roche get --ring=artifacts/bif --filter="{\"id\":\"$bif_id\"}" |
   grep -q 'codec=bif encoding=nif adapter=nif'
 ROCHEDB_NIF_TOOL="$WORK/fake_nif_tool" \
-  bin/roche get --ring=artifacts/bif --where="{\"id\":\"$bif_id\"}" |
+  bin/roche get --ring=artifacts/bif --filter="{\"id\":\"$bif_id\"}" |
   grep -q '(decoded "from adapter")'
 
 echo "[cli-crud] shell"

--- a/scripts/cli_crud_smoke.sh
+++ b/scripts/cli_crud_smoke.sh
@@ -30,7 +30,7 @@ bin/roche --help | grep -q "roche put"
 
 echo "[cli-crud] put"
 put_out="$(bin/roche put --ring=docs/japan \
-  --payload='{"title":"Hello","status":"draft"}')"
+  --payload='{"title":"Hello","status":"draft"}' --codec=json)"
 grep -q "put OK" <<<"$put_out"
 raw_id="$(sed -n 's/.*rawId=\([^ ]*\).*/\1/p' <<<"$put_out")"
 if [[ -z "$raw_id" ]]; then
@@ -58,6 +58,30 @@ bin/roche get --ring=docs/japan --filter='{"status":"draft"}' --selection='{ tit
 bin/roche query --ring=docs/japan --filter="{\"id\":\"$raw_id\"}" --selection='{ title }' |
   grep -q '"title": "Hello"'
 
+echo "[cli-crud] explicit and profile-driven codecs"
+printf '(object (title "NIF text"))' >"$WORK/payload.nif"
+nif_out="$(bin/roche put --ring=artifacts/nif \
+  --in="$WORK/payload.nif" --codec=nif)"
+nif_id="$(sed -n 's/.*rawId=\([^ ]*\).*/\1/p' <<<"$nif_out")"
+bin/roche get --ring=artifacts/nif --filter="{\"id\":\"$nif_id\"}" |
+  grep -q '"codec": "nif"'
+bin/roche get --ring=artifacts/nif --filter="{\"id\":\"$nif_id\"}" |
+  grep -q '"encoding": "text"'
+
+bin/roche ring-profile --ring=artifacts/auto-nif \
+  --codec=nif --charset=UTF-8 --format-version=1 |
+  grep -q '"defaultCodec": "nif"'
+auto_nif_out="$(bin/roche put --ring=artifacts/auto-nif \
+  --payload='(object (title "Auto NIF"))' --codec=auto)"
+auto_nif_id="$(sed -n 's/.*rawId=\([^ ]*\).*/\1/p' <<<"$auto_nif_out")"
+bin/roche get --ring=artifacts/auto-nif --filter="{\"id\":\"$auto_nif_id\"}" |
+  grep -q '"codec": "nif"'
+
+raw_out="$(bin/roche put --ring=logs/raw --payload='plain text payload' --codec=raw)"
+raw_text_id="$(sed -n 's/.*rawId=\([^ ]*\).*/\1/p' <<<"$raw_out")"
+bin/roche get --ring=logs/raw --filter="{\"id\":\"$raw_text_id\"}" |
+  grep -q '"codec": "raw"'
+
 echo "[cli-crud] binary codec display"
 printf '\001\002\003\004' >"$WORK/payload.bif"
 bif_out="$(bin/roche put --ring=artifacts/bif \
@@ -67,6 +91,8 @@ bin/roche get --ring=artifacts/bif --filter="{\"id\":\"$bif_id\"}" |
   grep -q '"codec": "bif"'
 bin/roche get --ring=artifacts/bif --filter="{\"id\":\"$bif_id\"}" |
   grep -q '"encoding": "base64"'
+bin/roche get --ring=artifacts/bif --filter="{\"id\":\"$bif_id\"}" --view=hex |
+  grep -q '"encoding": "hex"'
 cat >"$WORK/fake_nif_tool" <<'TOOL'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -94,6 +120,14 @@ ROCHEDB_NIF_TOOL="$WORK/fake_nif_tool" \
 ROCHEDB_NIF_TOOL="$WORK/fake_nif_tool" \
   bin/roche get --ring=artifacts/bif --filter="{\"id\":\"$bif_id\"}" |
   grep -q 'decoded'
+
+echo "[cli-crud] read validation"
+bad_filter_out="$(bin/roche get --ring=docs/japan --filter='[]' 2>&1 >/dev/null || true)"
+grep -q 'filter must be a JSON object' <<<"$bad_filter_out"
+bad_sort_out="$(bin/roche get --ring=docs/japan --sort=payload 2>&1 >/dev/null || true)"
+grep -q 'sort field must be id, time, or write' <<<"$bad_sort_out"
+bad_selection_out="$(bin/roche get --ring=artifacts/bif --selection='{ title }' 2>&1 >/dev/null || true)"
+grep -q 'payload codec bif does not support JSON projection' <<<"$bad_selection_out"
 
 echo "[cli-crud] shell"
 shell_out="$(bin/roche shell --data="$WORK/shell" <<'SHELL'

--- a/scripts/cli_crud_smoke.sh
+++ b/scripts/cli_crud_smoke.sh
@@ -42,9 +42,9 @@ bin/roche count-ring --data="$WORK/data" --ring=docs/japan |
   grep -q "count=1"
 bin/roche list-ring --data="$WORK/data" --ring=docs/japan |
   grep -q '"rawId"'
-bin/roche get --data="$WORK/data" --id="$raw_id" |
+bin/roche get --data="$WORK/data" --ring=docs/japan --id="$raw_id" |
   grep -q '"status":"draft"'
-bin/roche query --data="$WORK/data" --id="$raw_id" --selection='{ title }' |
+bin/roche query --data="$WORK/data" --ring=docs/japan --id="$raw_id" --selection='{ title }' |
   grep -q '"title": "Hello"'
 
 echo "[cli-crud] binary codec display"
@@ -52,7 +52,7 @@ printf '\001\002\003\004' >"$WORK/payload.bif"
 bif_out="$(bin/roche put --data="$WORK/data" --ring=artifacts/bif \
   --in="$WORK/payload.bif" --codec=bif)"
 bif_id="$(sed -n 's/.*rawId=\([^ ]*\).*/\1/p' <<<"$bif_out")"
-bin/roche get --data="$WORK/data" --id="$bif_id" --view=auto |
+bin/roche get --data="$WORK/data" --ring=artifacts/bif --id="$bif_id" --view=auto |
   grep -q 'codec=bif encoding=base64'
 cat >"$WORK/fake_nif_tool" <<'TOOL'
 #!/usr/bin/env bash
@@ -73,10 +73,10 @@ printf '(decoded "from adapter")' >"$out"
 TOOL
 chmod +x "$WORK/fake_nif_tool"
 ROCHEDB_NIF_TOOL="$WORK/fake_nif_tool" \
-  bin/roche get --data="$WORK/data" --id="$bif_id" --view=auto |
+  bin/roche get --data="$WORK/data" --ring=artifacts/bif --id="$bif_id" --view=auto |
   grep -q 'codec=bif encoding=nif adapter=nif'
 ROCHEDB_NIF_TOOL="$WORK/fake_nif_tool" \
-  bin/roche get --data="$WORK/data" --id="$bif_id" --view=auto |
+  bin/roche get --data="$WORK/data" --ring=artifacts/bif --id="$bif_id" --view=auto |
   grep -q '(decoded "from adapter")'
 
 echo "[cli-crud] shell"

--- a/scripts/cli_crud_smoke.sh
+++ b/scripts/cli_crud_smoke.sh
@@ -43,6 +43,10 @@ bin/roche count-ring --ring=docs/japan |
   grep -q "count=1"
 bin/roche get --ring=docs/japan |
   grep -q '"status": "draft"'
+bin/roche get --ring=docs/japan --limit=1 --order=write-desc |
+  grep -q '"items"'
+bin/roche get --ring=docs/japan --limit=1 --order=id-asc |
+  grep -q '"order": "id-asc"'
 bin/roche list-ring --ring=docs/japan |
   grep -q '"rawId"'
 bin/roche get --ring=docs/japan --filter="{\"id\":\"$raw_id\"}" |

--- a/scripts/cli_crud_smoke.sh
+++ b/scripts/cli_crud_smoke.sh
@@ -43,10 +43,12 @@ bin/roche count-ring --ring=docs/japan |
   grep -q "count=1"
 bin/roche get --ring=docs/japan |
   grep -q '"status": "draft"'
-bin/roche get --ring=docs/japan --limit=1 --order=write-desc |
+bin/roche get --ring=docs/japan --limit=1 --rsort=time |
   grep -q '"items"'
-bin/roche get --ring=docs/japan --limit=1 --order=id-asc |
-  grep -q '"order": "id-asc"'
+bin/roche get --ring=docs/japan --limit=1 --sort=id |
+  grep -q '"sort": "id"'
+bin/roche get --ring=docs/japan --limit=1 --sort=id |
+  grep -q '"sortDirection": "asc"'
 bin/roche list-ring --ring=docs/japan |
   grep -q '"rawId"'
 bin/roche get --ring=docs/japan --filter="{\"id\":\"$raw_id\"}" |
@@ -62,7 +64,9 @@ bif_out="$(bin/roche put --ring=artifacts/bif \
   --in="$WORK/payload.bif" --codec=bif)"
 bif_id="$(sed -n 's/.*rawId=\([^ ]*\).*/\1/p' <<<"$bif_out")"
 bin/roche get --ring=artifacts/bif --filter="{\"id\":\"$bif_id\"}" |
-  grep -q 'codec=bif encoding=base64'
+  grep -q '"codec": "bif"'
+bin/roche get --ring=artifacts/bif --filter="{\"id\":\"$bif_id\"}" |
+  grep -q '"encoding": "base64"'
 cat >"$WORK/fake_nif_tool" <<'TOOL'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -83,10 +87,13 @@ TOOL
 chmod +x "$WORK/fake_nif_tool"
 ROCHEDB_NIF_TOOL="$WORK/fake_nif_tool" \
   bin/roche get --ring=artifacts/bif --filter="{\"id\":\"$bif_id\"}" |
-  grep -q 'codec=bif encoding=nif adapter=nif'
+  grep -q '"encoding": "nif"'
 ROCHEDB_NIF_TOOL="$WORK/fake_nif_tool" \
   bin/roche get --ring=artifacts/bif --filter="{\"id\":\"$bif_id\"}" |
-  grep -q '(decoded "from adapter")'
+  grep -q '"adapter": "nif"'
+ROCHEDB_NIF_TOOL="$WORK/fake_nif_tool" \
+  bin/roche get --ring=artifacts/bif --filter="{\"id\":\"$bif_id\"}" |
+  grep -q 'decoded'
 
 echo "[cli-crud] shell"
 shell_out="$(bin/roche shell --data="$WORK/shell" <<'SHELL'

--- a/scripts/cli_crud_smoke.sh
+++ b/scripts/cli_crud_smoke.sh
@@ -54,6 +54,30 @@ bif_out="$(bin/roche put --data="$WORK/data" --ring=artifacts/bif \
 bif_id="$(sed -n 's/.*rawId=\([^ ]*\).*/\1/p' <<<"$bif_out")"
 bin/roche get --data="$WORK/data" --id="$bif_id" --view=auto |
   grep -q 'codec=bif encoding=base64'
+cat >"$WORK/fake_nif_tool" <<'TOOL'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" != "decode" ]]; then
+  exit 2
+fi
+out=""
+for arg in "$@"; do
+  case "$arg" in
+    --out=*) out="${arg#--out=}" ;;
+  esac
+done
+if [[ -z "$out" ]]; then
+  exit 2
+fi
+printf '(decoded "from adapter")' >"$out"
+TOOL
+chmod +x "$WORK/fake_nif_tool"
+ROCHEDB_NIF_TOOL="$WORK/fake_nif_tool" \
+  bin/roche get --data="$WORK/data" --id="$bif_id" --view=auto |
+  grep -q 'codec=bif encoding=nif adapter=nif'
+ROCHEDB_NIF_TOOL="$WORK/fake_nif_tool" \
+  bin/roche get --data="$WORK/data" --id="$bif_id" --view=auto |
+  grep -q '(decoded "from adapter")'
 
 echo "[cli-crud] shell"
 shell_out="$(bin/roche shell --data="$WORK/shell" <<'SHELL'

--- a/src/roche/field.nim
+++ b/src/roche/field.nim
@@ -148,7 +148,7 @@ proc adoptClump(fs: FieldState, st: Store, idx: int, target: uint64,
     let newSeq = st.nextSeq(target)
     tx.upsert Particle(parent: target, seq: newSeq, period: meta.period,
                        head: meta.head, tWrite: now, payload: p.payload,
-                       vec: p.vec)
+                       codec: p.codec, vec: p.vec)
     let f = Forwarder(newParent: target, newSeq: newSeq,
                       newTWrite: now, expiresAt: now + forwardTtl)
     tx.remove(oldId[0], oldId[1])

--- a/src/roche/payload.nim
+++ b/src/roche/payload.nim
@@ -1,0 +1,48 @@
+## Payload format metadata shared by the embedded store and wire protocol.
+
+import std/strutils
+
+type
+  PayloadCodec* = enum
+    pcRaw
+    pcJson
+    pcNif
+    pcBif
+
+  EncodedPayload* = object
+    data*: string
+    codec*: PayloadCodec
+
+  RingPayloadProfile* = object
+    ## Ring-scoped declaration for applications and CLI tools. Individual
+    ## records retain their own codec and remain authoritative.
+    defaultCodec*: PayloadCodec
+    charset*: string
+    formatVersion*: string
+
+proc payloadCodecName*(codec: PayloadCodec): string =
+  case codec
+  of pcRaw: "raw"
+  of pcJson: "json"
+  of pcNif: "nif"
+  of pcBif: "bif"
+
+proc parsePayloadCodec*(value: string): PayloadCodec =
+  case value.toLowerAscii()
+  of "raw", "bytes", "application/octet-stream": pcRaw
+  of "json", "application/json": pcJson
+  of "nif", "application/nif": pcNif
+  of "bif", "application/bif": pcBif
+  else:
+    raise newException(ValueError, "unsupported payload codec: " & value)
+
+proc encodedPayload*(data: string, codec = pcRaw): EncodedPayload =
+  EncodedPayload(data: data, codec: codec)
+
+proc defaultRingPayloadProfile*(): RingPayloadProfile =
+  RingPayloadProfile(defaultCodec: pcRaw, charset: "", formatVersion: "")
+
+proc supportsJsonProjection*(codec: PayloadCodec): bool =
+  ## Raw remains projection-compatible for records written before codec metadata
+  ## existed and for legacy drivers that already send JSON through PUTR.
+  codec in {pcRaw, pcJson}

--- a/src/roche/select.nim
+++ b/src/roche/select.nim
@@ -12,6 +12,12 @@ type Selection* = ref object
   ## 木構造で循環はない（ARC 制約, 設計書 §13.3）。
   fields*: OrderedTable[string, Selection]
 
+type PreparedSelection* = object
+  ## Validated reusable projection. Keeping the parsed tree prevents repeated
+  ## parsing in embedded mode and prevents callers from interpolating values.
+  source*: string
+  tree*: Selection
+
 proc isIdentChar(c: char): bool =
   c in {'a'..'z', 'A'..'Z', '0'..'9', '_', '-', '.'}
 
@@ -56,6 +62,9 @@ proc parseSelection*(src: string): Selection =
       raise newException(ValueError, "selection: '}' の後に余分な入力")
     inc pos
 
+proc prepareSelection*(src: string): PreparedSelection =
+  PreparedSelection(source: src, tree: parseSelection(src))
+
 proc applySelection*(sel: Selection, node: JsonNode): JsonNode =
   ## 選択木を JSON に適用して部分だけを返す。
   ## - オブジェクト: 選択したフィールドのうち存在するものだけ（欠けは黙って省略）
@@ -75,3 +84,6 @@ proc applySelection*(sel: Selection, node: JsonNode): JsonNode =
       result.add applySelection(sel, elem)
   else:
     result = node
+
+proc applySelection*(prepared: PreparedSelection, node: JsonNode): JsonNode =
+  applySelection(prepared.tree, node)

--- a/src/roche/store.nim
+++ b/src/roche/store.nim
@@ -14,7 +14,9 @@
 ##   N <ringKey> <len>\n<name>\n                               環名
 ##   RD <ringKey> <len>\n<description>\n                     環説明
 ##   R <ringKey> <period> <head>\n                             環メタ
-##   P <parent> <seq> <period> <head> <tWrite> <len>\n<payload>\n   粒子 upsert
+##   RP <ringKey> <len>\n<json>\n                              環payload profile
+##   P <parent> <seq> <period> <head> <tWrite> <len> <dim> <codec>\n<payload><vec>\n
+##                                                               粒子 upsert
 ##   E <parent> <seq> <dim>\n<dim×float32>\n                    埋め込み
 ##   F <oldParent> <oldSeq> <newParent> <newSeq> <newTWrite> <expiresAt>\n フォワーダ
 ##   D <parent> <seq>\n                                        削除（ハンドオフ退去）
@@ -28,8 +30,11 @@
 ##   UA <len>\n<eventKey>\n                         universe sync event applied marker
 ##   Q <nextTxId>\n                                      次の transaction id
 
-import std/[tables, os, streams, strutils, monotimes, times, posix]
+import std/[tables, os, streams, strutils, monotimes, times, posix, json]
 import nimsodium
+import payload
+
+export payload
 
 type
   StoreDurability* = enum
@@ -43,6 +48,7 @@ type
     head*: float
     tWrite*: float
     payload*: string
+    codec*: PayloadCodec
     vec*: seq[float32]
     # serving 状態（永続化しない）
     sentAhead*: bool
@@ -90,6 +96,7 @@ type
     head*: float
     tWrite*: float
     payload*: string
+    codec*: PayloadCodec
     vec*: seq[float32]
 
   ClusterTxIntent* = object
@@ -131,6 +138,7 @@ type
     ringMeta*: Table[uint64, tuple[period, head: float]]
     ringNames*: Table[uint64, string]
     ringDescriptions*: Table[uint64, string]
+    ringPayloadProfiles*: Table[uint64, RingPayloadProfile]
     galaxy*: string
     galaxyDescription*: string
     clusterTx*: Table[uint64, ClusterTxIntent]
@@ -231,7 +239,7 @@ proc writeParticleRecord(file: File, tag: string, txid: uint64, p: Particle) =
   let prefix = if tag.len > 0: tag & " " & $txid & " " else: "P "
   file.write(prefix & $p.parent & " " & $p.seq & " " & $p.period & " " &
              $p.head & " " & $p.tWrite & " " & $p.payload.len & " " &
-             $p.vec.len & "\n")
+             $p.vec.len & " " & p.codec.payloadCodecName & "\n")
   file.write(p.payload)
   if p.vec.len > 0:
     file.writeVec(p.vec)
@@ -241,7 +249,8 @@ proc writeClusterTxOp(file: File, txid: uint64, op: ClusterTxOp) =
   let kind = if op.kind == ctxDelete: "D" else: "P"
   file.write("CP " & $txid & " " & kind & " " & $op.parent & " " & $op.seq & " " &
              $op.period & " " & $op.head & " " & $op.tWrite & " " &
-             $op.payload.len & " " & $op.vec.len & "\n")
+             $op.payload.len & " " & $op.vec.len & " " &
+             op.codec.payloadCodecName & "\n")
   file.write(op.payload)
   if op.vec.len > 0:
     file.writeVec(op.vec)
@@ -255,6 +264,10 @@ proc readParticleRecord(fs: FileStream, parts: seq[string], firstData: int): Par
                     tWrite: parseFloat(parts[firstData + 4]))
   let len = parseInt(parts[firstData + 5])
   let dim = if parts.len > firstData + 6: parseInt(parts[firstData + 6]) else: 0
+  result.codec = if parts.len > firstData + 7:
+                   parsePayloadCodec(parts[firstData + 7])
+                 else:
+                   pcRaw
   result.payload = fs.readExactStr(len)
   result.vec = fs.readVec(dim)
   fs.readRecordSep()
@@ -272,6 +285,10 @@ proc readClusterTxOp(fs: FileStream, parts: seq[string], firstData: int): Cluste
   result.tWrite = parseFloat(parts[data + 4])
   let len = parseInt(parts[data + 5])
   let dim = if parts.len > data + 6: parseInt(parts[data + 6]) else: 0
+  result.codec = if parts.len > data + 7:
+                   parsePayloadCodec(parts[data + 7])
+                 else:
+                   pcRaw
   result.payload = fs.readExactStr(len)
   result.vec = fs.readVec(dim)
   fs.readRecordSep()
@@ -374,6 +391,15 @@ proc replay(s: Store, path: string, repair = true) =
           s.ringDescriptions.del ringKey
         else:
           s.ringDescriptions[ringKey] = desc
+        fs.readRecordSep()
+      of "RP":
+        let ringKey = parseBiggestUInt(parts[1]).uint64
+        let len = parseInt(parts[2])
+        let profile = parseJson(fs.readExactStr(len))
+        s.ringPayloadProfiles[ringKey] = RingPayloadProfile(
+          defaultCodec: parsePayloadCodec(profile{"defaultCodec"}.getStr("raw")),
+          charset: profile{"charset"}.getStr(""),
+          formatVersion: profile{"formatVersion"}.getStr(""))
         fs.readRecordSep()
       of "P":
         let p = fs.readParticleRecord(parts, 1)
@@ -591,6 +617,15 @@ proc writeSnapshotFile(s: Store, path: string) =
         file.write("RD " & $ringKey & " " & $desc.len & "\n")
         file.write(desc)
         file.write("\n")
+    for ringKey, profile in s.ringPayloadProfiles:
+      let raw = $(%*{
+        "defaultCodec": profile.defaultCodec.payloadCodecName,
+        "charset": profile.charset,
+        "formatVersion": profile.formatVersion
+      })
+      file.write("RP " & $ringKey & " " & $raw.len & "\n")
+      file.write(raw)
+      file.write("\n")
     for ringKey, meta in s.ringMeta:
       file.write("R " & $ringKey & " " & $meta.period & " " & $meta.head & "\n")
     for _, p in s.items:
@@ -851,6 +886,20 @@ proc putRingDescription*(s: Store, ringKey: uint64, description: string) =
     s.logFile.write("\n")
     s.flushMaybe(force = true)
 
+proc putRingPayloadProfile*(s: Store, ringKey: uint64,
+                            profile: RingPayloadProfile) =
+  s.ringPayloadProfiles[ringKey] = profile
+  if s.persistent:
+    let raw = $(%*{
+      "defaultCodec": profile.defaultCodec.payloadCodecName,
+      "charset": profile.charset,
+      "formatVersion": profile.formatVersion
+    })
+    s.logFile.write("RP " & $ringKey & " " & $raw.len & "\n")
+    s.logFile.write(raw)
+    s.logFile.write("\n")
+    s.flushMaybe(force = true)
+
 proc putWarpJob*(s: Store, jobId: uint64, blob: string) =
   ## RocheDB layer が解釈する warp job snapshot を保存する。
   ## Store は WAL/compact/backup/restore だけを担当し、scheduler policy は持たない。
@@ -909,13 +958,7 @@ proc nextSeq*(s: Store, ring: uint64): uint32 =
 proc upsert*(s: Store, p: Particle) =
   s.applyOp(TxOp(kind: txUpsert, p: p))
   if s.persistent:
-    if p.vec.len == 0:
-      s.logFile.write("P " & $p.parent & " " & $p.seq & " " & $p.period & " " &
-                      $p.head & " " & $p.tWrite & " " & $p.payload.len & "\n")
-      s.logFile.write(p.payload)
-      s.logFile.write("\n")
-    else:
-      s.logFile.writeParticleRecord("", 0, p)
+    s.logFile.writeParticleRecord("", 0, p)
     s.flushMaybe()
 
 proc putForwarder*(s: Store, oldParent: uint64, oldSeq: uint32, f: Forwarder) =

--- a/src/roche/wire.nim
+++ b/src/roche/wire.nim
@@ -29,6 +29,8 @@
 ##   USTATUS\n
 ##       → USTATUS <pending> <appliedKeys> <appliedOps> <skippedOps> <errors> <forwarded> <lastOk> <lastError>
 ##   WIREVER\n                                                     → WIREVER <version>
+##   CODECS\n                                                      → CODECS raw json nif bif
+##   CODECMETA ON\n                                                → OK codec-metadata
 ##   APPLYTX <txid> <parent> <seq> <period> <head> <tWrite> <len> <vecDim>\n<payload><vec> → OK\n
 ##   RETRIEVE <hasRing> <ringKey> <budget> <vecDim>\n<vec>
 ##     → RHIT <scanned> <ringsTouched> <n>\n repeated: <parent> <seq> <tWrite> <score> <len>\n<payload>
@@ -36,7 +38,9 @@
 ##   STATS\n                                                   → OK <node> <count>\n
 
 import std/[net, strutils, tables]
-import ./auth
+import ./[auth, payload]
+
+export payload
 
 const
   WireProtocolVersion* = 1
@@ -64,6 +68,7 @@ type
     head*: float
     tWrite*: float
     payload*: string
+    codec*: PayloadCodec
     vec*: seq[float32]
 
   WireId* = object
@@ -78,6 +83,7 @@ type
     found*: bool
     node*: int
     value*: string
+    codec*: PayloadCodec
     deleted*: bool
     forwarded*: bool
     id*: WireId
@@ -88,6 +94,7 @@ type
     tWrite*: float
     score*: float
     payload*: string
+    codec*: PayloadCodec
 
   RetrieveWireResult* = object
     totalVectors*: int
@@ -108,6 +115,7 @@ type
     seq*: uint32
     tWrite*: float
     payload*: string
+    codec*: PayloadCodec
 
   WireListResult* = object
     items*: seq[WireListItem]
@@ -120,6 +128,7 @@ type
     password: string
     secretKey: string
     galaxy: string
+    codecMetadata: Table[int, bool]
 
   SecureState = object
     secretKey: string
@@ -301,6 +310,9 @@ proc socketFor(c: ClusterClient, node: int): Socket =
     result.sendFrame("HELLO " & c.galaxy)
     let r = result.readHeader()
     expect(r, "OK", "HELLO")
+  result.sendFrame("CODECMETA ON")
+  let codecReply = result.readHeader()
+  c.codecMetadata[node] = codecReply.len > 0 and codecReply[0] == "OK"
   c.socks[node] = result
 
 proc rpc(c: ClusterClient, node: int, header: string,
@@ -320,18 +332,19 @@ proc rpc(c: ClusterClient, node: int, header: string,
 
 proc putReq*(c: ClusterClient, node: int, ringKey: uint64,
              period, head: float, payload: string,
-             vec: seq[float32] = @[]): tuple[seq: uint32, tWrite: float] =
+             vec: seq[float32] = @[], codec = pcRaw): tuple[seq: uint32, tWrite: float] =
   let body = payload & vec.vecBytes
   let r = c.rpc(node, "PUT " & $ringKey & " " & $period & " " & $head & " " &
-                $payload.len & " " & $vec.len, body)
+                $payload.len & " " & $vec.len & " " & codec.payloadCodecName, body)
   expect(r, "OK", "PUT")
   (parseUInt(r[1]).uint32, parseFloat(r[2]))
 
 proc putRingReq*(c: ClusterClient, node: int, ring: string, payload: string,
-                 vec: seq[float32] = @[]): WireId =
+                 vec: seq[float32] = @[], codec = pcRaw): WireId =
   ## Named put for drivers. ringKey/period/head are server-side conventions.
   let body = ring & payload & vec.vecBytes
-  let r = c.rpc(node, "PUTR " & $ring.len & " " & $payload.len & " " & $vec.len,
+  let r = c.rpc(node, "PUTR " & $ring.len & " " & $payload.len & " " & $vec.len &
+                " " & codec.payloadCodecName,
                 body)
   expect(r, "ID", "PUTR")
   WireId(parent: parseBiggestUInt(r[1]).uint64,
@@ -359,7 +372,8 @@ proc getIdReq*(c: ClusterClient, node: int, id: WireId): WireGetResult =
                                     head: parseFloat(r[6])))
   expect(r, "VAL", "GETID")
   WireGetResult(found: true, node: parseInt(r[1]),
-                value: c.socks[node].readExact(parseInt(r[2])))
+                value: c.socks[node].readExact(parseInt(r[2])),
+                codec: if r.len >= 4: parsePayloadCodec(r[3]) else: pcRaw)
 
 proc queryIdReq*(c: ClusterClient, node: int, id: WireId,
                  selection: string): WireGetResult =
@@ -380,7 +394,7 @@ proc queryIdReq*(c: ClusterClient, node: int, id: WireId,
     raise newException(ValueError, "query: " & r[1 .. ^1].join(" "))
   expect(r, "VAL", "QRYID")
   WireGetResult(found: true, node: parseInt(r[1]),
-                value: c.socks[node].readExact(parseInt(r[2])))
+                value: c.socks[node].readExact(parseInt(r[2])), codec: pcJson)
 
 proc txGetIdReq*(c: ClusterClient, node: int, id: WireId,
                  selection: string = ""): WireGetResult =
@@ -399,20 +413,25 @@ proc txGetIdReq*(c: ClusterClient, node: int, id: WireId,
     raise newException(ValueError, "tx-get: " & r[1 .. ^1].join(" "))
   expect(r, "VAL", op)
   WireGetResult(found: true, node: parseInt(r[1]),
-                value: c.socks[node].readExact(parseInt(r[2])))
+                value: c.socks[node].readExact(parseInt(r[2])),
+                codec: if selection.len > 0: pcJson
+                       elif r.len >= 4: parsePayloadCodec(r[3])
+                       else: pcRaw)
 
 proc getReq*(c: ClusterClient, node: int, parent: uint64, seq: uint32,
              period, head, tWrite: float): tuple[found: bool, node: int, value: string,
+                                                  codec: PayloadCodec,
                                                   forwarded: bool, newParent: uint64,
                                                   newSeq: uint32, newTWrite: float] =
   let r = c.rpc(node, "GET " & $parent & " " & $seq & " " & $period & " " &
                 $head & " " & $tWrite)
-  if r[0] == "MISS": return (false, node, "", false, 0'u64, 0'u32, 0.0)
+  if r[0] == "MISS": return (false, node, "", pcRaw, false, 0'u64, 0'u32, 0.0)
   if r[0] == "FWD":
-    return (false, node, "", true, parseBiggestUInt(r[1]).uint64,
+    return (false, node, "", pcRaw, true, parseBiggestUInt(r[1]).uint64,
             parseUInt(r[2]).uint32, parseFloat(r[3]))
   expect(r, "VAL", "GET")
   (true, parseInt(r[1]), c.socks[node].readExact(parseInt(r[2])),
+   (if r.len >= 4: parsePayloadCodec(r[3]) else: pcRaw),
    false, 0'u64, 0'u32, 0.0)
 
 proc batchGetReq*(c: ClusterClient, node: int,
@@ -450,7 +469,8 @@ proc listRingReq*(c: ClusterClient, node: int, ringKey: uint64, limit: int,
     result.items.add WireListItem(parent: ringKey,
                                   seq: parseUInt(h[1]).uint32,
                                   tWrite: parseFloat(h[2]),
-                                  payload: payload)
+                                  payload: payload,
+                                  codec: if h.len >= 6: parsePayloadCodec(h[5]) else: pcRaw)
 
 proc countRingReq*(c: ClusterClient, node: int, ringKey: uint64): int =
   let r = c.rpc(node, "COUNTR " & $ringKey)
@@ -460,29 +480,32 @@ proc countRingReq*(c: ClusterClient, node: int, ringKey: uint64): int =
 proc queryReq*(c: ClusterClient, node: int, parent: uint64, seq: uint32,
                period, head, tWrite: float,
                selection: string): tuple[found: bool, node: int, value: string,
+                                          codec: PayloadCodec,
                                           forwarded: bool, newParent: uint64,
                                           newSeq: uint32, newTWrite: float] =
   let r = c.rpc(node, "QRY " & $parent & " " & $seq & " " & $period & " " &
                 $head & " " & $tWrite & " " & $selection.len, selection)
-  if r[0] == "MISS": return (false, node, "", false, 0'u64, 0'u32, 0.0)
+  if r[0] == "MISS": return (false, node, "", pcJson, false, 0'u64, 0'u32, 0.0)
   if r[0] == "FWD":
-    return (false, node, "", true, parseBiggestUInt(r[1]).uint64,
+    return (false, node, "", pcJson, true, parseBiggestUInt(r[1]).uint64,
             parseUInt(r[2]).uint32, parseFloat(r[3]))
   if r[0] == "ERR":
     raise newException(ValueError, "query: " & r[1 .. ^1].join(" "))
   expect(r, "VAL", "QRY")
-  (true, parseInt(r[1]), c.socks[node].readExact(parseInt(r[2])),
+  (true, parseInt(r[1]), c.socks[node].readExact(parseInt(r[2])), pcJson,
    false, 0'u64, 0'u32, 0.0)
 
 proc transferReq*(c: ClusterClient, node: int, parent: uint64, seq: uint32,
                   period, head, tWrite: float, payload: string,
                   vec: seq[float32] = @[],
+                  codec = pcRaw,
                   timeoutMs = 10_000) =
   ## Inter-node handoff. roched is single-threaded, so callers should pass a
   ## short timeoutMs to avoid long blocking during mutual transfer.
   let body = payload & vec.vecBytes
   let r = c.rpc(node, "TRF " & $parent & " " & $seq & " " & $period & " " &
-                $head & " " & $tWrite & " " & $payload.len & " " & $vec.len, body,
+                $head & " " & $tWrite & " " & $payload.len & " " & $vec.len &
+                " " & codec.payloadCodecName, body,
                 timeoutMs = timeoutMs)
   expect(r, "OK", "TRF")
 
@@ -503,7 +526,7 @@ proc txCommitReq*(c: ClusterClient, node: int, txid: uint64, ops: seq[TxWireOp])
   for op in ops:
     body.add((if op.delete: "D " else: "P ") & $op.parent & " " & $op.seq & " " & $op.period & " " &
              $op.head & " " & $op.tWrite & " " & $op.payload.len & " " &
-             $op.vec.len & "\n")
+             $op.vec.len & " " & op.codec.payloadCodecName & "\n")
     body.add(op.payload)
     body.add(op.vec.vecBytes)
     body.add("\n")
@@ -544,7 +567,8 @@ proc applyTxReq*(c: ClusterClient, node: int, txid: uint64, op: TxWireOp,
   let kind = if op.delete: "D" else: "P"
   let r = c.rpc(node, "APPLYTX " & $txid & " " & kind & " " & $op.parent & " " & $op.seq & " " &
                 $op.period & " " & $op.head & " " & $op.tWrite & " " &
-                $op.payload.len & " " & $op.vec.len, body, timeoutMs = timeoutMs)
+                $op.payload.len & " " & $op.vec.len & " " &
+                op.codec.payloadCodecName, body, timeoutMs = timeoutMs)
   expect(r, "OK", "APPLYTX")
 
 proc retrieveReq*(c: ClusterClient, node: int, hasRing: bool, ringKey: uint64,
@@ -568,7 +592,8 @@ proc retrieveReq*(c: ClusterClient, node: int, hasRing: bool, ringKey: uint64,
                                     seq: parseUInt(h[2]).uint32,
                                     tWrite: parseFloat(h[3]),
                                     score: parseFloat(h[4]),
-                                    payload: c.socks[node].readExact(parseInt(h[5])))
+                                    payload: c.socks[node].readExact(parseInt(h[5])),
+                                    codec: if h.len >= 7: parsePayloadCodec(h[6]) else: pcRaw)
   result.skippedVectors = max(0, result.totalVectors - result.scanned)
   if result.payloadBytes == 0:
     for h in result.hits:
@@ -606,6 +631,12 @@ proc wireVersionReq*(c: ClusterClient, node: int): int =
   let r = c.rpc(node, "WIREVER")
   expect(r, "WIREVER", "WIREVER")
   parseInt(r[1])
+
+proc codecsReq*(c: ClusterClient, node: int): seq[PayloadCodec] =
+  let r = c.rpc(node, "CODECS")
+  expect(r, "CODECS", "CODECS")
+  for i in 1 ..< r.len:
+    result.add parsePayloadCodec(r[i])
 
 proc shutdownReq*(c: ClusterClient, node: int): string =
   let r = c.rpc(node, "SHUTDOWN")

--- a/src/rochecli.nim
+++ b/src/rochecli.nim
@@ -2,7 +2,7 @@
 ##
 ## usage:
 ##   roche put [--data=DIR | --peers=host:port,...] --ring=RING [--payload=TEXT | --in=FILE] [--codec=raw|json|nif|bif]
-##   roche get [--data=DIR | --peers=host:port,...] --ring=RING [--filter='{"id":"RAW_ID"}'] [--selection=SEL] [--order=write-desc]
+##   roche get [--data=DIR | --peers=host:port,...] --ring=RING [--filter='{"id":"RAW_ID"}'] [--selection=SEL] [--sort=id|time] [--rsort=id|time]
 ##   roche query [--data=DIR | --peers=host:port,...] --ring=RING [--filter='{"id":"RAW_ID"}' | --id=RAW_ID] --selection=SEL
 ##   roche list-ring [--data=DIR | --peers=host:port,...] --ring=RING [--limit=N] [--cursor=CURSOR]
 ##   roche count-ring [--data=DIR | --peers=host:port,...] --ring=RING
@@ -325,38 +325,26 @@ proc resolveIdArg(idArg, filterArg: string): string =
   else:
     idFromFilter(filterArg)
 
-proc filterHasOnlyId(filterNode: JsonNode): bool =
-  filterNode.kind == JObject and filterNode.len == 1 and filterNode.hasKey("id")
+proc filterWithId(filterNode: JsonNode, idArg: string): JsonNode =
+  if filterNode.isNil:
+    result = newJObject()
+  else:
+    result = filterNode.copy()
+  if idArg.len == 0:
+    return
+  if result.hasKey("id") and result["id"].getStr() != idArg:
+    raise newException(ValueError, "--id and --filter.id must refer to the same record")
+  result["id"] = %idArg
 
-proc recordMatchesFilter(item: RocheRecord, filterNode: JsonNode): bool =
-  if filterNode.kind != JObject or filterNode.len == 0:
-    return true
-  if filterNode.hasKey("id") and
-      filterNode["id"].getStr() notin [$item.id, item.id.cliIdString()]:
-    return false
-  for key, expected in filterNode:
-    if key == "id":
-      continue
-    if not item.codec.supportsJsonProjection:
-      return false
-    try:
-      let doc = parseJson(item.payload)
-      if doc.kind != JObject or not doc.hasKey(key) or doc[key] != expected:
-        return false
-    except JsonParsingError:
-      return false
-  true
+proc sortDirectionName(direction: RocheReadSortDirection): string =
+  case direction
+  of rsAsc: "asc"
+  of rsDesc: "desc"
 
-proc recordPayloadNode(item: RocheRecord, selection: string): JsonNode =
-  if item.codec.supportsJsonProjection:
-    try:
-      let doc = parseJson(item.payload)
-      if selection.len > 0:
-        return applySelection(prepareSelection(selection), doc)
-      return doc
-    except JsonParsingError:
-      discard
-  %item.payload
+proc paginationName(mode: RochePaginationMode): string =
+  case mode
+  of rpOff: "off"
+  of rpOn: "on"
 
 proc checkFile(path, label: string): bool =
   result = fileExists(path)
@@ -638,110 +626,96 @@ proc tryDecodeBifWithAdapter(data: string): tuple[ok: bool, text: string] =
     except OSError:
       discard
 
-proc renderPayload(value: EncodedPayload, view: string): string =
-  case view.toLowerAscii()
-  of "raw": value.data
-  of "auto":
-    if value.codec == pcBif:
-      let decoded = tryDecodeBifWithAdapter(value.data)
-      if decoded.ok:
-        "codec=bif encoding=nif adapter=nif\n" & decoded.text
-      else:
-        "codec=bif encoding=base64\n" & base64.encode(value.data)
-    elif value.codec.supportsJsonProjection:
-      try:
-        parseJson(value.data).pretty
-      except JsonParsingError:
-        "codec=" & value.codec.payloadCodecName & " encoding=text\n" & value.data
-    else:
-      "codec=" & value.codec.payloadCodecName & " encoding=text\n" & value.data
+proc recordPayloadDisplay(item: RocheRecord, view: string): JsonNode =
+  let mode = view.toLowerAscii()
+  case mode
+  of "raw":
+    %*{"encoding": "raw", "payload": item.payload}
   of "base64":
-    "codec=" & value.codec.payloadCodecName & " encoding=base64\n" &
-      base64.encode(value.data)
+    %*{"encoding": "base64", "payload": base64.encode(item.payload)}
   of "hex":
-    "codec=" & value.codec.payloadCodecName & " encoding=hex\n" & hexPayload(value.data)
+    %*{"encoding": "hex", "payload": hexPayload(item.payload)}
+  of "auto":
+    if item.codec == pcBif:
+      let decoded = tryDecodeBifWithAdapter(item.payload)
+      if decoded.ok:
+        return %*{"encoding": "nif", "adapter": "nif", "payload": decoded.text}
+      return %*{"encoding": "base64", "payload": base64.encode(item.payload)}
+    if item.codec.supportsJsonProjection:
+      try:
+        return %*{"encoding": "json", "payload": parseJson(item.payload)}
+      except JsonParsingError:
+        discard
+    %*{"encoding": "text", "payload": item.payload}
   else:
     raise newException(ValueError, "get view must be raw, auto, base64, or hex")
 
-proc compareRecords(a, b: RocheRecord, order: string): int =
-  let ar = a.id.toRaw()
-  let br = b.id.toRaw()
-  case order
-  of "id-asc":
-    cmp(a.id.cliIdString(), b.id.cliIdString())
-  of "id-desc":
-    -cmp(a.id.cliIdString(), b.id.cliIdString())
-  of "write-asc":
-    cmp(ar.tWrite, br.tWrite)
-  of "write-desc", "":
-    -cmp(ar.tWrite, br.tWrite)
-  else:
-    raise newException(ValueError,
-      "order must be write-desc, write-asc, id-asc, or id-desc")
-
-proc renderListPage(db: RocheDb, ring, cursor: string, limit: int,
-                    filterNode: JsonNode, selection, order: string): JsonNode =
-  var matched: seq[RocheRecord] = @[]
-  var nextCursor = cursor
-  let pageSize = max(limit, 100)
-  while matched.len < limit:
-    let page = db.listByRing(ring, limit = pageSize, cursor = nextCursor)
-    for item in page.items:
-      if recordMatchesFilter(item, filterNode):
-        matched.add item
-        if matched.len >= limit:
-          break
-    nextCursor = page.nextCursor
-    if nextCursor.len == 0 or page.items.len == 0:
-      break
-  matched.sort(proc(a, b: RocheRecord): int = compareRecords(a, b, order))
-
+proc readPageNode(page: RocheReadPage, view: string): JsonNode =
   var items = newJArray()
-  for item in matched:
-    items.add %*{
+  for item in page.items:
+    let display = recordPayloadDisplay(item, view)
+    var node = %*{
       "id": $item.id,
       "rawId": item.id.cliIdString(),
       "codec": item.codec.payloadCodecName,
-      "payload": recordPayloadNode(item, selection)
+      "encoding": display["encoding"].getStr(),
+      "payload": display["payload"]
     }
+    if display.hasKey("adapter"):
+      node["adapter"] = display["adapter"]
+    items.add node
   %*{
-    "ring": ring,
-    "count": db.countByRing(ring),
-    "order": if order.len == 0: "write-desc" else: order,
+    "ring": page.ring,
+    "count": page.count,
+    "pagination": page.pagination.paginationName,
+    "page": page.page,
+    "pageLimit": page.pageLimit,
+    "sort": page.sortField,
+    "sortDirection": page.sortDirection.sortDirectionName,
     "items": items,
-    "nextCursor": nextCursor
+    "nextCursor": page.nextCursor
   }
+
+proc readSortOptions(sortArg, rsortArg: string): tuple[field: string, direction: RocheReadSortDirection] =
+  if sortArg.len > 0 and rsortArg.len > 0:
+    raise newException(ValueError, "--sort and --rsort cannot be used together")
+  if sortArg.len > 0:
+    return (sortArg, rsAsc)
+  if rsortArg.len > 0:
+    return (rsortArg, rsDesc)
+  ("time", rsDesc)
+
+proc readPaginationMode(value: string): RochePaginationMode =
+  case value.toLowerAscii()
+  of "off", "false", "0", "no": rpOff
+  of "on", "true", "1", "yes": rpOn
+  else:
+    raise newException(ValueError, "pagination must be on or off")
 
 proc runGet(dataDir, peers, username, password, authToken, secretKey,
             galaxy, idArg, filterArg, ring, view, selection, cursor: string,
-            limit: int, order: string) =
+            limit, page, pageLimit: int, paginationArg, sortArg, rsortArg: string) =
   let actualDataDir = requireCliTarget(dataDir, peers)
   let filterNode = parseFilter(filterArg)
   let resolvedId = resolveIdArg(idArg, filterArg)
+  let sortOptions = readSortOptions(sortArg, rsortArg)
   if ring.len == 0:
     raise newException(ValueError, "get requires --ring=RING")
   var db = openCliDb(actualDataDir, peers, username, password, authToken, secretKey,
                      galaxy)
   try:
     db.configureRing(ring, 60.0)
-    if resolvedId.len > 0 and filterHasOnlyId(filterNode):
-      if selection.len > 0:
-        echo db.query(cliId(resolvedId), selection).pretty
-      else:
-        echo renderPayload(db.getEncoded(cliId(resolvedId)), view)
-    elif resolvedId.len > 0:
-      let id = cliId(resolvedId)
-      let item = RocheRecord(id: id,
-        payload: db.getEncoded(id).data,
-        codec: db.getEncoded(id).codec)
-      if not recordMatchesFilter(item, filterNode):
-        echo pretty(%*{"ring": ring, "count": 0, "items": newJArray(), "nextCursor": ""})
-      elif selection.len > 0:
-        echo recordPayloadNode(item, selection).pretty
-      else:
-        echo renderPayload(encodedPayload(item.payload, item.codec), view)
-    else:
-      echo renderListPage(db, ring, cursor, limit, filterNode, selection, order).pretty
+    let options = RocheReadOptions(
+      filter: filterWithId(filterNode, resolvedId),
+      selection: selection,
+      limit: limit,
+      cursor: cursor,
+      pagination: readPaginationMode(paginationArg),
+      page: page,
+      pageLimit: pageLimit,
+      sortField: sortOptions.field,
+      sortDirection: sortOptions.direction)
+    echo db.readRing(ring, options).readPageNode(view).pretty
   finally:
     db.close()
 
@@ -2025,7 +1999,7 @@ proc printHelp() =
   echo ""
   echo "Usage:"
   echo "  roche put [--data=DIR | --peers=host:port,...] --ring=RING [--payload=TEXT | --in=FILE] [--codec=auto|raw|json|nif|bif]"
-  echo "  roche get [--data=DIR | --peers=host:port,...] --ring=RING [--filter='{\"id\":\"RAW_ID\"}'] [--selection=SEL] [--limit=N] [--cursor=CURSOR] [--order=write-desc|write-asc|id-asc|id-desc]"
+  echo "  roche get [--data=DIR | --peers=host:port,...] --ring=RING [--filter='{\"id\":\"RAW_ID\"}'] [--selection=SEL] [--limit=N] [--cursor=CURSOR] [--sort=id|time] [--rsort=id|time] [--pagination=on|off] [--page=N] [--pagelimit=N]"
   echo "  roche query [--data=DIR | --peers=host:port,...] --ring=RING [--filter='{\"id\":\"RAW_ID\"}' | --id=RAW_ID] --selection=SEL"
   echo "  roche list-ring [--data=DIR | --peers=host:port,...] --ring=RING [--limit=N] [--cursor=CURSOR]"
   echo "  roche count-ring [--data=DIR | --peers=host:port,...] --ring=RING"
@@ -2071,7 +2045,9 @@ proc main() =
   var idArg = ""
   var whereArg = ""
   var filterArg = ""
-  var order = "write-desc"
+  var sortArg = ""
+  var rsortArg = "time"
+  var paginationArg = "off"
   var selection = ""
   var cursor = ""
   var defaultRing = "imported"
@@ -2113,6 +2089,8 @@ proc main() =
   var help = false
   var executeDriverInstall = false
   var limit = 100
+  var page = 1
+  var pageLimit = 20
   var positionals: seq[string] = @[]
   for kind, key, val in getopt():
     case kind
@@ -2141,7 +2119,25 @@ proc main() =
       of "id": idArg = val
       of "where": whereArg = val
       of "filter": filterArg = val
-      of "order": order = val
+      of "sort":
+        sortArg = val
+        if rsortArg == "time": rsortArg = ""
+      of "rsort": rsortArg = val
+      of "order":
+        case val
+        of "id-asc":
+          sortArg = "id"; rsortArg = ""
+        of "id-desc":
+          sortArg = ""; rsortArg = "id"
+        of "write-asc", "time-asc":
+          sortArg = "time"; rsortArg = ""
+        of "write-desc", "time-desc":
+          sortArg = ""; rsortArg = "time"
+        else:
+          raise newException(ValueError, "order must be id-asc, id-desc, write-asc, or write-desc")
+      of "pagination": paginationArg = val
+      of "page": page = parseInt(val)
+      of "pagelimit", "page-limit": pageLimit = parseInt(val)
       of "select": selection = val
       of "selection": selection = val
       of "cursor": cursor = val
@@ -2196,7 +2192,8 @@ proc main() =
   of "get":
     let readFilter = effectiveFilter(filterArg, whereArg)
     runGet(dataDir, peers, username, password, authToken, secretKey, galaxy,
-           idArg, readFilter, ringName, view, selection, cursor, limit, order)
+           idArg, readFilter, ringName, view, selection, cursor, limit,
+           page, pageLimit, paginationArg, sortArg, rsortArg)
   of "query":
     let readFilter = effectiveFilter(filterArg, whereArg)
     runQuery(dataDir, peers, username, password, authToken, secretKey, galaxy,

--- a/src/rochecli.nim
+++ b/src/rochecli.nim
@@ -2,7 +2,7 @@
 ##
 ## usage:
 ##   roche put [--data=DIR | --peers=host:port,...] --ring=RING [--payload=TEXT | --in=FILE] [--codec=raw|json|nif|bif]
-##   roche get [--data=DIR | --peers=host:port,...] --ring=RING [--filter='{"id":"RAW_ID"}'] [--selection=SEL]
+##   roche get [--data=DIR | --peers=host:port,...] --ring=RING [--filter='{"id":"RAW_ID"}'] [--selection=SEL] [--order=write-desc]
 ##   roche query [--data=DIR | --peers=host:port,...] --ring=RING [--filter='{"id":"RAW_ID"}' | --id=RAW_ID] --selection=SEL
 ##   roche list-ring [--data=DIR | --peers=host:port,...] --ring=RING [--limit=N] [--cursor=CURSOR]
 ##   roche count-ring [--data=DIR | --peers=host:port,...] --ring=RING
@@ -663,36 +663,58 @@ proc renderPayload(value: EncodedPayload, view: string): string =
   else:
     raise newException(ValueError, "get view must be raw, auto, base64, or hex")
 
+proc compareRecords(a, b: RocheRecord, order: string): int =
+  let ar = a.id.toRaw()
+  let br = b.id.toRaw()
+  case order
+  of "id-asc":
+    cmp(a.id.cliIdString(), b.id.cliIdString())
+  of "id-desc":
+    -cmp(a.id.cliIdString(), b.id.cliIdString())
+  of "write-asc":
+    cmp(ar.tWrite, br.tWrite)
+  of "write-desc", "":
+    -cmp(ar.tWrite, br.tWrite)
+  else:
+    raise newException(ValueError,
+      "order must be write-desc, write-asc, id-asc, or id-desc")
+
 proc renderListPage(db: RocheDb, ring, cursor: string, limit: int,
-                    filterNode: JsonNode, selection: string): JsonNode =
-  var items = newJArray()
+                    filterNode: JsonNode, selection, order: string): JsonNode =
+  var matched: seq[RocheRecord] = @[]
   var nextCursor = cursor
   let pageSize = max(limit, 100)
-  while items.len < limit:
+  while matched.len < limit:
     let page = db.listByRing(ring, limit = pageSize, cursor = nextCursor)
     for item in page.items:
       if recordMatchesFilter(item, filterNode):
-        items.add %*{
-          "id": $item.id,
-          "rawId": item.id.cliIdString(),
-          "codec": item.codec.payloadCodecName,
-          "payload": recordPayloadNode(item, selection)
-        }
-        if items.len >= limit:
+        matched.add item
+        if matched.len >= limit:
           break
     nextCursor = page.nextCursor
     if nextCursor.len == 0 or page.items.len == 0:
       break
+  matched.sort(proc(a, b: RocheRecord): int = compareRecords(a, b, order))
+
+  var items = newJArray()
+  for item in matched:
+    items.add %*{
+      "id": $item.id,
+      "rawId": item.id.cliIdString(),
+      "codec": item.codec.payloadCodecName,
+      "payload": recordPayloadNode(item, selection)
+    }
   %*{
     "ring": ring,
     "count": db.countByRing(ring),
+    "order": if order.len == 0: "write-desc" else: order,
     "items": items,
     "nextCursor": nextCursor
   }
 
 proc runGet(dataDir, peers, username, password, authToken, secretKey,
             galaxy, idArg, filterArg, ring, view, selection, cursor: string,
-            limit: int) =
+            limit: int, order: string) =
   let actualDataDir = requireCliTarget(dataDir, peers)
   let filterNode = parseFilter(filterArg)
   let resolvedId = resolveIdArg(idArg, filterArg)
@@ -719,20 +741,7 @@ proc runGet(dataDir, peers, username, password, authToken, secretKey,
       else:
         echo renderPayload(encodedPayload(item.payload, item.codec), view)
     else:
-      let page = renderListPage(db, ring, cursor, limit, filterNode, selection)
-      if filterNode.len == 0 and cursor.len == 0 and page["count"].getInt() == 1 and
-          page["items"].len == 1:
-        let item = page["items"][0]
-        if selection.len > 0:
-          echo item["payload"].pretty
-        else:
-          let codec = parsePayloadCodec(item["codec"].getStr())
-          if item["payload"].kind == JString:
-            echo renderPayload(encodedPayload(item["payload"].getStr(), codec), view)
-          else:
-            echo item["payload"].pretty
-      else:
-        echo page.pretty
+      echo renderListPage(db, ring, cursor, limit, filterNode, selection, order).pretty
   finally:
     db.close()
 
@@ -2016,7 +2025,7 @@ proc printHelp() =
   echo ""
   echo "Usage:"
   echo "  roche put [--data=DIR | --peers=host:port,...] --ring=RING [--payload=TEXT | --in=FILE] [--codec=auto|raw|json|nif|bif]"
-  echo "  roche get [--data=DIR | --peers=host:port,...] --ring=RING [--filter='{\"id\":\"RAW_ID\"}'] [--selection=SEL] [--limit=N] [--cursor=CURSOR]"
+  echo "  roche get [--data=DIR | --peers=host:port,...] --ring=RING [--filter='{\"id\":\"RAW_ID\"}'] [--selection=SEL] [--limit=N] [--cursor=CURSOR] [--order=write-desc|write-asc|id-asc|id-desc]"
   echo "  roche query [--data=DIR | --peers=host:port,...] --ring=RING [--filter='{\"id\":\"RAW_ID\"}' | --id=RAW_ID] --selection=SEL"
   echo "  roche list-ring [--data=DIR | --peers=host:port,...] --ring=RING [--limit=N] [--cursor=CURSOR]"
   echo "  roche count-ring [--data=DIR | --peers=host:port,...] --ring=RING"
@@ -2062,6 +2071,7 @@ proc main() =
   var idArg = ""
   var whereArg = ""
   var filterArg = ""
+  var order = "write-desc"
   var selection = ""
   var cursor = ""
   var defaultRing = "imported"
@@ -2131,6 +2141,7 @@ proc main() =
       of "id": idArg = val
       of "where": whereArg = val
       of "filter": filterArg = val
+      of "order": order = val
       of "select": selection = val
       of "selection": selection = val
       of "cursor": cursor = val
@@ -2185,7 +2196,7 @@ proc main() =
   of "get":
     let readFilter = effectiveFilter(filterArg, whereArg)
     runGet(dataDir, peers, username, password, authToken, secretKey, galaxy,
-           idArg, readFilter, ringName, view, selection, cursor, limit)
+           idArg, readFilter, ringName, view, selection, cursor, limit, order)
   of "query":
     let readFilter = effectiveFilter(filterArg, whereArg)
     runQuery(dataDir, peers, username, password, authToken, secretKey, galaxy,

--- a/src/rochecli.nim
+++ b/src/rochecli.nim
@@ -13,7 +13,7 @@
 ##   roche doctor
 
 import std/[algorithm, base64, os, osproc, strutils, strformat, json, times, monotimes,
-            parseopt, net, dynlib]
+            parseopt, net, dynlib, tempfiles]
 import nimsodium/hash
 import rochedb
 import roche/wire
@@ -513,12 +513,63 @@ proc hexPayload(data: string): string =
     result.add Hex[value shr 4]
     result.add Hex[value and 0x0f]
 
+proc findNifAdapterTool(): string =
+  let configured = getEnv("ROCHEDB_NIF_TOOL")
+  if configured.len > 0:
+    let resolved = findExe(configured)
+    if resolved.len > 0:
+      return resolved
+    if fileExists(configured):
+      return configured
+    return configured
+
+  for candidate in ["rochedb-nif", "nif_file_tool"]:
+    let resolved = findExe(candidate)
+    if resolved.len > 0:
+      return resolved
+
+proc tryDecodeBifWithAdapter(data: string): tuple[ok: bool, text: string] =
+  let tool = findNifAdapterTool()
+  if tool.len == 0:
+    return (false, "")
+
+  let (inputFile, inputPath) = createTempFile("rochedb-bif-", ".bif", getTempDir())
+  let (outputFile, outputPath) = createTempFile("rochedb-nif-", ".nif", getTempDir())
+  inputFile.write(data)
+  inputFile.close()
+  outputFile.close()
+
+  try:
+    let process = startProcess(tool,
+      args = @["decode", "--in=" & inputPath, "--out=" & outputPath],
+      options = {poUsePath})
+    let code = process.waitForExit()
+    process.close()
+    if code == 0 and fileExists(outputPath):
+      return (true, readFile(outputPath))
+    return (false, "")
+  except OSError:
+    return (false, "")
+  finally:
+    try:
+      removeFile(inputPath)
+    except OSError:
+      discard
+    try:
+      removeFile(outputPath)
+    except OSError:
+      discard
+
 proc renderPayload(value: EncodedPayload, view: string): string =
   case view.toLowerAscii()
   of "raw": value.data
   of "auto":
     if value.codec == pcBif:
-      "codec=bif encoding=base64\n" & base64.encode(value.data)
+      let decoded = tryDecodeBifWithAdapter(value.data)
+      if decoded.ok:
+        "codec=bif encoding=nif adapter=nif\n" & decoded.text
+      else:
+        "codec=bif encoding=base64\n" & base64.encode(value.data)
     else:
       "codec=" & value.codec.payloadCodecName & " encoding=text\n" & value.data
   of "base64":

--- a/src/rochecli.nim
+++ b/src/rochecli.nim
@@ -2,8 +2,8 @@
 ##
 ## usage:
 ##   roche put [--data=DIR | --peers=host:port,...] --ring=RING [--payload=TEXT | --in=FILE] [--codec=raw|json|nif|bif]
-##   roche get [--data=DIR | --peers=host:port,...] --id=ID [--ring=RING]
-##   roche query [--data=DIR | --peers=host:port,...] --id=ID --selection=SEL [--ring=RING]
+##   roche get [--data=DIR | --peers=host:port,...] --ring=RING [--where='{"id":"RAW_ID"}' | --id=RAW_ID]
+##   roche query [--data=DIR | --peers=host:port,...] --ring=RING [--where='{"id":"RAW_ID"}' | --id=RAW_ID] --selection=SEL
 ##   roche list-ring [--data=DIR | --peers=host:port,...] --ring=RING [--limit=N] [--cursor=CURSOR]
 ##   roche count-ring [--data=DIR | --peers=host:port,...] --ring=RING
 ##   roche health --peers=host:port,...
@@ -248,9 +248,23 @@ proc openCliDb(dataDir, peers, username, password, authToken, secretKey,
   else:
     open(dataDir = dataDir)
 
-proc requireCliTarget(dataDir, peers: string) =
-  if dataDir.len == 0 and peers.len == 0:
-    raise newException(ValueError, "requires --data=DIR or --peers=host:port,...")
+proc defaultDataDir(): string =
+  let envData = getEnv("ROCHE_DATA")
+  if envData.len > 0:
+    envData
+  else:
+    "data"
+
+proc resolveDataDir(dataDir, peers: string): string =
+  if peers.len > 0:
+    dataDir
+  elif dataDir.len > 0:
+    dataDir
+  else:
+    defaultDataDir()
+
+proc requireCliTarget(dataDir, peers: string): string =
+  resolveDataDir(dataDir, peers)
 
 proc cliPayload(payload, inPath: string): string =
   if payload.len > 0:
@@ -275,6 +289,28 @@ proc cliId(idArg: string): RocheId =
                    parseFloat(parts[3]))
   raise newException(ValueError,
     "--id must be parent:seq or parent:epoch:seq:tWrite")
+
+proc idFromWhere(whereArg: string): string =
+  if whereArg.len == 0:
+    return ""
+  try:
+    let node = parseJson(whereArg)
+    if node.kind != JObject or not node.hasKey("id"):
+      raise newException(ValueError, "where must be a JSON object containing id")
+    result = node["id"].getStr()
+    if result.len == 0:
+      raise newException(ValueError, "where.id must not be empty")
+  except JsonParsingError as e:
+    raise newException(ValueError, "invalid --where JSON: " & e.msg)
+
+proc resolveIdArg(idArg, whereArg: string): string =
+  if idArg.len > 0:
+    idArg
+  else:
+    let fromWhere = idFromWhere(whereArg)
+    if fromWhere.len == 0:
+      raise newException(ValueError, "requires --where='{\"id\":\"RAW_ID\"}' or --id=RAW_ID")
+    fromWhere
 
 proc cliIdString(id: RocheId): string =
   let raw = id.toRaw()
@@ -489,10 +525,10 @@ proc runAtlas(dataDir, peers, username, password, authToken, secretKey,
 
 proc runPut(dataDir, peers, username, password, authToken, secretKey,
             galaxy, ring, payload, inPath, codecName: string) =
-  requireCliTarget(dataDir, peers)
+  let actualDataDir = requireCliTarget(dataDir, peers)
   if ring.len == 0:
     raise newException(ValueError, "put requires --ring=RING")
-  var db = openCliDb(dataDir, peers, username, password, authToken, secretKey,
+  var db = openCliDb(actualDataDir, peers, username, password, authToken, secretKey,
                      galaxy)
   try:
     let codec =
@@ -581,41 +617,43 @@ proc renderPayload(value: EncodedPayload, view: string): string =
     raise newException(ValueError, "get view must be raw, auto, base64, or hex")
 
 proc runGet(dataDir, peers, username, password, authToken, secretKey,
-            galaxy, idArg, ring, view: string) =
-  requireCliTarget(dataDir, peers)
+            galaxy, idArg, whereArg, ring, view: string) =
+  let actualDataDir = requireCliTarget(dataDir, peers)
+  let resolvedId = resolveIdArg(idArg, whereArg)
   if peers.len > 0 and ring.len == 0:
     raise newException(ValueError, "cluster get requires --ring=RING")
-  var db = openCliDb(dataDir, peers, username, password, authToken, secretKey,
+  var db = openCliDb(actualDataDir, peers, username, password, authToken, secretKey,
                      galaxy)
   try:
     if ring.len > 0:
       db.configureRing(ring, 60.0)
-    echo renderPayload(db.getEncoded(cliId(idArg)), view)
+    echo renderPayload(db.getEncoded(cliId(resolvedId)), view)
   finally:
     db.close()
 
 proc runQuery(dataDir, peers, username, password, authToken, secretKey,
-              galaxy, idArg, ring, selection: string) =
-  requireCliTarget(dataDir, peers)
+              galaxy, idArg, whereArg, ring, selection: string) =
+  let actualDataDir = requireCliTarget(dataDir, peers)
+  let resolvedId = resolveIdArg(idArg, whereArg)
   if selection.len == 0:
     raise newException(ValueError, "query requires --selection=SEL")
   if peers.len > 0 and ring.len == 0:
     raise newException(ValueError, "cluster query requires --ring=RING")
-  var db = openCliDb(dataDir, peers, username, password, authToken, secretKey,
+  var db = openCliDb(actualDataDir, peers, username, password, authToken, secretKey,
                      galaxy)
   try:
     if ring.len > 0:
       db.configureRing(ring, 60.0)
-    echo db.query(cliId(idArg), selection).pretty
+    echo db.query(cliId(resolvedId), selection).pretty
   finally:
     db.close()
 
 proc runListRing(dataDir, peers, username, password, authToken, secretKey,
                  galaxy, ring, cursor: string, limit: int) =
-  requireCliTarget(dataDir, peers)
+  let actualDataDir = requireCliTarget(dataDir, peers)
   if ring.len == 0:
     raise newException(ValueError, "list-ring requires --ring=RING")
-  var db = openCliDb(dataDir, peers, username, password, authToken, secretKey,
+  var db = openCliDb(actualDataDir, peers, username, password, authToken, secretKey,
                      galaxy)
   try:
     let page = db.listByRing(ring, limit = limit, cursor = cursor)
@@ -633,13 +671,13 @@ proc runListRing(dataDir, peers, username, password, authToken, secretKey,
 
 proc runRingProfile(dataDir, peers, username, password, authToken, secretKey,
                     galaxy, ring, codecName, charset, formatVersion: string) =
-  requireCliTarget(dataDir, peers)
+  let actualDataDir = requireCliTarget(dataDir, peers)
   if ring.len == 0:
     raise newException(ValueError, "ring-profile requires --ring=RING")
   if peers.len > 0:
     raise newException(ValueError,
       "ring-profile is currently configured through the embedded store; remote profile administration is not available yet")
-  var db = openCliDb(dataDir, peers, username, password, authToken, secretKey,
+  var db = openCliDb(actualDataDir, peers, username, password, authToken, secretKey,
                      galaxy)
   try:
     if codecName.toLowerAscii() != "auto" or charset.len > 0 or formatVersion.len > 0:
@@ -661,10 +699,10 @@ proc runRingProfile(dataDir, peers, username, password, authToken, secretKey,
 
 proc runCountRing(dataDir, peers, username, password, authToken, secretKey,
                   galaxy, ring: string) =
-  requireCliTarget(dataDir, peers)
+  let actualDataDir = requireCliTarget(dataDir, peers)
   if ring.len == 0:
     raise newException(ValueError, "count-ring requires --ring=RING")
-  var db = openCliDb(dataDir, peers, username, password, authToken, secretKey,
+  var db = openCliDb(actualDataDir, peers, username, password, authToken, secretKey,
                      galaxy)
   try:
     echo &"count-ring OK ring={ring} count={db.countByRing(ring)}"
@@ -705,8 +743,8 @@ proc printShellHelp() =
 
 proc runShell(dataDir, peers, username, password, authToken, secretKey,
               galaxy: string) =
-  requireCliTarget(dataDir, peers)
-  var db = openCliDb(dataDir, peers, username, password, authToken, secretKey,
+  let actualDataDir = requireCliTarget(dataDir, peers)
+  var db = openCliDb(actualDataDir, peers, username, password, authToken, secretKey,
                      galaxy)
   try:
     echo "RocheDB shell. Type help or exit."
@@ -1873,8 +1911,8 @@ proc printHelp() =
   echo ""
   echo "Usage:"
   echo "  roche put [--data=DIR | --peers=host:port,...] --ring=RING [--payload=TEXT | --in=FILE] [--codec=auto|raw|json|nif|bif]"
-  echo "  roche get [--data=DIR | --peers=host:port,...] --id=ID [--ring=RING] [--view=raw|auto|base64|hex]"
-  echo "  roche query [--data=DIR | --peers=host:port,...] --id=ID --selection=SEL [--ring=RING]"
+  echo "  roche get [--data=DIR | --peers=host:port,...] --ring=RING [--where='{\"id\":\"RAW_ID\"}' | --id=RAW_ID] [--view=raw|auto|base64|hex]"
+  echo "  roche query [--data=DIR | --peers=host:port,...] --ring=RING [--where='{\"id\":\"RAW_ID\"}' | --id=RAW_ID] --selection=SEL"
   echo "  roche list-ring [--data=DIR | --peers=host:port,...] --ring=RING [--limit=N] [--cursor=CURSOR]"
   echo "  roche count-ring [--data=DIR | --peers=host:port,...] --ring=RING"
   echo "  roche ring-profile --data=DIR --ring=RING [--codec=raw|json|nif|bif] [--charset=UTF-8] [--format-version=VERSION]"
@@ -1896,6 +1934,9 @@ proc printHelp() =
   echo "  parent:seq"
   echo "  parent:epoch:seq:tWrite"
   echo ""
+  echo "Local commands use --data=DIR, ROCHE_DATA, or ./data by default."
+  echo "Cluster commands use --peers=host:port,..."
+  echo "Get uses --view=auto by default; payload codec is inferred from stored metadata."
   echo "Cluster get/query requires --ring=RING so the CLI can reconstruct ring placement metadata."
 
 proc main() =
@@ -1911,8 +1952,9 @@ proc main() =
   var codecName = "auto"
   var charset = ""
   var formatVersion = ""
-  var view = "raw"
+  var view = "auto"
   var idArg = ""
+  var whereArg = ""
   var selection = ""
   var cursor = ""
   var defaultRing = "imported"
@@ -1980,6 +2022,7 @@ proc main() =
       of "format-version": formatVersion = val
       of "view": view = val
       of "id": idArg = val
+      of "where": whereArg = val
       of "selection": selection = val
       of "cursor": cursor = val
       of "default-ring": defaultRing = val
@@ -2032,10 +2075,10 @@ proc main() =
            ringName, payload, inPath, codecName)
   of "get":
     runGet(dataDir, peers, username, password, authToken, secretKey, galaxy,
-           idArg, ringName, view)
+           idArg, whereArg, ringName, view)
   of "query":
     runQuery(dataDir, peers, username, password, authToken, secretKey, galaxy,
-             idArg, ringName, selection)
+             idArg, whereArg, ringName, selection)
   of "list-ring":
     runListRing(dataDir, peers, username, password, authToken, secretKey,
                 galaxy, ringName, cursor, limit)

--- a/src/rochecli.nim
+++ b/src/rochecli.nim
@@ -1,7 +1,7 @@
 ## roche - RocheDB command-line client
 ##
 ## usage:
-##   roche put [--data=DIR | --peers=host:port,...] --ring=RING [--payload=TEXT | --in=FILE]
+##   roche put [--data=DIR | --peers=host:port,...] --ring=RING [--payload=TEXT | --in=FILE] [--codec=raw|json|nif|bif]
 ##   roche get [--data=DIR | --peers=host:port,...] --id=ID [--ring=RING]
 ##   roche query [--data=DIR | --peers=host:port,...] --id=ID --selection=SEL [--ring=RING]
 ##   roche list-ring [--data=DIR | --peers=host:port,...] --ring=RING [--limit=N] [--cursor=CURSOR]
@@ -12,7 +12,7 @@
 ##   roche driver list|info|install [LANG] [--manifest-path=FILE] [--execute]
 ##   roche doctor
 
-import std/[algorithm, os, osproc, strutils, strformat, json, times, monotimes,
+import std/[algorithm, base64, os, osproc, strutils, strformat, json, times, monotimes,
             parseopt, net, dynlib]
 import nimsodium/hash
 import rochedb
@@ -488,20 +488,49 @@ proc runAtlas(dataDir, peers, username, password, authToken, secretKey,
   db.close()
 
 proc runPut(dataDir, peers, username, password, authToken, secretKey,
-            galaxy, ring, payload, inPath: string) =
+            galaxy, ring, payload, inPath, codecName: string) =
   requireCliTarget(dataDir, peers)
   if ring.len == 0:
     raise newException(ValueError, "put requires --ring=RING")
   var db = openCliDb(dataDir, peers, username, password, authToken, secretKey,
                      galaxy)
   try:
-    let id = db.put(cliPayload(payload, inPath), ring = ring)
-    echo &"put OK id={id} rawId={cliIdString(id)} ring={ring}"
+    let codec =
+      if codecName.toLowerAscii() == "auto":
+        db.ringPayloadProfile(ring).defaultCodec
+      else:
+        parsePayloadCodec(codecName)
+    let id = db.put(encodedPayload(cliPayload(payload, inPath), codec), ring = ring)
+    echo &"put OK id={id} rawId={cliIdString(id)} ring={ring} codec={codec.payloadCodecName}"
   finally:
     db.close()
 
+proc hexPayload(data: string): string =
+  const Hex = "0123456789abcdef"
+  result = newStringOfCap(data.len * 2)
+  for c in data:
+    let value = ord(c)
+    result.add Hex[value shr 4]
+    result.add Hex[value and 0x0f]
+
+proc renderPayload(value: EncodedPayload, view: string): string =
+  case view.toLowerAscii()
+  of "raw": value.data
+  of "auto":
+    if value.codec == pcBif:
+      "codec=bif encoding=base64\n" & base64.encode(value.data)
+    else:
+      "codec=" & value.codec.payloadCodecName & " encoding=text\n" & value.data
+  of "base64":
+    "codec=" & value.codec.payloadCodecName & " encoding=base64\n" &
+      base64.encode(value.data)
+  of "hex":
+    "codec=" & value.codec.payloadCodecName & " encoding=hex\n" & hexPayload(value.data)
+  else:
+    raise newException(ValueError, "get view must be raw, auto, base64, or hex")
+
 proc runGet(dataDir, peers, username, password, authToken, secretKey,
-            galaxy, idArg, ring: string) =
+            galaxy, idArg, ring, view: string) =
   requireCliTarget(dataDir, peers)
   if peers.len > 0 and ring.len == 0:
     raise newException(ValueError, "cluster get requires --ring=RING")
@@ -510,7 +539,7 @@ proc runGet(dataDir, peers, username, password, authToken, secretKey,
   try:
     if ring.len > 0:
       db.configureRing(ring, 60.0)
-    echo db.get(cliId(idArg))
+    echo renderPayload(db.getEncoded(cliId(idArg)), view)
   finally:
     db.close()
 
@@ -544,9 +573,38 @@ proc runListRing(dataDir, peers, username, password, authToken, secretKey,
       items.add %*{
         "id": $item.id,
         "rawId": item.id.cliIdString(),
-        "payload": item.payload
+        "payload": item.payload,
+        "codec": item.codec.payloadCodecName
       }
     echo pretty(%*{"items": items, "nextCursor": page.nextCursor})
+  finally:
+    db.close()
+
+proc runRingProfile(dataDir, peers, username, password, authToken, secretKey,
+                    galaxy, ring, codecName, charset, formatVersion: string) =
+  requireCliTarget(dataDir, peers)
+  if ring.len == 0:
+    raise newException(ValueError, "ring-profile requires --ring=RING")
+  if peers.len > 0:
+    raise newException(ValueError,
+      "ring-profile is currently configured through the embedded store; remote profile administration is not available yet")
+  var db = openCliDb(dataDir, peers, username, password, authToken, secretKey,
+                     galaxy)
+  try:
+    if codecName.toLowerAscii() != "auto" or charset.len > 0 or formatVersion.len > 0:
+      let old = db.ringPayloadProfile(ring)
+      let profile = RingPayloadProfile(
+        defaultCodec: if codecName.toLowerAscii() == "auto": old.defaultCodec else: parsePayloadCodec(codecName),
+        charset: if charset.len == 0: old.charset else: charset,
+        formatVersion: if formatVersion.len == 0: old.formatVersion else: formatVersion)
+      db.configureRingPayloadProfile(ring, profile)
+    let profile = db.ringPayloadProfile(ring)
+    echo (%*{
+      "ring": ring,
+      "defaultCodec": profile.defaultCodec.payloadCodecName,
+      "charset": profile.charset,
+      "formatVersion": profile.formatVersion
+    }).pretty
   finally:
     db.close()
 
@@ -1763,11 +1821,12 @@ proc printHelp() =
   echo "RocheDB command-line client"
   echo ""
   echo "Usage:"
-  echo "  roche put [--data=DIR | --peers=host:port,...] --ring=RING [--payload=TEXT | --in=FILE]"
-  echo "  roche get [--data=DIR | --peers=host:port,...] --id=ID [--ring=RING]"
+  echo "  roche put [--data=DIR | --peers=host:port,...] --ring=RING [--payload=TEXT | --in=FILE] [--codec=auto|raw|json|nif|bif]"
+  echo "  roche get [--data=DIR | --peers=host:port,...] --id=ID [--ring=RING] [--view=raw|auto|base64|hex]"
   echo "  roche query [--data=DIR | --peers=host:port,...] --id=ID --selection=SEL [--ring=RING]"
   echo "  roche list-ring [--data=DIR | --peers=host:port,...] --ring=RING [--limit=N] [--cursor=CURSOR]"
   echo "  roche count-ring [--data=DIR | --peers=host:port,...] --ring=RING"
+  echo "  roche ring-profile --data=DIR --ring=RING [--codec=raw|json|nif|bif] [--charset=UTF-8] [--format-version=VERSION]"
   echo "  roche shell [--data=DIR | --peers=host:port,...]"
   echo "  roche atlas [--data=DIR | --peers=host:port,...]"
   echo "  roche health|metrics|rings --peers=host:port,..."
@@ -1798,6 +1857,10 @@ proc main() =
   var outPath = ""
   var inPath = ""
   var payload = ""
+  var codecName = "auto"
+  var charset = ""
+  var formatVersion = ""
+  var view = "raw"
   var idArg = ""
   var selection = ""
   var cursor = ""
@@ -1861,6 +1924,10 @@ proc main() =
       of "out": outPath = val
       of "in": inPath = val
       of "payload": payload = val
+      of "codec": codecName = val
+      of "charset": charset = val
+      of "format-version": formatVersion = val
+      of "view": view = val
       of "id": idArg = val
       of "selection": selection = val
       of "cursor": cursor = val
@@ -1911,10 +1978,10 @@ proc main() =
   case cmd
   of "put":
     runPut(dataDir, peers, username, password, authToken, secretKey, galaxy,
-           ringName, payload, inPath)
+           ringName, payload, inPath, codecName)
   of "get":
     runGet(dataDir, peers, username, password, authToken, secretKey, galaxy,
-           idArg, ringName)
+           idArg, ringName, view)
   of "query":
     runQuery(dataDir, peers, username, password, authToken, secretKey, galaxy,
              idArg, ringName, selection)
@@ -1924,6 +1991,9 @@ proc main() =
   of "count-ring":
     runCountRing(dataDir, peers, username, password, authToken, secretKey,
                  galaxy, ringName)
+  of "ring-profile":
+    runRingProfile(dataDir, peers, username, password, authToken, secretKey,
+                   galaxy, ringName, codecName, charset, formatVersion)
   of "shell":
     runShell(dataDir, peers, username, password, authToken, secretKey, galaxy)
   of "demo": runDemo(peers, username, password, authToken, secretKey, galaxy)

--- a/src/rochecli.nim
+++ b/src/rochecli.nim
@@ -2,8 +2,8 @@
 ##
 ## usage:
 ##   roche put [--data=DIR | --peers=host:port,...] --ring=RING [--payload=TEXT | --in=FILE] [--codec=raw|json|nif|bif]
-##   roche get [--data=DIR | --peers=host:port,...] --ring=RING [--where='{"id":"RAW_ID"}' | --id=RAW_ID]
-##   roche query [--data=DIR | --peers=host:port,...] --ring=RING [--where='{"id":"RAW_ID"}' | --id=RAW_ID] --selection=SEL
+##   roche get [--data=DIR | --peers=host:port,...] --ring=RING [--filter='{"id":"RAW_ID"}'] [--selection=SEL]
+##   roche query [--data=DIR | --peers=host:port,...] --ring=RING [--filter='{"id":"RAW_ID"}' | --id=RAW_ID] --selection=SEL
 ##   roche list-ring [--data=DIR | --peers=host:port,...] --ring=RING [--limit=N] [--cursor=CURSOR]
 ##   roche count-ring [--data=DIR | --peers=host:port,...] --ring=RING
 ##   roche health --peers=host:port,...
@@ -290,31 +290,73 @@ proc cliId(idArg: string): RocheId =
   raise newException(ValueError,
     "--id must be parent:seq or parent:epoch:seq:tWrite")
 
-proc idFromWhere(whereArg: string): string =
-  if whereArg.len == 0:
-    return ""
-  try:
-    let node = parseJson(whereArg)
-    if node.kind != JObject or not node.hasKey("id"):
-      raise newException(ValueError, "where must be a JSON object containing id")
-    result = node["id"].getStr()
-    if result.len == 0:
-      raise newException(ValueError, "where.id must not be empty")
-  except JsonParsingError as e:
-    raise newException(ValueError, "invalid --where JSON: " & e.msg)
-
-proc resolveIdArg(idArg, whereArg: string): string =
-  if idArg.len > 0:
-    idArg
-  else:
-    let fromWhere = idFromWhere(whereArg)
-    if fromWhere.len == 0:
-      raise newException(ValueError, "requires --where='{\"id\":\"RAW_ID\"}' or --id=RAW_ID")
-    fromWhere
-
 proc cliIdString(id: RocheId): string =
   let raw = id.toRaw()
   $raw.parent & ":" & $raw.epoch & ":" & $raw.seq & ":" & $raw.tWrite
+
+proc effectiveFilter(filterArg, whereArg: string): string =
+  if filterArg.len > 0:
+    filterArg
+  else:
+    whereArg
+
+proc parseFilter(filterArg: string): JsonNode =
+  if filterArg.len == 0:
+    return newJObject()
+  try:
+    result = parseJson(filterArg)
+    if result.kind != JObject:
+      raise newException(ValueError, "filter must be a JSON object")
+  except JsonParsingError as e:
+    raise newException(ValueError, "invalid --filter JSON: " & e.msg)
+
+proc idFromFilter(filterArg: string): string =
+  if filterArg.len == 0:
+    return ""
+  let node = parseFilter(filterArg)
+  if node.hasKey("id"):
+    result = node["id"].getStr()
+    if result.len == 0:
+      raise newException(ValueError, "filter.id must not be empty")
+
+proc resolveIdArg(idArg, filterArg: string): string =
+  if idArg.len > 0:
+    idArg
+  else:
+    idFromFilter(filterArg)
+
+proc filterHasOnlyId(filterNode: JsonNode): bool =
+  filterNode.kind == JObject and filterNode.len == 1 and filterNode.hasKey("id")
+
+proc recordMatchesFilter(item: RocheRecord, filterNode: JsonNode): bool =
+  if filterNode.kind != JObject or filterNode.len == 0:
+    return true
+  if filterNode.hasKey("id") and
+      filterNode["id"].getStr() notin [$item.id, item.id.cliIdString()]:
+    return false
+  for key, expected in filterNode:
+    if key == "id":
+      continue
+    if not item.codec.supportsJsonProjection:
+      return false
+    try:
+      let doc = parseJson(item.payload)
+      if doc.kind != JObject or not doc.hasKey(key) or doc[key] != expected:
+        return false
+    except JsonParsingError:
+      return false
+  true
+
+proc recordPayloadNode(item: RocheRecord, selection: string): JsonNode =
+  if item.codec.supportsJsonProjection:
+    try:
+      let doc = parseJson(item.payload)
+      if selection.len > 0:
+        return applySelection(prepareSelection(selection), doc)
+      return doc
+    except JsonParsingError:
+      discard
+  %item.payload
 
 proc checkFile(path, label: string): bool =
   result = fileExists(path)
@@ -606,6 +648,11 @@ proc renderPayload(value: EncodedPayload, view: string): string =
         "codec=bif encoding=nif adapter=nif\n" & decoded.text
       else:
         "codec=bif encoding=base64\n" & base64.encode(value.data)
+    elif value.codec.supportsJsonProjection:
+      try:
+        parseJson(value.data).pretty
+      except JsonParsingError:
+        "codec=" & value.codec.payloadCodecName & " encoding=text\n" & value.data
     else:
       "codec=" & value.codec.payloadCodecName & " encoding=text\n" & value.data
   of "base64":
@@ -616,18 +663,76 @@ proc renderPayload(value: EncodedPayload, view: string): string =
   else:
     raise newException(ValueError, "get view must be raw, auto, base64, or hex")
 
+proc renderListPage(db: RocheDb, ring, cursor: string, limit: int,
+                    filterNode: JsonNode, selection: string): JsonNode =
+  var items = newJArray()
+  var nextCursor = cursor
+  let pageSize = max(limit, 100)
+  while items.len < limit:
+    let page = db.listByRing(ring, limit = pageSize, cursor = nextCursor)
+    for item in page.items:
+      if recordMatchesFilter(item, filterNode):
+        items.add %*{
+          "id": $item.id,
+          "rawId": item.id.cliIdString(),
+          "codec": item.codec.payloadCodecName,
+          "payload": recordPayloadNode(item, selection)
+        }
+        if items.len >= limit:
+          break
+    nextCursor = page.nextCursor
+    if nextCursor.len == 0 or page.items.len == 0:
+      break
+  %*{
+    "ring": ring,
+    "count": db.countByRing(ring),
+    "items": items,
+    "nextCursor": nextCursor
+  }
+
 proc runGet(dataDir, peers, username, password, authToken, secretKey,
-            galaxy, idArg, whereArg, ring, view: string) =
+            galaxy, idArg, filterArg, ring, view, selection, cursor: string,
+            limit: int) =
   let actualDataDir = requireCliTarget(dataDir, peers)
-  let resolvedId = resolveIdArg(idArg, whereArg)
-  if peers.len > 0 and ring.len == 0:
-    raise newException(ValueError, "cluster get requires --ring=RING")
+  let filterNode = parseFilter(filterArg)
+  let resolvedId = resolveIdArg(idArg, filterArg)
+  if ring.len == 0:
+    raise newException(ValueError, "get requires --ring=RING")
   var db = openCliDb(actualDataDir, peers, username, password, authToken, secretKey,
                      galaxy)
   try:
-    if ring.len > 0:
-      db.configureRing(ring, 60.0)
-    echo renderPayload(db.getEncoded(cliId(resolvedId)), view)
+    db.configureRing(ring, 60.0)
+    if resolvedId.len > 0 and filterHasOnlyId(filterNode):
+      if selection.len > 0:
+        echo db.query(cliId(resolvedId), selection).pretty
+      else:
+        echo renderPayload(db.getEncoded(cliId(resolvedId)), view)
+    elif resolvedId.len > 0:
+      let id = cliId(resolvedId)
+      let item = RocheRecord(id: id,
+        payload: db.getEncoded(id).data,
+        codec: db.getEncoded(id).codec)
+      if not recordMatchesFilter(item, filterNode):
+        echo pretty(%*{"ring": ring, "count": 0, "items": newJArray(), "nextCursor": ""})
+      elif selection.len > 0:
+        echo recordPayloadNode(item, selection).pretty
+      else:
+        echo renderPayload(encodedPayload(item.payload, item.codec), view)
+    else:
+      let page = renderListPage(db, ring, cursor, limit, filterNode, selection)
+      if filterNode.len == 0 and cursor.len == 0 and page["count"].getInt() == 1 and
+          page["items"].len == 1:
+        let item = page["items"][0]
+        if selection.len > 0:
+          echo item["payload"].pretty
+        else:
+          let codec = parsePayloadCodec(item["codec"].getStr())
+          if item["payload"].kind == JString:
+            echo renderPayload(encodedPayload(item["payload"].getStr(), codec), view)
+          else:
+            echo item["payload"].pretty
+      else:
+        echo page.pretty
   finally:
     db.close()
 
@@ -1911,8 +2016,8 @@ proc printHelp() =
   echo ""
   echo "Usage:"
   echo "  roche put [--data=DIR | --peers=host:port,...] --ring=RING [--payload=TEXT | --in=FILE] [--codec=auto|raw|json|nif|bif]"
-  echo "  roche get [--data=DIR | --peers=host:port,...] --ring=RING [--where='{\"id\":\"RAW_ID\"}' | --id=RAW_ID] [--view=raw|auto|base64|hex]"
-  echo "  roche query [--data=DIR | --peers=host:port,...] --ring=RING [--where='{\"id\":\"RAW_ID\"}' | --id=RAW_ID] --selection=SEL"
+  echo "  roche get [--data=DIR | --peers=host:port,...] --ring=RING [--filter='{\"id\":\"RAW_ID\"}'] [--selection=SEL] [--limit=N] [--cursor=CURSOR]"
+  echo "  roche query [--data=DIR | --peers=host:port,...] --ring=RING [--filter='{\"id\":\"RAW_ID\"}' | --id=RAW_ID] --selection=SEL"
   echo "  roche list-ring [--data=DIR | --peers=host:port,...] --ring=RING [--limit=N] [--cursor=CURSOR]"
   echo "  roche count-ring [--data=DIR | --peers=host:port,...] --ring=RING"
   echo "  roche ring-profile --data=DIR --ring=RING [--codec=raw|json|nif|bif] [--charset=UTF-8] [--format-version=VERSION]"
@@ -1937,6 +2042,7 @@ proc printHelp() =
   echo "Local commands use --data=DIR, ROCHE_DATA, or ./data by default."
   echo "Cluster commands use --peers=host:port,..."
   echo "Get uses --view=auto by default; payload codec is inferred from stored metadata."
+  echo "--where is accepted as an alias for --filter. --id is a low-level shortcut for scripts."
   echo "Cluster get/query requires --ring=RING so the CLI can reconstruct ring placement metadata."
 
 proc main() =
@@ -1955,6 +2061,7 @@ proc main() =
   var view = "auto"
   var idArg = ""
   var whereArg = ""
+  var filterArg = ""
   var selection = ""
   var cursor = ""
   var defaultRing = "imported"
@@ -2023,6 +2130,8 @@ proc main() =
       of "view": view = val
       of "id": idArg = val
       of "where": whereArg = val
+      of "filter": filterArg = val
+      of "select": selection = val
       of "selection": selection = val
       of "cursor": cursor = val
       of "default-ring": defaultRing = val
@@ -2074,11 +2183,13 @@ proc main() =
     runPut(dataDir, peers, username, password, authToken, secretKey, galaxy,
            ringName, payload, inPath, codecName)
   of "get":
+    let readFilter = effectiveFilter(filterArg, whereArg)
     runGet(dataDir, peers, username, password, authToken, secretKey, galaxy,
-           idArg, whereArg, ringName, view)
+           idArg, readFilter, ringName, view, selection, cursor, limit)
   of "query":
+    let readFilter = effectiveFilter(filterArg, whereArg)
     runQuery(dataDir, peers, username, password, authToken, secretKey, galaxy,
-             idArg, whereArg, ringName, selection)
+             idArg, readFilter, ringName, selection)
   of "list-ring":
     runListRing(dataDir, peers, username, password, authToken, secretKey,
                 galaxy, ringName, cursor, limit)

--- a/src/roched.nim
+++ b/src/roched.nim
@@ -17,6 +17,7 @@ const
   TickMs = 100      # ハンドオフ判定の周期
   DefaultSlowTickSec = 10.0
   MaxTransfersPerTick = 256   # 一括移動時も select ループを塞がない上限
+  MaxPreparedSelections = 1024
   DefaultPeriod = 60.0
   MaxWireBodyBytes = 64 * 1024 * 1024
   MaxWireVectorDim = MaxWireBodyBytes div sizeof(float32)
@@ -61,6 +62,8 @@ type
     universeApplyForwarded: uint64
     universeApplyLastOk: float
     universeApplyLastError: float
+    preparedSelections: Table[string, Selection]
+    codecMetadata: Table[int, bool]
 
 type LocalHit = object
   parent: uint64
@@ -68,6 +71,27 @@ type LocalHit = object
   tWrite: float
   score: float
   payload: string
+  codec: PayloadCodec
+
+proc compiledSelection(sv: Server, source: string): Selection =
+  if source in sv.preparedSelections:
+    return sv.preparedSelections[source]
+  result = parseSelection(source)
+  if sv.preparedSelections.len < MaxPreparedSelections:
+    sv.preparedSelections[source] = result
+
+proc projectPayload(sv: Server, payload: string, codec: PayloadCodec,
+                    selection: string): string =
+  if not codec.supportsJsonProjection:
+    raise newException(ValueError,
+      "payload codec " & codec.payloadCodecName & " does not support JSON projection")
+  $applySelection(sv.compiledSelection(selection), parseJson(payload))
+
+proc codecSuffix(sv: Server, sock: Socket, codec: PayloadCodec): string =
+  if sv.codecMetadata.getOrDefault(sock.getFd.int, false):
+    " " & codec.payloadCodecName
+  else:
+    ""
 
 proc orbitOf(p: Particle): Orbit =
   OrbitalId(parent: p.parent, epoch: 1, tWrite: p.tWrite, seq: p.seq)
@@ -245,13 +269,14 @@ proc applyUniverseEvent(sv: Server, event: JsonNode, now: float): bool =
   if sv.st.isUniverseSyncEventApplied(eventKey):
     return false
   let payload = event{"payload"}.getStr()
+  let codec = parsePayloadCodec(event{"codec"}.getStr("raw"))
   let vec = jsonFloat32Seq(event{"vec"}).normalize()
   let ri = sv.ringInfo(ringName)
   let seq = sv.st.nextSeq(ri.key)
   let tWrite = event{"timestamp"}.getFloat(now)
   sv.st.upsert Particle(parent: ri.key, seq: seq, period: ri.period,
                         head: ri.head, tWrite: tWrite, payload: payload,
-                        vec: vec, lastHere: now)
+                        codec: codec, vec: vec, lastHere: now)
   if ri.key != HaloKey:
     sv.fs.observeRingPut(ri.key, vec)
   sv.st.markUniverseSyncEventApplied(eventKey)
@@ -284,7 +309,7 @@ proc handoffTick(sv: Server) =
         if not p.sentAhead:
           try:
             sv.peerLink.transferReq(nextNode, p.parent, p.seq, p.period, p.head,
-                                    p.tWrite, p.payload, p.vec, timeoutMs = 500)
+                                    p.tWrite, p.payload, p.vec, p.codec, timeoutMs = 500)
             p.sentAhead = true
             dec budget
           except CatchableError:
@@ -295,7 +320,7 @@ proc handoffTick(sv: Server) =
       if not p.sentAhead:
         try:
           sv.peerLink.transferReq(ownNow, p.parent, p.seq, p.period, p.head,
-                                  p.tWrite, p.payload, p.vec, timeoutMs = 500)
+                                  p.tWrite, p.payload, p.vec, p.codec, timeoutMs = 500)
           p.sentAhead = true
           dec budget
         except CatchableError:
@@ -339,7 +364,7 @@ proc handleRetrieve(sv: Server, sock: Socket, parts: seq[string]) =
       rings[p.parent] = true
       hits.add LocalHit(parent: p.parent, seq: p.seq, tWrite: p.tWrite,
                         score: 1.0 - cosineDistance(q, p.vec),
-                        payload: p.payload)
+                        payload: p.payload, codec: p.codec)
     hits.sort(proc(a, b: LocalHit): int = cmp(b.score, a.score))
     if hits.len > budget:
       hits.setLen(budget)
@@ -351,7 +376,8 @@ proc handleRetrieve(sv: Server, sock: Socket, parts: seq[string]) =
                  " " & $totalVectors & " " & $payloadBytes)
   for h in hits:
     sock.sendFrame("HIT " & $h.parent & " " & $h.seq & " " & $h.tWrite & " " &
-                   $h.score & " " & $h.payload.len, h.payload)
+                   $h.score & " " & $h.payload.len & sv.codecSuffix(sock, h.codec),
+                   h.payload)
 
 proc applyClusterTxTick(sv: Server) =
   ## node0 が landing zone。commit intent は全 op の apply ACK まで残す。
@@ -371,7 +397,7 @@ proc applyClusterTxTick(sv: Server) =
           TxWireOp(delete: op.kind == ctxDelete,
                    parent: op.parent, seq: op.seq, period: op.period,
                    head: op.head, tWrite: op.tWrite,
-                   payload: op.payload, vec: op.vec),
+                   payload: op.payload, codec: op.codec, vec: op.vec),
           timeoutMs = 500)
       except CatchableError:
         allApplied = false
@@ -476,6 +502,7 @@ proc handleFrame(sv: Server, sock: Socket): bool =
                            tWrite: parseFloat(h[data + 4]))
       let payloadLen = parseInt(h[data + 5])
       let vecDim = parseInt(h[data + 6])
+      op.codec = if h.len > data + 7: parsePayloadCodec(h[data + 7]) else: pcRaw
       let bodyBytes = checkedFrameBytes(payloadLen, vecDim, extra = 1)
       if not sv.ringKeyAllowed(sock, op.parent):
         sock.drainBytes(bodyBytes)
@@ -543,6 +570,14 @@ proc handleFrame(sv: Server, sock: Socket): bool =
                    $(int(sv.universeApplyLastError)))
   of "WIREVER":
     sock.sendFrame("WIREVER " & $WireProtocolVersion)
+  of "CODECS":
+    sock.sendFrame("CODECS raw json nif bif")
+  of "CODECMETA":
+    if parts.len != 2 or parts[1] != "ON":
+      sock.sendFrame("ERR CODECMETA requires ON")
+    else:
+      sv.codecMetadata[sock.getFd.int] = true
+      sock.sendFrame("OK codec-metadata")
   of "APPLYTX":
     if not sv.requireRole(sock, roleWriter):
       return false
@@ -553,6 +588,7 @@ proc handleFrame(sv: Server, sock: Socket): bool =
     let seq = parseUInt(parts[data + 1]).uint32
     let payloadLen = parseInt(parts[data + 5])
     let vecDim = parseInt(parts[data + 6])
+    let codec = if parts.len > data + 7: parsePayloadCodec(parts[data + 7]) else: pcRaw
     let bodyBytes = checkedFrameBytes(payloadLen, vecDim)
     if not sv.ringKeyAllowed(sock, parent):
       sock.drainBytes(bodyBytes)
@@ -566,6 +602,7 @@ proc handleFrame(sv: Server, sock: Socket): bool =
                      period: parseFloat(parts[data + 2]),
                      head: parseFloat(parts[data + 3]),
                      tWrite: parseFloat(parts[data + 4]),
+                     codec: codec,
                      lastHere: now)
     p.payload = sock.readExact(payloadLen)
     p.vec = sock.readExact(checkedVecBytes(vecDim)).bytesVec(vecDim).normalize()
@@ -616,11 +653,12 @@ proc handleFrame(sv: Server, sock: Socket): bool =
       var value = best.payload
       if parts[0] == "TXQRYID":
         try:
-          value = $applySelection(parseSelection(selection), parseJson(value))
+          value = sv.projectPayload(value, best.codec, selection)
         except ValueError, JsonParsingError:
           sock.sendFrame("ERR " & getCurrentExceptionMsg().replace("\n", " "))
           return true
-      sock.sendFrame("VAL 0 " & $value.len, value)
+      let codec = if parts[0] == "TXQRYID": pcJson else: best.codec
+      sock.sendFrame("VAL 0 " & $value.len & sv.codecSuffix(sock, codec), value)
       return true
     sock.sendFrame("MISS")
   of "RETRIEVE":
@@ -648,6 +686,7 @@ proc handleFrame(sv: Server, sock: Socket): bool =
     let ringLen = parseInt(parts[1])
     let payloadLen = parseInt(parts[2])
     let vecDim = if parts.len >= 4: parseInt(parts[3]) else: 0
+    let codec = if parts.len >= 5: parsePayloadCodec(parts[4]) else: pcRaw
     discard checkedWireLen(ringLen, "ringLen")
     let bodyBytes = checkedFrameBytes(payloadLen, vecDim)
     let ringName = sock.readExact(ringLen)
@@ -660,14 +699,14 @@ proc handleFrame(sv: Server, sock: Socket): bool =
     let ri = sv.ringInfo(ringName)
     let owner = int(sv.tbl.owner(ri.head))
     if owner != sv.myId:
-      let id = sv.peerLink.putRingReq(owner, ringName, payload, vec)
+      let id = sv.peerLink.putRingReq(owner, ringName, payload, vec, codec)
       sock.sendFrame("ID " & $id.parent & " " & $id.epoch & " " & $id.seq & " " &
                      $id.tWrite & " " & $id.period & " " & $id.head)
     else:
       let seq = sv.st.nextSeq(ri.key)
       sv.st.upsert Particle(parent: ri.key, seq: seq, period: ri.period,
                             head: ri.head, tWrite: now, payload: payload,
-                            vec: vec, lastHere: now)
+                            codec: codec, vec: vec, lastHere: now)
       if ri.key != HaloKey:
         sv.fs.observeRingPut(ri.key, vec)
       sock.sendFrame("ID " & $ri.key & " 1 " & $seq & " " & $now & " " &
@@ -680,6 +719,7 @@ proc handleFrame(sv: Server, sock: Socket): bool =
     let head = parseFloat(parts[3])
     let payloadLen = parseInt(parts[4])
     let vecDim = if parts.len >= 6: parseInt(parts[5]) else: 0
+    let codec = if parts.len >= 7: parsePayloadCodec(parts[6]) else: pcRaw
     let bodyBytes = checkedFrameBytes(payloadLen, vecDim)
     if not sv.ringKeyAllowed(sock, ringKey):
       sock.drainBytes(bodyBytes)
@@ -691,7 +731,8 @@ proc handleFrame(sv: Server, sock: Socket): bool =
     if ringKey notin sv.st.ringMeta:
       sv.st.putRingMeta(ringKey, period, head)
     sv.st.upsert Particle(parent: ringKey, seq: seq, period: period, head: head,
-                          tWrite: now, payload: payload, vec: vec, lastHere: now)
+                          tWrite: now, payload: payload, codec: codec,
+                          vec: vec, lastHere: now)
     if ringKey != HaloKey:
       sv.fs.observeRingPut(ringKey, vec)
     sock.sendFrame("OK " & $seq & " " & $now)
@@ -728,7 +769,7 @@ proc handleFrame(sv: Server, sock: Socket): bool =
     sock.sendFrame("LVAL " & $rows.len & " " & nextCursor)
     for p in rows:
       sock.sendFrame("ITEM " & $p.seq & " " & $p.tWrite & " " & $p.parent & " " &
-                     $p.payload.len, p.payload)
+                     $p.payload.len & sv.codecSuffix(sock, p.codec), p.payload)
   of "GETID", "QRYID":
     let parent = parseBiggestUInt(parts[1]).uint64
     let epoch = parseUInt(parts[2]).uint32
@@ -758,7 +799,8 @@ proc handleFrame(sv: Server, sock: Socket): bool =
         sock.sendFrame("FWD " & $r.newParent & " " & $epoch & " " & $r.newSeq & " " &
                        $r.newTWrite & " " & $period & " " & $head)
       elif r.found:
-        sock.sendFrame("VAL " & $r.node & " " & $r.value.len, r.value)
+        sock.sendFrame("VAL " & $r.node & " " & $r.value.len &
+                       sv.codecSuffix(sock, r.codec), r.value)
       else:
         sock.sendFrame("MISS")
       return true
@@ -771,14 +813,18 @@ proc handleFrame(sv: Server, sock: Socket): bool =
       else:
         sock.sendFrame("MISS")
     else:
-      var value = sv.st.items[(parent, seq)].payload
+      let item = sv.st.items[(parent, seq)]
+      var value = item.payload
+      var codec = item.codec
       if parts[0] == "QRYID":
         try:
-          value = $applySelection(parseSelection(selection), parseJson(value))
+          value = sv.projectPayload(value, codec, selection)
+          codec = pcJson
         except ValueError, JsonParsingError:
           sock.sendFrame("ERR " & getCurrentExceptionMsg().replace("\n", " "))
           return true
-      sock.sendFrame("VAL " & $sv.myId & " " & $value.len, value)
+      sock.sendFrame("VAL " & $sv.myId & " " & $value.len &
+                     sv.codecSuffix(sock, codec), value)
   of "GET", "QRY":
     let parent = parseBiggestUInt(parts[1]).uint64
     let seq = parseUInt(parts[2]).uint32
@@ -802,14 +848,18 @@ proc handleFrame(sv: Server, sock: Socket): bool =
       else:
         sock.sendFrame("MISS")
     else:
-      var value = sv.st.items[(parent, seq)].payload
+      let item = sv.st.items[(parent, seq)]
+      var value = item.payload
+      var codec = item.codec
       if parts[0] == "QRY":
         try:
-          value = $applySelection(parseSelection(selection), parseJson(value))
+          value = sv.projectPayload(value, codec, selection)
+          codec = pcJson
         except ValueError, JsonParsingError:
           sock.sendFrame("ERR " & getCurrentExceptionMsg().replace("\n", " "))
           return true
-      sock.sendFrame("VAL " & $sv.myId & " " & $value.len, value)
+      sock.sendFrame("VAL " & $sv.myId & " " & $value.len &
+                     sv.codecSuffix(sock, codec), value)
   of "BGET":
     let n = parseInt(parts[1])
     let bodyLen = parseInt(parts[2])
@@ -850,6 +900,7 @@ proc handleFrame(sv: Server, sock: Socket): bool =
                      lastHere: now)
     let payloadLen = parseInt(parts[6])
     let vecDim = if parts.len >= 8: parseInt(parts[7]) else: 0
+    p.codec = if parts.len >= 9: parsePayloadCodec(parts[8]) else: pcRaw
     let bodyBytes = checkedFrameBytes(payloadLen, vecDim)
     if not sv.ringKeyAllowed(sock, p.parent):
       sock.drainBytes(bodyBytes)
@@ -1007,6 +1058,8 @@ proc main() =
                   users: users,
                   galaxy: galaxy,
                   allowedRingPrefixes: allowedRingPrefixes,
+                  preparedSelections: initTable[string, Selection](),
+                  codecMetadata: initTable[int, bool](),
                   startedAt: epochTime())
   sv.st.setGalaxy(galaxy)
   sv.rebuildFieldState()
@@ -1069,6 +1122,7 @@ proc main() =
           conns.del fd
           sv.activeConnections = conns.len
           sv.authed.del fd
+          sv.codecMetadata.del fd
           sv.authChallenges.del fd
           sock.disableSecure()
           sock.close()

--- a/src/rochedb.nim
+++ b/src/rochedb.nim
@@ -216,6 +216,39 @@ type
     items*: seq[RocheRecord]
     nextCursor*: string
 
+  RocheReadSortDirection* = enum
+    rsAsc
+    rsDesc
+
+  RochePaginationMode* = enum
+    rpOff
+    rpOn
+
+  RocheReadOptions* = object
+    ## Ring read options shared by the public API and CLI.
+    ## Cursor reads are the efficient default. Page reads are human-facing and
+    ## may need to skip earlier filtered matches.
+    filter*: JsonNode
+    selection*: string
+    limit*: int
+    cursor*: string
+    pagination*: RochePaginationMode
+    page*: int
+    pageLimit*: int
+    sortField*: string
+    sortDirection*: RocheReadSortDirection
+
+  RocheReadPage* = object
+    ring*: string
+    count*: int
+    items*: seq[RocheRecord]
+    nextCursor*: string
+    pagination*: RochePaginationMode
+    page*: int
+    pageLimit*: int
+    sortField*: string
+    sortDirection*: RocheReadSortDirection
+
   RetrieveStats* = object
     totalVectors*: int
     scanned*: int
@@ -1428,6 +1461,121 @@ proc listByRing*(db: RocheDb, ring: string, limit = 100,
       payload: p.payload, codec: p.codec)
     lastSeq = itemKey[1].int64
     inc emitted
+
+proc defaultReadOptions*(): RocheReadOptions =
+  RocheReadOptions(
+    filter: newJObject(),
+    selection: "",
+    limit: 100,
+    cursor: "",
+    pagination: rpOff,
+    page: 1,
+    pageLimit: 20,
+    sortField: "",
+    sortDirection: rsDesc)
+
+proc normalizedReadOptions(options: RocheReadOptions): RocheReadOptions =
+  result = options
+  if result.filter.isNil:
+    result.filter = newJObject()
+  if result.limit <= 0:
+    result.limit = 100
+  if result.page <= 0:
+    result.page = 1
+  if result.pageLimit <= 0:
+    result.pageLimit = result.limit
+  if result.sortField.len == 0:
+    result.sortField = "time"
+  if result.sortField == "write":
+    result.sortField = "time"
+  if result.sortField notin ["id", "time"]:
+    raise newException(ValueError, "sort field must be id, time, or write")
+
+proc recordMatchesReadFilter(item: RocheRecord, filterNode: JsonNode): bool =
+  if filterNode.isNil or filterNode.kind != JObject or filterNode.len == 0:
+    return true
+  let cliId = $item.id.parent & ":" & $item.id.epoch & ":" & $item.id.seq & ":" & $item.id.tWrite
+  if filterNode.hasKey("id") and
+      filterNode["id"].getStr() notin [$item.id, cliId]:
+    return false
+  for key, expected in filterNode:
+    if key == "id":
+      continue
+    if not item.codec.supportsJsonProjection:
+      return false
+    try:
+      let doc = parseJson(item.payload)
+      if doc.kind != JObject or not doc.hasKey(key) or doc[key] != expected:
+        return false
+    except JsonParsingError:
+      return false
+  true
+
+proc projectReadRecord(item: RocheRecord, selection: string): RocheRecord =
+  result = item
+  if selection.len == 0:
+    return
+  if not item.codec.supportsJsonProjection:
+    raise newException(ValueError,
+      "payload codec " & item.codec.payloadCodecName & " does not support JSON projection")
+  result.payload = $applySelection(prepareSelection(selection), parseJson(item.payload))
+  result.codec = pcJson
+
+proc compareReadRecords(a, b: RocheRecord, options: RocheReadOptions): int =
+  case options.sortField
+  of "id":
+    result = cmp($a.id, $b.id)
+  of "time":
+    result = cmp(a.id.tWrite, b.id.tWrite)
+  else:
+    result = 0
+  if options.sortDirection == rsDesc:
+    result = -result
+
+proc readRing*(db: RocheDb, ring: string,
+               options: RocheReadOptions = defaultReadOptions()): RocheReadPage =
+  ## Read records from one ring with filter, projection, limit/cursor,
+  ## page/pagelimit, and page-local sort controls.
+  let opts = normalizedReadOptions(options)
+  let requested =
+    if opts.pagination == rpOn: opts.page * opts.pageLimit
+    else: opts.limit
+  let skip =
+    if opts.pagination == rpOn: (opts.page - 1) * opts.pageLimit
+    else: 0
+  let take =
+    if opts.pagination == rpOn: opts.pageLimit
+    else: opts.limit
+
+  result.ring = ring
+  result.pagination = opts.pagination
+  result.page = opts.page
+  result.pageLimit = opts.pageLimit
+  result.sortField = opts.sortField
+  result.sortDirection = opts.sortDirection
+
+  if requested <= 0:
+    return
+
+  var matched: seq[RocheRecord] = @[]
+  var nextCursor = opts.cursor
+  let pageSize = max(requested, 100)
+  while matched.len < requested:
+    let page = db.listByRing(ring, limit = pageSize, cursor = nextCursor)
+    for item in page.items:
+      if recordMatchesReadFilter(item, opts.filter):
+        matched.add item
+        if matched.len >= requested:
+          break
+    nextCursor = page.nextCursor
+    if nextCursor.len == 0 or page.items.len == 0:
+      break
+
+  matched.sort(proc(a, b: RocheRecord): int = compareReadRecords(a, b, opts))
+  for i in skip ..< min(skip + take, matched.len):
+    result.items.add projectReadRecord(matched[i], opts.selection)
+  result.count = result.items.len
+  result.nextCursor = nextCursor
 
 proc batchPut*(db: RocheDb, payloads: seq[string], ring: string = "default",
                vecs: seq[seq[float32]] = @[]): seq[RocheId] =

--- a/src/rochedb.nim
+++ b/src/rochedb.nim
@@ -23,11 +23,13 @@
 
 import std/[algorithm, tables, hashes, json, times, strutils, os]
 import roche/[core, store, select, wire, field, vector_backend, faiss_backend,
-              planner_backend]
+              planner_backend, payload]
 
 export vector_backend
 export faiss_backend
 export planner_backend
+export payload
+export select
 
 type
   RocheDurability* = StoreDurability
@@ -137,6 +139,7 @@ type
     op*: string
     logicalKey*: string
     payload*: string
+    codec*: PayloadCodec
     vec*: seq[float32]
     timestamp*: float
     originSeq*: uint64
@@ -152,6 +155,7 @@ type
     ringNames: Table[string, uint64]
     ringKeyNames: Table[uint64, string]
     ringDescriptions: Table[uint64, string]
+    ringPayloadProfiles: Table[uint64, RingPayloadProfile]
     ringWriteAckModes: Table[uint64, WriteAckMode]
     ringApplyPolicies: Table[uint64, RingApplyPolicy]
     ringChildren: Table[uint64, seq[uint64]]
@@ -193,11 +197,13 @@ type
     id*: RocheId
     score*: float
     payload*: string
+    codec*: PayloadCodec
 
   RocheRecord* = object
     ## ORM / driver が listByRing で扱う薄い record。
     id*: RocheId
     payload*: string
+    codec*: PayloadCodec
 
   WarpStepResult* = object
     job*: WarpJob
@@ -319,6 +325,7 @@ proc put*(db: RocheDb, payload: string, ring: string = "default",
 proc enqueueUniverseSyncEvent*(db: RocheDb, sourceUniverse, sourceGalaxy,
                                ring, payload: string,
                                vec: seq[float32] = @[],
+                               codec = pcRaw,
                                op = "put", logicalKey = "",
                                timestamp = -1.0,
                                eventKey = ""): uint64
@@ -397,6 +404,8 @@ proc open*(nodes: int = 8, dataDir: string = "",
     result.ringKeyNames[key] = name
   for key, desc in result.st.ringDescriptions:
     result.ringDescriptions[key] = desc
+  for key, profile in result.st.ringPayloadProfiles:
+    result.ringPayloadProfiles[key] = profile
   result.galaxyDescription = result.st.galaxyDescription
   for _, blob in result.st.warpJobs:
     let raw = parseJson(blob)
@@ -451,6 +460,7 @@ proc open*(nodes: int = 8, dataDir: string = "",
       op: raw{"op"}.getStr("put"),
       logicalKey: raw{"logicalKey"}.getStr(),
       payload: raw{"payload"}.getStr(),
+      codec: parsePayloadCodec(raw{"codec"}.getStr("raw")),
       vec: vec,
       timestamp: raw{"timestamp"}.getFloat(),
       originSeq: raw{"originSeq"}.getBiggestInt().uint64,
@@ -533,6 +543,22 @@ proc getRingDescription*(db: RocheDb, ring: string): string =
     ""
   else:
     db.ringDescriptions.getOrDefault(key, "")
+
+proc configureRingPayloadProfile*(db: RocheDb, ring: string,
+                                  profile: RingPayloadProfile) =
+  ## A declaration for applications and tools. It never changes the codec of
+  ## existing records, whose explicit metadata remains authoritative.
+  let key = db.ringKey(ring)
+  db.ringPayloadProfiles[key] = profile
+  if db.mode == mEmbedded:
+    db.st.putRingPayloadProfile(key, profile)
+
+proc ringPayloadProfile*(db: RocheDb, ring: string): RingPayloadProfile =
+  let key = db.ringKeyForRead(ring)
+  if key == 0'u64:
+    defaultRingPayloadProfile()
+  else:
+    db.ringPayloadProfiles.getOrDefault(key, defaultRingPayloadProfile())
 
 proc compact*(db: RocheDb): CompactStats =
   ## 組み込み永続 Store の WAL を生存レコードだけに再構築する。
@@ -929,7 +955,7 @@ proc waitClusterTxApplied*(db: RocheDb, txid: uint64, timeoutMs = 10_000,
     sleep(max(1, pollMs))
   false
 
-proc put*(db: RocheDb, payload: string, ring: string = "default",
+proc put*(db: RocheDb, encoded: EncodedPayload, ring: string = "default",
           vec: seq[float32] = @[]): RocheId =
   ## 書き込み。環は初回利用時に自動作成。
   ## 返る ID を持っていれば、所在は誰にも問い合わせずいつでも計算できる。
@@ -941,40 +967,62 @@ proc put*(db: RocheDb, payload: string, ring: string = "default",
     let seq = db.st.nextSeq(key)
     result = RocheId(parent: key, epoch: db.tbl.epoch, seq: seq, tWrite: db.clock)
     let p = Particle(parent: key, seq: seq, period: ri.period,
-                     head: ri.headAngle, tWrite: db.clock, payload: payload,
+                     head: ri.headAngle, tWrite: db.clock, payload: encoded.data,
+                     codec: encoded.codec,
                      vec: normVec)
     db.st.upsert p
     db.vectorBackend.upsert p
   of mCluster:
     # 書き込み先 = 環ヘッド角の所有ノード（決定論的 write leader, §7 の最小版）
     let node = int(db.tbl.owner(ri.headAngle))
-    let (seq, tWrite) = db.client.putReq(node, key, ri.period, ri.headAngle, payload, normVec)
+    let (seq, tWrite) = db.client.putReq(node, key, ri.period, ri.headAngle,
+                                         encoded.data, normVec, encoded.codec)
     result = RocheId(parent: key, epoch: db.tbl.epoch, seq: seq, tWrite: tWrite)
+
+proc put*(db: RocheDb, payload: string, ring: string = "default",
+          vec: seq[float32] = @[]): RocheId =
+  db.put(encodedPayload(payload), ring, vec)
+
+proc putUsingRingProfile*(db: RocheDb, payload: string,
+                          ring: string = "default",
+                          vec: seq[float32] = @[]): RocheId =
+  ## Uses the ring's declared default codec. The ordinary string overload
+  ## remains raw for backwards compatibility.
+  db.put(encodedPayload(payload, db.ringPayloadProfile(ring).defaultCodec),
+         ring, vec)
 
 proc put*(db: RocheDb, doc: JsonNode, ring: string = "default",
           vec: seq[float32] = @[]): RocheId =
   ## 構造化ドキュメントの書き込み。query（選択取得）の対象になる。
-  db.put($doc, ring, vec)
+  db.put(encodedPayload($doc, pcJson), ring, vec)
 
-proc putSynced*(db: RocheDb, payload: string, sourceUniverse, sourceGalaxy: string,
+proc putSynced*(db: RocheDb, encoded: EncodedPayload,
+                sourceUniverse, sourceGalaxy: string,
                 ring: string = "default", vec: seq[float32] = @[],
                 logicalKey = ""): RocheId =
   ## embedded put と universe outbox 登録を同時に行う。
   ## 既存 put の意味は変えず、Universe 同期したい write path だけで使う。
   doAssert db.mode == mEmbedded, "putSynced は embedded mode 専用"
-  result = db.put(payload, ring = ring, vec = vec)
+  result = db.put(encoded, ring = ring, vec = vec)
   discard db.enqueueUniverseSyncEvent(sourceUniverse = sourceUniverse,
                                       sourceGalaxy = sourceGalaxy,
                                       ring = ring,
-                                      payload = payload,
+                                      payload = encoded.data,
                                       vec = vec,
+                                      codec = encoded.codec,
                                       logicalKey = logicalKey,
                                       timestamp = epochTime())
+
+proc putSynced*(db: RocheDb, payload: string, sourceUniverse, sourceGalaxy: string,
+                ring: string = "default", vec: seq[float32] = @[],
+                logicalKey = ""): RocheId =
+  db.putSynced(encodedPayload(payload), sourceUniverse, sourceGalaxy,
+               ring, vec, logicalKey)
 
 proc putSynced*(db: RocheDb, doc: JsonNode, sourceUniverse, sourceGalaxy: string,
                 ring: string = "default", vec: seq[float32] = @[],
                 logicalKey = ""): RocheId =
-  db.putSynced($doc, sourceUniverse = sourceUniverse,
+  db.putSynced(encodedPayload($doc, pcJson), sourceUniverse = sourceUniverse,
                sourceGalaxy = sourceGalaxy, ring = ring, vec = vec,
                logicalKey = logicalKey)
 
@@ -990,7 +1038,7 @@ proc beginTransaction*(db: RocheDb): RocheTx =
   of mCluster:
     RocheTx(db: db, clusterTxId: db.client.txBeginReq(0))
 
-proc put*(tx: RocheTx, payload: string, ring: string = "default",
+proc put*(tx: RocheTx, encoded: EncodedPayload, ring: string = "default",
           vec: seq[float32] = @[]): RocheId =
   ## transaction 内の書き込み。commit まで DB 本体には見えない。
   doAssert not tx.closed, "transaction is closed"
@@ -1005,18 +1053,22 @@ proc put*(tx: RocheTx, payload: string, ring: string = "default",
     result = RocheId(parent: key, epoch: tx.db.tbl.epoch, seq: seq, tWrite: tx.db.clock)
     tx.tx.upsert Particle(parent: key, seq: seq, period: ri.period,
                           head: ri.headAngle, tWrite: tx.db.clock,
-                          payload: payload, vec: normVec)
+                          payload: encoded.data, codec: encoded.codec, vec: normVec)
   of mCluster:
     let (seq, tWrite) = tx.db.client.txReserveReq(0, tx.clusterTxId, key,
                                                   ri.period, ri.headAngle)
     result = RocheId(parent: key, epoch: tx.db.tbl.epoch, seq: seq, tWrite: tWrite)
     tx.clusterOps.add TxWireOp(parent: key, seq: seq, period: ri.period,
                                head: ri.headAngle, tWrite: tWrite,
-                               payload: payload, vec: normVec)
+                               payload: encoded.data, codec: encoded.codec, vec: normVec)
+
+proc put*(tx: RocheTx, payload: string, ring: string = "default",
+          vec: seq[float32] = @[]): RocheId =
+  tx.put(encodedPayload(payload), ring, vec)
 
 proc put*(tx: RocheTx, doc: JsonNode, ring: string = "default",
           vec: seq[float32] = @[]): RocheId =
-  tx.put($doc, ring, vec)
+  tx.put(encodedPayload($doc, pcJson), ring, vec)
 
 proc remove*(tx: RocheTx, id: RocheId) =
   ## transaction 内の削除。commit まで DB 本体には反映されない。
@@ -1030,7 +1082,7 @@ proc remove*(tx: RocheTx, id: RocheId) =
                                period: ri.period, head: ri.headAngle,
                                tWrite: id.tWrite)
 
-proc update*(tx: RocheTx, id: RocheId, payload: string,
+proc update*(tx: RocheTx, id: RocheId, encoded: EncodedPayload,
              vec: seq[float32] = @[]) =
   ## transaction 内の置換更新。commit まで DB 本体には反映されない。
   doAssert not tx.closed, "transaction is closed"
@@ -1041,7 +1093,8 @@ proc update*(tx: RocheTx, id: RocheId, payload: string,
     if k notin tx.db.st.items:
       raise newException(KeyError, "id が見つからない")
     var p = tx.db.st.items[k]
-    p.payload = payload
+    p.payload = encoded.data
+    p.codec = encoded.codec
     p.tWrite = tx.db.clock
     if vec.len > 0:
       p.vec = normVec
@@ -1050,12 +1103,17 @@ proc update*(tx: RocheTx, id: RocheId, payload: string,
     let ri = tx.db.rings[id.parent]
     tx.clusterOps.add TxWireOp(parent: id.parent, seq: id.seq,
                                period: ri.period, head: ri.headAngle,
-                               tWrite: id.tWrite, payload: payload,
+                               tWrite: id.tWrite, payload: encoded.data,
+                               codec: encoded.codec,
                                vec: normVec)
+
+proc update*(tx: RocheTx, id: RocheId, payload: string,
+             vec: seq[float32] = @[]) =
+  tx.update(id, encodedPayload(payload), vec)
 
 proc update*(tx: RocheTx, id: RocheId, doc: JsonNode,
              vec: seq[float32] = @[]) =
-  tx.update(id, $doc, vec)
+  tx.update(id, encodedPayload($doc, pcJson), vec)
 
 proc commit*(tx: RocheTx) =
   doAssert not tx.closed, "transaction is closed"
@@ -1107,7 +1165,8 @@ proc transaction*(db: RocheDb, body: proc(tx: RocheTx)) =
 
 # ---------------------------------------------------------------- 読み出し
 
-proc fetchCluster(db: RocheDb, id: RocheId, selection: string, fwdDepth = 0): string =
+proc fetchClusterPayload(db: RocheDb, id: RocheId, selection: string,
+                         fwdDepth = 0): EncodedPayload =
   ## 現在の所有ノードから取得。取りこぼしのフォールバック順:
   ##   primary → 1つ手前（尾流コピー, §6.1）→ もう一度 primary
   ## 最後の再試行は「手前を見ている間に粒子が前方へハンドオフされた」TOCTOU
@@ -1115,16 +1174,16 @@ proc fetchCluster(db: RocheDb, id: RocheId, selection: string, fwdDepth = 0): st
   let ri = db.rings[id.parent]
   let n = int(db.tbl.nNodes)
   let primary = int(db.tbl.node(db.orbitOf(id), epochTime()))
-  proc landingRead(): tuple[hit: bool, deleted: bool, value: string] =
+  proc landingRead(): tuple[hit: bool, deleted: bool, value: EncodedPayload] =
     let r = db.client.txGetIdReq(0, WireId(parent: id.parent, epoch: id.epoch,
       seq: id.seq, tWrite: id.tWrite, period: ri.period, head: ri.headAngle),
       selection)
     if r.found:
-      return (true, false, r.value)
+      return (true, false, encodedPayload(r.value, r.codec))
     if r.deleted:
       db.clearPendingLandingRead(id)
-      return (false, true, "")
-    (false, false, "")
+      return (false, true, EncodedPayload())
+    (false, false, EncodedPayload())
   if db.hasPendingLandingRead(id):
     let pending = landingRead()
     if pending.deleted:
@@ -1133,7 +1192,7 @@ proc fetchCluster(db: RocheDb, id: RocheId, selection: string, fwdDepth = 0): st
       return pending.value
     db.clearPendingLandingRead(id)
   for node in [primary, (primary + n - 1) mod n, primary]:
-    var r: tuple[found: bool, node: int, value: string, forwarded: bool,
+    var r: tuple[found: bool, node: int, value: string, codec: PayloadCodec, forwarded: bool,
                  newParent: uint64, newSeq: uint32, newTWrite: float]
     try:
       r =
@@ -1150,15 +1209,15 @@ proc fetchCluster(db: RocheDb, id: RocheId, selection: string, fwdDepth = 0): st
         return pendingRetry.value
       continue
     if r.found:
-      return r.value
+      return encodedPayload(r.value, r.codec)
     if r.forwarded:
       if fwdDepth >= 1:
         raise newException(KeyError, "FWD chain が長すぎる")
       if r.newParent notin db.rings:
         raise newException(KeyError, "FWD 先の環メタがない（parent=" & $r.newParent & "）")
-      return db.fetchCluster(RocheId(parent: r.newParent, epoch: id.epoch,
-                                     seq: r.newSeq, tWrite: r.newTWrite),
-                             selection, fwdDepth + 1)
+      return db.fetchClusterPayload(RocheId(parent: r.newParent, epoch: id.epoch,
+                                            seq: r.newSeq, tWrite: r.newTWrite),
+                                    selection, fwdDepth + 1)
     let pendingRetry = landingRead()
     if pendingRetry.deleted:
       raise newException(KeyError, "id は cluster tx landing intent で削除済み")
@@ -1173,7 +1232,16 @@ proc get*(db: RocheDb, id: RocheId): string =
   of mEmbedded:
     db.st.items[(id.parent, id.seq)].payload
   of mCluster:
-    db.fetchCluster(id, "")
+    db.fetchClusterPayload(id, "").data
+
+proc getEncoded*(db: RocheDb, id: RocheId): EncodedPayload =
+  ## Read payload bytes together with the persisted format identifier.
+  case db.mode
+  of mEmbedded:
+    let p = db.st.items[(id.parent, id.seq)]
+    encodedPayload(p.payload, p.codec)
+  of mCluster:
+    db.fetchClusterPayload(id, "")
 
 proc batchGet*(db: RocheDb, ids: seq[RocheId]): seq[string] =
   ## 複数 ID をまとめて取得する。cluster では同一 node 行きをまとめて 1 request にする。
@@ -1241,7 +1309,7 @@ proc deleteById*(db: RocheDb, id: RocheId) =
   ## ORM で直感的に使うための alias。
   db.remove(id)
 
-proc update*(db: RocheDb, id: RocheId, payload: string,
+proc update*(db: RocheDb, id: RocheId, encoded: EncodedPayload,
              vec: seq[float32] = @[]) =
   ## payload を置換する。vec を省略した場合は既存 vec を保持する。
   case db.mode
@@ -1250,7 +1318,8 @@ proc update*(db: RocheDb, id: RocheId, payload: string,
     if k notin db.st.items:
       raise newException(KeyError, "id が見つからない")
     var p = db.st.items[k]
-    p.payload = payload
+    p.payload = encoded.data
+    p.codec = encoded.codec
     p.tWrite = db.clock
     if vec.len > 0:
       p.vec = vec.normalize()
@@ -1262,7 +1331,7 @@ proc update*(db: RocheDb, id: RocheId, payload: string,
     let ops = @[
       TxWireOp(parent: id.parent, seq: id.seq, period: ri.period,
                head: ri.headAngle, tWrite: id.tWrite,
-               payload: payload, vec: vec.normalize())
+               payload: encoded.data, codec: encoded.codec, vec: vec.normalize())
     ]
     db.client.txCommitReq(0, txid, ops)
     if db.writeAckModeForOps(ops) == wamApplied:
@@ -1271,9 +1340,13 @@ proc update*(db: RocheDb, id: RocheId, payload: string,
     else:
       db.markPendingLandingReads(ops)
 
+proc update*(db: RocheDb, id: RocheId, payload: string,
+             vec: seq[float32] = @[]) =
+  db.update(id, encodedPayload(payload), vec)
+
 proc update*(db: RocheDb, id: RocheId, doc: JsonNode,
              vec: seq[float32] = @[]) =
-  db.update(id, $doc, vec)
+  db.update(id, encodedPayload($doc, pcJson), vec)
 
 proc mergePatch(dst: var JsonNode, patch: JsonNode) =
   if patch.kind != JObject or dst.kind != JObject:
@@ -1336,7 +1409,7 @@ proc listByRing*(db: RocheDb, ring: string, limit = 100,
       result.items.add RocheRecord(
         id: RocheId(parent: row.parent, epoch: db.tbl.epoch, seq: row.seq,
                     tWrite: row.tWrite),
-        payload: row.payload)
+        payload: row.payload, codec: row.codec)
     return
   var emitted = 0
   var lastSeq = -1'i64
@@ -1352,7 +1425,7 @@ proc listByRing*(db: RocheDb, ring: string, limit = 100,
     result.items.add RocheRecord(
       id: RocheId(parent: p.parent, epoch: db.tbl.epoch, seq: p.seq,
                   tWrite: p.tWrite),
-      payload: p.payload)
+      payload: p.payload, codec: p.codec)
     lastSeq = itemKey[1].int64
     inc emitted
 
@@ -1422,6 +1495,7 @@ proc universeSyncEventJson(event: UniverseSyncEvent): JsonNode =
     "op": event.op,
     "logicalKey": event.logicalKey,
     "payload": event.payload,
+    "codec": event.codec.payloadCodecName,
     "vec": event.vec,
     "timestamp": event.timestamp,
     "originSeq": event.originSeq,
@@ -1501,6 +1575,7 @@ proc universeSyncEventReady(db: RocheDb, event: UniverseSyncEvent): bool =
 proc enqueueUniverseSyncEvent*(db: RocheDb, sourceUniverse, sourceGalaxy,
                                ring, payload: string,
                                vec: seq[float32] = @[],
+                               codec = pcRaw,
                                op = "put", logicalKey = "",
                                timestamp = -1.0,
                                eventKey = ""): uint64 =
@@ -1527,6 +1602,7 @@ proc enqueueUniverseSyncEvent*(db: RocheDb, sourceUniverse, sourceGalaxy,
                                 op: op,
                                 logicalKey: logicalKey,
                                 payload: payload,
+                                codec: codec,
                                 vec: vec.normalize(),
                                 timestamp: ts,
                                 originSeq: db.nextUniverseSyncId)
@@ -1552,7 +1628,8 @@ proc applyUniverseSyncEvent*(db: RocheDb, event: UniverseSyncEvent): bool =
   let policy = db.ringApplyPolicy(event.ring)
   case policy.mode
   of ramLatestOnly, ramAppendOnly, ramBoundedHistory, ramDelayedTimestamp:
-    discard db.put(event.payload, ring = event.ring, vec = event.vec)
+    discard db.put(encodedPayload(event.payload, event.codec),
+                   ring = event.ring, vec = event.vec)
   db.st.markUniverseSyncEventApplied(event.eventKey)
   true
 
@@ -1738,16 +1815,23 @@ proc batchRemove*(db: RocheDb, ids: seq[RocheId]) =
 proc batchDelete*(db: RocheDb, ids: seq[RocheId]) =
   db.batchRemove(ids)
 
-proc query*(db: RocheDb, id: RocheId, selection: string): JsonNode =
+proc query*(db: RocheDb, id: RocheId, prepared: PreparedSelection): JsonNode =
   ## 選択取得（GraphQL 風, 設計書 §15）。payload は JSON であること。
-  ##   db.query(id, "{ title author { name } }")
+  ## prepareSelection validates and parses the projection once for reuse.
   ## クラスタではサーバ側で射影され、選択した分だけがネットワークを流れる。
   case db.mode
   of mEmbedded:
-    applySelection(parseSelection(selection),
-                   parseJson(db.st.items[(id.parent, id.seq)].payload))
+    let p = db.st.items[(id.parent, id.seq)]
+    if not p.codec.supportsJsonProjection:
+      raise newException(ValueError,
+        "payload codec " & p.codec.payloadCodecName & " does not support JSON projection")
+    applySelection(prepared, parseJson(p.payload))
   of mCluster:
-    parseJson(db.fetchCluster(id, selection))
+    parseJson(db.fetchClusterPayload(id, prepared.source).data)
+
+proc query*(db: RocheDb, id: RocheId, selection: string): JsonNode =
+  ## Convenience form. Reuse PreparedSelection on hot paths.
+  db.query(id, prepareSelection(selection))
 
 proc contains*(db: RocheDb, id: RocheId): bool =
   ## `id in db` と書ける（組み込みモード）。
@@ -2245,7 +2329,8 @@ proc retrieveWithStats*(db: RocheDb, queryVec: seq[float32], ring: string = "",
     for h in rr.hits:
       result.hits.add RocheHit(id: RocheId(parent: h.parent, epoch: db.tbl.epoch,
                                            seq: h.seq, tWrite: h.tWrite),
-                               score: h.score, payload: h.payload)
+                               score: h.score, payload: h.payload,
+                               codec: db.st.items.getOrDefault((h.parent, h.seq)).codec)
     result.stats.totalVectors = rr.totalVectors
     result.stats.scanned = rr.scanned
     result.stats.skippedVectors = rr.skippedVectors
@@ -2267,7 +2352,7 @@ proc retrieveWithStats*(db: RocheDb, queryVec: seq[float32], ring: string = "",
           for h in rr.hits:
             result.hits.add RocheHit(id: RocheId(parent: h.parent, epoch: db.tbl.epoch,
                                                  seq: h.seq, tWrite: h.tWrite),
-                                     score: h.score, payload: h.payload)
+                                     score: h.score, payload: h.payload, codec: h.codec)
     elif result.plan.effectiveTopRings <= 0:
       for node in 0 ..< db.client.peers.len:
         let rr = db.client.retrieveReq(node, ring.len > 0, ringFilter, q, budget)
@@ -2280,7 +2365,7 @@ proc retrieveWithStats*(db: RocheDb, queryVec: seq[float32], ring: string = "",
         for h in rr.hits:
           result.hits.add RocheHit(id: RocheId(parent: h.parent, epoch: db.tbl.epoch,
                                                seq: h.seq, tWrite: h.tWrite),
-                                   score: h.score, payload: h.payload)
+                                   score: h.score, payload: h.payload, codec: h.codec)
     else:
       var rings = db.ringSummaries(q)
       if rings.len > result.plan.effectiveTopRings:
@@ -2297,7 +2382,7 @@ proc retrieveWithStats*(db: RocheDb, queryVec: seq[float32], ring: string = "",
           for h in rr.hits:
             result.hits.add RocheHit(id: RocheId(parent: h.parent, epoch: db.tbl.epoch,
                                                  seq: h.seq, tWrite: h.tWrite),
-                                     score: h.score, payload: h.payload)
+                                     score: h.score, payload: h.payload, codec: h.codec)
   result.hits.sort(proc(a, b: RocheHit): int = cmp(b.score, a.score))
   if result.hits.len > budget:
     result.hits.setLen(budget)

--- a/src/rochedb_capi.nim
+++ b/src/rochedb_capi.nim
@@ -97,6 +97,28 @@ proc optStr(s: cstring): string =
   else:
     $s
 
+proc codecFromC(value: cint): PayloadCodec =
+  case value
+  of 0: pcRaw
+  of 1: pcJson
+  of 2: pcNif
+  of 3: pcBif
+  else: raise newException(ValueError, "invalid payload codec")
+
+proc codecToC(value: PayloadCodec): cint =
+  case value
+  of pcRaw: 0
+  of pcJson: 1
+  of pcNif: 2
+  of pcBif: 3
+
+proc bytesFromC(data: pointer, len: csize_t): string =
+  if len > 0 and data == nil:
+    raise newException(ValueError, "data is nil")
+  result = newString(int(len))
+  if len > 0:
+    copyMem(addr result[0], data, int(len))
+
 proc roche_abi_version(): cint {.exportc, cdecl, dynlib.} =
   RocheAbiVersion
 
@@ -217,12 +239,22 @@ proc roche_put(h: pointer, ring: cstring, data: pointer, len: csize_t,
     clearError()
     if outId == nil:
       raise newException(ValueError, "out_id is nil")
-    if len > 0 and data == nil:
-      raise newException(ValueError, "data is nil")
-    var payload = newString(int(len))
-    if len > 0:
-      copyMem(addr payload[0], data, int(len))
+    let payload = bytesFromC(data, len)
     outId[] = ensureHandle(h).put(payload, cstringToString(ring, "ring", allowNil = false)).toC
+    RocheOk
+  except CatchableError as e:
+    setError(e)
+    RocheErr
+
+proc roche_put_codec(h: pointer, ring: cstring, data: pointer, len: csize_t,
+                     codec: cint, outId: ptr RocheCId): cint
+                     {.exportc, cdecl, dynlib.} =
+  try:
+    clearError()
+    if outId == nil:
+      raise newException(ValueError, "out_id is nil")
+    outId[] = ensureHandle(h).put(encodedPayload(bytesFromC(data, len),
+      codecFromC(codec)), cstringToString(ring, "ring", allowNil = false)).toC
     RocheOk
   except CatchableError as e:
     setError(e)
@@ -235,19 +267,36 @@ proc roche_put_vec(h: pointer, ring: cstring, data: pointer, len: csize_t,
     clearError()
     if outId == nil:
       raise newException(ValueError, "out_id is nil")
-    if len > 0 and data == nil:
-      raise newException(ValueError, "data is nil")
     if vecLen > 0 and vec == nil:
       raise newException(ValueError, "vec is nil")
-    var payload = newString(int(len))
-    if len > 0:
-      copyMem(addr payload[0], data, int(len))
+    let payload = bytesFromC(data, len)
     var values = newSeq[float32](int(vecLen))
     let rawVec = cast[ptr UncheckedArray[cfloat]](vec)
     for i in 0 ..< int(vecLen):
       values[i] = float32(rawVec[i])
     outId[] = ensureHandle(h).put(payload, cstringToString(ring, "ring", allowNil = false),
                                   vec = values).toC
+    RocheOk
+  except CatchableError as e:
+    setError(e)
+    RocheErr
+
+proc roche_put_vec_codec(h: pointer, ring: cstring, data: pointer, len: csize_t,
+                         codec: cint, vec: ptr cfloat, vecLen: csize_t,
+                         outId: ptr RocheCId): cint {.exportc, cdecl, dynlib.} =
+  try:
+    clearError()
+    if outId == nil:
+      raise newException(ValueError, "out_id is nil")
+    if vecLen > 0 and vec == nil:
+      raise newException(ValueError, "vec is nil")
+    var values = newSeq[float32](int(vecLen))
+    let rawVec = cast[ptr UncheckedArray[cfloat]](vec)
+    for i in 0 ..< int(vecLen):
+      values[i] = float32(rawVec[i])
+    outId[] = ensureHandle(h).put(encodedPayload(bytesFromC(data, len),
+      codecFromC(codec)), cstringToString(ring, "ring", allowNil = false),
+      vec = values).toC
     RocheOk
   except CatchableError as e:
     setError(e)
@@ -267,6 +316,20 @@ proc roche_get(h: pointer, id: RocheCId,
   except CatchableError as e:
     setError(e)
     return nil
+
+proc roche_get_codec(h: pointer, id: RocheCId, outLen: ptr csize_t,
+                     outCodec: ptr cint): pointer {.exportc, cdecl, dynlib.} =
+  try:
+    clearError()
+    if outLen == nil or outCodec == nil:
+      raise newException(ValueError, "out_len and out_codec are required")
+    let value = ensureHandle(h).getEncoded(fromC(id))
+    outLen[] = csize_t(value.data.len)
+    outCodec[] = value.codec.codecToC
+    copyStringToShared(value.data)
+  except CatchableError as e:
+    setError(e)
+    nil
 
 proc roche_free(p: pointer) {.exportc, cdecl, dynlib.} =
   if p != nil:

--- a/src/rochedb_capi.nim
+++ b/src/rochedb_capi.nim
@@ -9,7 +9,7 @@
 ##   - 例外は境界を越えない: すべて捕捉し、エラーはリターンコード / nil で返す。
 ##   - roche_get が返すバッファは呼び出し側が roche_free で解放する。
 
-import std/json
+import std/[base64, json]
 import rochedb
 
 type
@@ -49,7 +49,7 @@ type
 const
   RocheOk = cint(0)
   RocheErr = cint(-1)
-  RocheAbiVersion = cint(1)
+  RocheAbiVersion = cint(2)
 
 var lastError {.threadvar.}: string
 
@@ -111,6 +111,13 @@ proc codecToC(value: PayloadCodec): cint =
   of pcJson: 1
   of pcNif: 2
   of pcBif: 3
+
+proc payloadCodecName(value: PayloadCodec): string =
+  case value
+  of pcRaw: "raw"
+  of pcJson: "json"
+  of pcNif: "nif"
+  of pcBif: "bif"
 
 proc bytesFromC(data: pointer, len: csize_t): string =
   if len > 0 and data == nil:
@@ -390,6 +397,74 @@ proc roche_query(h: pointer, id: RocheCId, selection: cstring,
   except CatchableError as e:
     setError(e)
     return nil
+
+proc rocheReadPayloadNode(item: RocheRecord): JsonNode =
+  if item.codec == pcJson:
+    try:
+      return %*{"encoding": "json", "payload": parseJson(item.payload)}
+    except JsonParsingError:
+      discard
+  %*{"encoding": "base64", "payload": base64.encode(item.payload)}
+
+proc rocheReadPageJson(page: RocheReadPage): string =
+  var items = newJArray()
+  for item in page.items:
+    let display = rocheReadPayloadNode(item)
+    let (parent, epoch, seq, tWrite) = item.id.toRaw
+    items.add %*{
+      "id": $item.id,
+      "rawId": $parent & ":" & $epoch & ":" & $seq & ":" & $tWrite,
+      "codec": item.codec.payloadCodecName,
+      "encoding": display["encoding"].getStr(),
+      "payload": display["payload"]
+    }
+  $(%*{
+    "ring": page.ring,
+    "count": page.count,
+    "pagination": if page.pagination == rpOn: "on" else: "off",
+    "page": page.page,
+    "pageLimit": page.pageLimit,
+    "sort": page.sortField,
+    "sortDirection": if page.sortDirection == rsDesc: "desc" else: "asc",
+    "items": items,
+    "nextCursor": page.nextCursor
+  })
+
+proc roche_read_ring_json(h: pointer, ring, filterJson, selection: cstring,
+                          limit: cint, cursor: cstring, pagination: cint,
+                          page: cint, pageLimit: cint, sortField: cstring,
+                          sortDesc: cint, outLen: ptr csize_t): pointer
+                          {.exportc, cdecl, dynlib.} =
+  ## Returns a JSON read page compatible with CLI get --ring output.
+  ## Binary/non-JSON payloads are base64 encoded and marked with encoding=base64.
+  try:
+    clearError()
+    if outLen == nil:
+      raise newException(ValueError, "out_len is nil")
+    let filterText = optStr(filterJson)
+    let filterNode =
+      if filterText.len == 0: newJObject()
+      else: parseJson(filterText)
+    if filterNode.kind != JObject:
+      raise newException(ValueError, "filter must be a JSON object")
+    let opts = RocheReadOptions(
+      filter: filterNode,
+      selection: optStr(selection),
+      limit: int(limit),
+      cursor: optStr(cursor),
+      pagination: if pagination == 0: rpOff else: rpOn,
+      page: int(page),
+      pageLimit: int(pageLimit),
+      sortField: optStr(sortField),
+      sortDirection: if sortDesc == 0: rsAsc else: rsDesc)
+    let pageResult = ensureHandle(h).readRing(
+      cstringToString(ring, "ring", allowNil = false), opts)
+    let s = rocheReadPageJson(pageResult)
+    outLen[] = csize_t(s.len)
+    copyStringToShared(s)
+  except CatchableError as e:
+    setError(e)
+    nil
 
 proc vecFromC(vec: ptr cfloat, vecLen: csize_t): seq[float32] =
   if vecLen == 0:

--- a/tests/tapi.nim
+++ b/tests/tapi.nim
@@ -147,6 +147,37 @@ suite "public api":
     check page2.items[0].payload.contains("\"name\":\"c\"")
     check page2.nextCursor.len == 0
 
+    let read1 = db.readRing("users", RocheReadOptions(
+      filter: %*{"name": "b"},
+      selection: "{ name }",
+      limit: 10,
+      sortField: "id",
+      sortDirection: rsAsc))
+    check read1.count == 1
+    check read1.items.len == 1
+    check parseJson(read1.items[0].payload) == %*{"name": "b"}
+
+    let readLimited = db.readRing("users", RocheReadOptions(
+      filter: newJObject(),
+      limit: 10,
+      sortField: "id",
+      sortDirection: rsAsc))
+    check readLimited.items.len == 3
+    check readLimited.count == 3
+
+    let readPaged = db.readRing("users", RocheReadOptions(
+      filter: newJObject(),
+      pagination: rpOn,
+      page: 2,
+      pageLimit: 2,
+      sortField: "id",
+      sortDirection: rsAsc))
+    check readPaged.items.len == 1
+    check readPaged.count == 1
+    check readPaged.pagination == rpOn
+    check readPaged.page == 2
+    check readPaged.pageLimit == 2
+
     db.update(ids[0], %*{"name": "a2", "meta": {"n": 10}})
     check db.query(ids[0], "{ name }") == %*{"name": "a2"}
     let patched = db.patch(ids[0], %*{"meta": {"ok": true}, "name": nil})

--- a/tests/tapi.nim
+++ b/tests/tapi.nim
@@ -11,6 +11,47 @@ suite "public api":
     check id in db
     db.close()
 
+  test "payload codecs are selectable and JSON projection is format-aware":
+    var db = open()
+    let rawId = db.put(encodedPayload("raw\0bytes", pcRaw))
+    let jsonId = db.put(%*{"title": "RocheDB", "private": true})
+    let nifId = db.put(encodedPayload("(object (title RocheDB))", pcNif))
+    let bifId = db.put(encodedPayload("\x01\x00\x00\x00", pcBif))
+
+    check db.getEncoded(rawId) == encodedPayload("raw\0bytes", pcRaw)
+    check db.getEncoded(jsonId).codec == pcJson
+    check db.getEncoded(nifId).codec == pcNif
+    check db.getEncoded(bifId).codec == pcBif
+
+    let prepared = prepareSelection("{ title }")
+    check db.query(jsonId, prepared) == %*{"title": "RocheDB"}
+    expect ValueError:
+      discard db.query(nifId, prepared)
+    db.close()
+
+  test "ring payload profile persists and can drive explicit writes":
+    let dir = createTempDir("rochedb", "ring-profile")
+    var db = open(dataDir = dir)
+    let profile = RingPayloadProfile(defaultCodec: pcBif,
+      charset: "", formatVersion: "1")
+    db.configureRingPayloadProfile("artifacts", profile)
+    check db.ringPayloadProfile("artifacts") == profile
+    let id = db.putUsingRingProfile("\x01\x02\x03", ring = "artifacts")
+    check db.getEncoded(id) == encodedPayload("\x01\x02\x03", pcBif)
+    db.close()
+
+    var reopened = open(dataDir = dir)
+    check reopened.ringPayloadProfile("artifacts") == profile
+    check reopened.getEncoded(id).codec == pcBif
+    discard reopened.compact()
+    reopened.close()
+
+    var compacted = open(dataDir = dir)
+    check compacted.ringPayloadProfile("artifacts") == profile
+    check compacted.getEncoded(id).codec == pcBif
+    compacted.close()
+    removeDir(dir)
+
   test "locate は決定論的で、未来も計算できる":
     var db = open(nodes = 8)
     let id = db.put("x", ring = "logs")
@@ -249,6 +290,32 @@ suite "public api":
     check resumed2.universeSyncEvents().len == 0
     resumed2.close()
 
+    removeDir(srcDir)
+    removeDir(dstDir)
+
+  test "universe sync preserves an opaque payload codec":
+    let srcDir = createTempDir("roche-universe", "codec-src")
+    let dstDir = createTempDir("roche-universe", "codec-dst")
+    var src = open(dataDir = srcDir)
+    discard src.enqueueUniverseSyncEvent(
+      sourceUniverse = "tokyo",
+      sourceGalaxy = "models",
+      ring = "artifacts/nif",
+      payload = "(object (name RocheDB))",
+      codec = pcNif,
+      logicalKey = "artifact-1")
+    src.close()
+
+    var resumed = open(dataDir = srcDir)
+    let event = resumed.universeSyncEvents()[0]
+    check event.codec == pcNif
+    var dst = open(dataDir = dstDir)
+    check dst.applyUniverseSyncEvent(event)
+    let item = dst.listByRing("artifacts/nif", limit = 1).items[0]
+    check item.codec == pcNif
+    check item.payload == "(object (name RocheDB))"
+    resumed.close()
+    dst.close()
     removeDir(srcDir)
     removeDir(dstDir)
 
@@ -868,6 +935,20 @@ suite "transaction":
     var db2 = open(dataDir = dir)
     check db2.get(id) == "inside tx"
     db2.close()
+    removeDir(dir)
+
+  test "transaction preserves payload codec across WAL replay":
+    let dir = createTempDir("rochedb", "tx-codec")
+    var db = open(dataDir = dir)
+    let tx = db.beginTransaction()
+    let id = tx.put(encodedPayload("\x01\x02\x03", pcBif), ring = "binary")
+    tx.commit()
+    check db.getEncoded(id).codec == pcBif
+    db.close()
+
+    var reopened = open(dataDir = dir)
+    check reopened.getEncoded(id) == encodedPayload("\x01\x02\x03", pcBif)
+    reopened.close()
     removeDir(dir)
 
   test "rollback した書き込みは見えない":

--- a/tests/tapi.nim
+++ b/tests/tapi.nim
@@ -27,6 +27,8 @@ suite "public api":
     check db.query(jsonId, prepared) == %*{"title": "RocheDB"}
     expect ValueError:
       discard db.query(nifId, prepared)
+    expect ValueError:
+      discard db.query(bifId, prepared)
     db.close()
 
   test "ring payload profile persists and can drive explicit writes":
@@ -177,6 +179,52 @@ suite "public api":
     check readPaged.pagination == rpOn
     check readPaged.page == 2
     check readPaged.pageLimit == 2
+
+    let raw0 = ids[0].toRaw()
+    let raw0Text = $raw0.parent & ":" & $raw0.epoch & ":" &
+      $raw0.seq & ":" & $raw0.tWrite
+    let readById = db.readRing("users", RocheReadOptions(
+      filter: %*{"id": raw0Text},
+      limit: 10))
+    check readById.count == 1
+    check readById.items[0].id == ids[0]
+
+    let readMissing = db.readRing("users", RocheReadOptions(
+      filter: %*{"name": "missing"},
+      limit: 10))
+    check readMissing.count == 0
+    check readMissing.items.len == 0
+
+    let readAlias = db.readRing("users", RocheReadOptions(
+      filter: newJObject(),
+      limit: 2,
+      sortField: "write",
+      sortDirection: rsDesc))
+    check readAlias.sortField == "time"
+    check readAlias.sortDirection == rsDesc
+    check readAlias.items.len == 2
+
+    let readDefaulted = db.readRing("users", RocheReadOptions(
+      filter: newJObject(),
+      limit: 0,
+      pageLimit: 0,
+      page: 0))
+    check readDefaulted.page == 1
+    check readDefaulted.pageLimit == 100
+    check readDefaulted.items.len == 3
+
+    expect ValueError:
+      discard db.readRing("users", RocheReadOptions(
+        filter: newJObject(),
+        limit: 10,
+        sortField: "unsupported"))
+
+    let bifDoc = db.put(encodedPayload("\x01\x02\x03", pcBif), ring = "binary")
+    check db.getEncoded(bifDoc).codec == pcBif
+    expect ValueError:
+      discard db.readRing("binary", RocheReadOptions(
+        selection: "{ title }",
+        limit: 1))
 
     db.update(ids[0], %*{"name": "a2", "meta": {"n": 10}})
     check db.query(ids[0], "{ name }") == %*{"name": "a2"}

--- a/tests/tcluster_tx.nim
+++ b/tests/tcluster_tx.nim
@@ -41,6 +41,19 @@ suite "cluster transaction":
     check narrowed[0].payload == "ret-ai-1"
     db.close()
 
+  test "cluster transaction preserves payload codec through owner apply":
+    let peers = getEnv("ROCHE_TEST_PEERS", "127.0.0.1:7411,127.0.0.1:7412,127.0.0.1:7413")
+    var db = connect(peers)
+    let tx = db.beginTransaction()
+    let id = tx.put(encodedPayload("(object (kind artifact))", pcNif),
+                    ring = "cluster-codec", vec = @[0.0'f32, 1.0'f32])
+    tx.commit(wamApplied)
+    check db.getEncoded(id) == encodedPayload("(object (kind artifact))", pcNif)
+    let hits = db.retrieve(@[0.0'f32, 1.0'f32], ring = "cluster-codec", budget = 1)
+    check hits.len == 1
+    check hits[0].codec == pcNif
+    db.close()
+
   test "cluster update/delete/list/count は landing intent 経由で反映される":
     let peers = getEnv("ROCHE_TEST_PEERS", "127.0.0.1:7411,127.0.0.1:7412,127.0.0.1:7413")
     var db = connect(peers)

--- a/tests/tcluster_wire_fuzz.nim
+++ b/tests/tcluster_wire_fuzz.nim
@@ -50,6 +50,8 @@ suite "cluster wire fuzz":
                payload: "allowed"),
       FuzzCase(name: "huge-vector", header: "PUTR 7 0 999999999",
                payload: "allowed"),
+      FuzzCase(name: "unknown-codec", header: "PUTR 7 0 0 executable",
+               payload: "allowed"),
       FuzzCase(name: "short-put", header: "PUT"),
       FuzzCase(name: "huge-put-payload", header: "PUT 1 60 0 999999999 0"),
       FuzzCase(name: "negative-put-payload", header: "PUT 1 60 0 -1 0"),
@@ -70,6 +72,7 @@ suite "cluster wire fuzz":
       FuzzCase(name: "short-applytx", header: "APPLYTX"),
       FuzzCase(name: "short-trf", header: "TRF"),
       FuzzCase(name: "unknown-command", header: "WHAT_IS_THIS 1 2 3"),
+      FuzzCase(name: "bad-codec-negotiation", header: "CODECMETA MAYBE"),
       FuzzCase(name: "truncated-txcommit", header: "TXCOMMIT 1 1",
                closeAfterSend: true)
     ]

--- a/tests/tselect.nim
+++ b/tests/tselect.nim
@@ -40,3 +40,11 @@ suite "selection":
     expect ValueError: discard parseSelection("title")
     expect ValueError: discard parseSelection("{ title")
     expect ValueError: discard parseSelection("{ a } b")
+
+  test "prepared selection is validated once and reusable":
+    let prepared = prepareSelection("{ title author { name } }")
+    check prepared.source == "{ title author { name } }"
+    check applySelection(prepared, doc) ==
+      %*{"title": "t", "author": {"name": "n"}}
+    expect ValueError:
+      discard prepareSelection("{ title } trailing")

--- a/tests/tstore.nim
+++ b/tests/tstore.nim
@@ -18,6 +18,27 @@ suite "store persistence":
     st2.close()
     removeDir(dir)
 
+  test "payload codec survives WAL replay while legacy records default to raw":
+    let dir = createTempDir("roche-store", "payload-codec")
+    var st = openStore(dir)
+    st.upsert Particle(parent: 12'u64, seq: 0'u32, period: 60.0, head: 0.0,
+                       tWrite: 1.0, payload: "(object (name RocheDB))",
+                       codec: pcNif)
+    st.close()
+
+    var restored = openStore(dir)
+    check restored.items[(12'u64, 0'u32)].codec == pcNif
+    restored.close()
+    removeDir(dir)
+
+    let legacyDir = createTempDir("roche-store", "legacy-payload-codec")
+    writeFile(legacyDir / "roche.log",
+              "P 13 0 60.0 0.0 1.0 5 0\nhello\n")
+    var legacy = openStore(legacyDir)
+    check legacy.items[(13'u64, 0'u32)].codec == pcRaw
+    legacy.close()
+    removeDir(legacyDir)
+
   test "Forwarder は F レコードで復元される":
     let dir = createTempDir("roche-store", "fwd")
     var st = openStore(dir)

--- a/tests/twire_driver.nim
+++ b/tests/twire_driver.nim
@@ -3,7 +3,7 @@
 ## Starts a small local roched cluster and verifies that drivers can use
 ## ring names without knowing ringKey/period/head derivation rules.
 
-import std/[os, osproc, unittest]
+import std/[net, os, osproc, strutils, unittest]
 import ../src/roche/[core, wire]
 
 proc startNode(id: int, peers: string): Process =
@@ -38,26 +38,51 @@ suite "driver wire protocol":
     var c = newClusterClient(ps)
     try:
       check c.waitCluster(ps.len)
+      check c.codecsReq(0) == @[pcRaw, pcJson, pcNif, pcBif]
 
       let first = c.putRingReq(0, "japan/tokyo",
                                """{"title":"Tokyo","country":"JP"}""",
-                               @[1.0'f32, 0.0'f32])
+                               @[1.0'f32, 0.0'f32], pcJson)
       let tbl = ArcTable(epoch: first.epoch, nNodes: uint16(ps.len))
       let owner = int(tbl.owner(first.head))
       let nonOwner = (owner + 1) mod ps.len
 
       let id = c.putRingReq(nonOwner, "japan/tokyo",
                             """{"title":"Shinjuku","country":"JP"}""",
-                            @[0.95'f32, 0.05'f32])
+                            @[0.95'f32, 0.05'f32], pcJson)
       check int(tbl.owner(id.head)) == owner
 
       let got = c.getIdReq(nonOwner, id)
       check got.found
       check got.value == """{"title":"Shinjuku","country":"JP"}"""
+      check got.codec == pcJson
+
+      var legacy = newSocket()
+      legacy.connect(ps[owner].host, Port(ps[owner].port))
+      legacy.sendFrame("GETID " & $id.parent & " " & $id.epoch & " " &
+                       $id.seq & " " & $id.tWrite & " " & $id.period & " " &
+                       $id.head)
+      let legacyHeader = legacy.readHeader()
+      check legacyHeader.len == 3
+      check legacyHeader[0] == "VAL"
+      discard legacy.readExact(parseInt(legacyHeader[2]))
+      legacy.close()
 
       let projected = c.queryIdReq(nonOwner, id, "{ title }")
       check projected.found
       check projected.value == """{"title":"Shinjuku"}"""
+      check projected.codec == pcJson
+
+      # Repeated projections exercise the server's bounded compiled-selection cache.
+      let projectedAgain = c.queryIdReq(owner, id, "{ title }")
+      check projectedAgain.value == projected.value
+
+      let bif = c.putRingReq(0, "japan/tokyo", "\x01\x00\x00\x00", @[], pcBif)
+      let bifGot = c.getIdReq(0, bif)
+      check bifGot.found
+      check bifGot.codec == pcBif
+      expect ValueError:
+        discard c.queryIdReq(0, bif, "{ title }")
     finally:
       c.close()
       for p in procs:


### PR DESCRIPTION
## Summary
- expose C ABI v2 ring reads through roche_read_ring_json
- unify ring-oriented CLI read result shape and document codec workflows
- expand embedded API, CLI, C ABI, cluster, recovery, and universe sync coverage documentation
- bump RocheDB package metadata to v0.3.0

## Verification
- scripts/test_core.sh
- scripts/cli_crud_smoke.sh
- scripts/test_all_smoke.sh
- C ABI shared-library build
- gcc examples/cabi_contract.c ...
- LD_LIBRARY_PATH=lib bin/cabi_contract
- nimble check
- git diff --check