### PR TITLE
feat: add TLS transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ corpus size toward semantic working-set size.
 - FAISS versioning policy: [docs/faiss-versioning.md](docs/faiss-versioning.md)
 - Vector backend selection: [docs/vector-backends.md](docs/vector-backends.md)
 - Protocol compatibility: [docs/protocol-compatibility.md](docs/protocol-compatibility.md)
+- TLS transport: [docs/tls-transport.md](docs/tls-transport.md)
 - Payload codecs and prepared selections: [docs/payload-codecs.md](docs/payload-codecs.md)
 - Universe sync: [docs/universe-sync.md](docs/universe-sync.md)
 - Threat model: [docs/threat-model.md](docs/threat-model.md)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -58,6 +58,10 @@ bin/roche --help
 | `--auth-token=TEXT` | Token-style auth. |
 | `--secret-key=TEXT` | Secret-key gate. |
 | `--galaxy=NAME` | Expected remote galaxy. |
+| `--tls` | Use standard TLS for the TCP transport. Requires TLS-enabled binaries built with `-d:ssl`. |
+| `--tls-ca=FILE` | CA/self-signed PEM file for server certificate verification. |
+| `--tls-server-name=NAME` | Optional hostname override for TLS verification and SNI. |
+| `--tls-insecure-skip-verify` | Skip certificate verification for local smoke tests only. |
 | `--metrics` | Emit key/value metrics where supported. |
 
 ## Cluster Commands

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -26,6 +26,10 @@ full reference in [Topology Configuration](topology-config.md).
 | `authToken` | string | `""` | Token-style auth convenience path. |
 | `secretKey` | string | `""` | Additional secret-key gate and encrypted auth transport. |
 | `galaxy` | string | `""` | Expected remote galaxy name. |
+| `tls` | bool | `false` | Use standard TLS for the TCP transport. Requires binaries built with `-d:ssl`. |
+| `tlsCaFile` | string | `""` | CA/self-signed PEM file for server certificate verification. |
+| `tlsServerName` | string | `""` | Optional hostname override for TLS verification and SNI. |
+| `tlsInsecureSkipVerify` | bool | `false` | Skip certificate verification for local smoke tests only. |
 
 ## `roched` Server Flags
 
@@ -39,6 +43,10 @@ full reference in [Topology Configuration](topology-config.md).
 | `--user=NAME` / `--password=TEXT` | Basic username/password gate. |
 | `--secret-key=TEXT` | Secret-key gate and secure auth transport. |
 | `--auth-token=TEXT` | Token-style auth convenience path. |
+| `--tls-cert=FILE` / `--tls-key=FILE` | Enable standard TLS for the TCP listener. Requires `-d:ssl`. |
+| `--tls-ca=FILE` | CA/self-signed PEM file used by the server's peer client. |
+| `--tls-server-name=NAME` | Optional hostname override for peer TLS verification and SNI. |
+| `--tls-insecure-skip-verify` | Skip peer certificate verification for local smoke tests only. |
 | `--galaxy=NAME` | Galaxy identity expected by clients. |
 | `--allow-ring=PREFIX[,PREFIX...]` | Ring-prefix authorization boundary. |
 | `--role=user:password:reader|writer|admin[:prefixes]` | Role and optional ring-prefix policy. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,7 @@ downstream AI/RAG or application logic.
 - [Driver Installation](driver-installation.md)
 - [Driver / FFI Roadmap](rochedb-driver-roadmap.md)
 - [Protocol Compatibility](protocol-compatibility.md)
+- [TLS Transport](tls-transport.md)
 - [Payload Codecs](payload-codecs.md)
 - [Vector Backend Selection](vector-backends.md)
 - [FAISS Versioning Policy](faiss-versioning.md)

--- a/docs/protocol-compatibility.md
+++ b/docs/protocol-compatibility.md
@@ -64,7 +64,7 @@ RocheDB has username/password/secret-key auth, ring-prefix authorization, simple
 RBAC, and deterministic wire fuzz smoke tests. For enterprise production claims,
 the remaining gaps are still material:
 
-- TLS and certificate rotation for untrusted networks;
+- certificate issuance, rotation, and expiry monitoring for TLS deployments;
 - richer role policy and audit logs;
 - cluster transaction coordinator redundancy;
 - explicit mixed-version upgrade tests for wire, WAL, snapshots, and drivers.

--- a/docs/rochedb-status.de.md
+++ b/docs/rochedb-status.de.md
@@ -51,7 +51,7 @@ Release checklist: [release-checklist.md](./release-checklist.md)
 | Authz / RBAC | PoC | Ring prefix authz and role matrix smoke |
 | Wire fuzz smoke | Done | Malformed frame cases |
 | Dynamic membership | Planned | Current peer list is static |
-| TLS | Planned | Required for public-network deployments |
+| TLS | Done | Standard TLS transport is implemented; see the English canonical document for details |
 
 ## Drivers / Bindings
 
@@ -60,14 +60,14 @@ Release checklist: [release-checklist.md](./release-checklist.md)
 | Nim API | Done | Native public API |
 | C ABI | Done | ABI version / last error / put/get/retrieve/batch/atlas |
 | Python | Done | Native wire minimal |
-| Node.js / TypeScript / Bun | Partially published | npm `rochedb` v0.1.2. Bun remains experimental |
+| Node.js / TypeScript / Bun | Partially published | npm `rochedb` v0.1.3. Bun remains experimental |
 | Rust | Published | crates.io `rochedb` v0.1.3; see the English canonical document for links |
 | Go | Done | C ABI wrapper minimal |
 | PHP / Swift / Kotlin | Done | Docker smoke available |
 | C# / C++ | Done | OSS generic wrappers; Unity / Unreal official assets are separate candidates |
 | React Native / WASM | Post-v0.1 candidate | Browser / local state boundary |
 | Driver discovery CLI | Done | `roche driver list/info/install` prints official driver metadata and setup commands without executing remote scripts |
-| Package publishing | Partial | `nimble install rochedb`, `cargo add rochedb`, and `npm install rochedb` are available. Other registries remain future work |
+| Package publishing | Partial | `nimble install rochedb`, `cargo add rochedb`, `npm install rochedb`, `composer require rochedb/rochedb`, and `python3 -m pip install rochedb` are available. Other registries remain future work |
 
 ## Benchmarks / Demos
 

--- a/docs/rochedb-status.fr.md
+++ b/docs/rochedb-status.fr.md
@@ -51,7 +51,7 @@ Release checklist: [release-checklist.md](./release-checklist.md)
 | Authz / RBAC | PoC | Ring prefix authz and role matrix smoke |
 | Wire fuzz smoke | Done | Malformed frame cases |
 | Dynamic membership | Planned | Current peer list is static |
-| TLS | Planned | Required for public-network deployments |
+| TLS | Done | Standard TLS transport is implemented; see the English canonical document for details |
 
 ## Drivers / Bindings
 
@@ -60,14 +60,14 @@ Release checklist: [release-checklist.md](./release-checklist.md)
 | Nim API | Done | Native public API |
 | C ABI | Done | ABI version / last error / put/get/retrieve/batch/atlas |
 | Python | Done | Native wire minimal |
-| Node.js / TypeScript / Bun | Partially published | npm `rochedb` v0.1.2. Bun remains experimental |
+| Node.js / TypeScript / Bun | Partially published | npm `rochedb` v0.1.3. Bun remains experimental |
 | Rust | Published | crates.io `rochedb` v0.1.3; see the English canonical document for links |
 | Go | Done | C ABI wrapper minimal |
 | PHP / Swift / Kotlin | Done | Docker smoke available |
 | C# / C++ | Done | OSS generic wrappers; Unity / Unreal official assets are separate candidates |
 | React Native / WASM | Post-v0.1 candidate | Browser / local state boundary |
 | Driver discovery CLI | Done | `roche driver list/info/install` prints official driver metadata and setup commands without executing remote scripts |
-| Package publishing | Partial | `nimble install rochedb`, `cargo add rochedb`, and `npm install rochedb` are available. Other registries remain future work |
+| Package publishing | Partial | `nimble install rochedb`, `cargo add rochedb`, `npm install rochedb`, `composer require rochedb/rochedb`, and `python3 -m pip install rochedb` are available. Other registries remain future work |
 
 ## Benchmarks / Demos
 

--- a/docs/rochedb-status.ja.md
+++ b/docs/rochedb-status.ja.md
@@ -50,7 +50,7 @@
 | Authz / RBAC | PoC | ring prefix authz と role matrix smoke |
 | Wire fuzz smoke | 完了 | malformed frame cases |
 | Dynamic membership | 予定 | 現在は static peers |
-| TLS | 予定 | public network では必須 |
+| TLS | 完了 | 標準TLS transportを実装済み。詳細は英語正本を参照 |
 
 ## Drivers / Bindings
 
@@ -59,14 +59,14 @@
 | Nim API | 完了 | Native public API |
 | C ABI | 完了 | ABI version / last error / put/get/retrieve/batch/atlas |
 | Python | 完了 | Native wire minimal |
-| Node.js / TypeScript / Bun | 一部公開済み | npm `rochedb` v0.1.2。Bun は実験的 |
+| Node.js / TypeScript / Bun | 一部公開済み | npm `rochedb` v0.1.3。Bun は実験的 |
 | Rust | 公開済み | crates.io `rochedb` v0.1.3。詳細は英語正本を参照 |
 | Go | 完了 | C ABI wrapper minimal |
 | PHP / Swift / Kotlin | 完了 | Docker smoke あり |
 | C# / C++ | 完了 | OSS generic wrappers。Unity / Unreal 公式 asset は別候補 |
 | React Native / WASM | v0.1 後の候補 | Browser / local state boundary |
 | Driver discovery CLI | 完了 | `roche driver list/info/install` が公式 driver metadata と setup command を表示。remote script は実行しない |
-| Package publishing | 一部完了 | `nimble install rochedb`, `cargo add rochedb`, `npm install rochedb` が利用可能。その他のレジストリは今後 |
+| Package publishing | 一部完了 | `nimble install rochedb`, `cargo add rochedb`, `npm install rochedb`, `composer require rochedb/rochedb`, `python3 -m pip install rochedb` が利用可能。その他のレジストリは今後 |
 
 ## Benchmarks / Demos
 

--- a/docs/rochedb-status.ko.md
+++ b/docs/rochedb-status.ko.md
@@ -50,7 +50,7 @@ Release checklist: [release-checklist.md](./release-checklist.md)
 | Authz / RBAC | PoC | Ring prefix authz and role matrix smoke |
 | Wire fuzz smoke | Done | Malformed frame cases |
 | Dynamic membership | Planned | Current peer list is static |
-| TLS | Planned | Required for public-network deployments |
+| TLS | Done | Standard TLS transport is implemented; see the English canonical document for details |
 
 ## Drivers / Bindings
 
@@ -59,14 +59,14 @@ Release checklist: [release-checklist.md](./release-checklist.md)
 | Nim API | Done | Native public API |
 | C ABI | Done | ABI version / last error / put/get/retrieve/batch/atlas |
 | Python | Done | Native wire minimal |
-| Node.js / TypeScript / Bun | Partially published | npm `rochedb` v0.1.2. Bun remains experimental |
+| Node.js / TypeScript / Bun | Partially published | npm `rochedb` v0.1.3. Bun remains experimental |
 | Rust | Published | crates.io `rochedb` v0.1.3; see the English canonical document for links |
 | Go | Done | C ABI wrapper minimal |
 | PHP / Swift / Kotlin | Done | Docker smoke available |
 | C# / C++ | Done | OSS generic wrappers; Unity / Unreal official assets are separate candidates |
 | React Native / WASM | Post-v0.1 candidate | Browser / local state boundary |
 | Driver discovery CLI | Done | `roche driver list/info/install` prints official driver metadata and setup commands without executing remote scripts |
-| Package publishing | Partial | `nimble install rochedb`, `cargo add rochedb`, and `npm install rochedb` are available. Other registries remain future work |
+| Package publishing | Partial | `nimble install rochedb`, `cargo add rochedb`, `npm install rochedb`, `composer require rochedb/rochedb`, and `python3 -m pip install rochedb` are available. Other registries remain future work |
 
 ## Benchmarks / Demos
 

--- a/docs/rochedb-status.md
+++ b/docs/rochedb-status.md
@@ -65,7 +65,7 @@ Translations:
 | Driver-friendly wire | Done | `PUTR/GETID/QRYID`; `WIREVER` exposes the current protocol version and `CODECS` exposes payload formats. Compatibility policy is documented in `docs/protocol-compatibility.md` |
 | Health / metrics / rings | Done | CLI and wire protocol; metrics include uptime, request/error/auth counters, connection counts, WAL bytes, warp backlog, universe apply counters, cluster tx backlog, and storage/ring counts |
 | Authn + secret key | Done | username/password/secret-key |
-| TLS | Planned | Required for public-network deployments |
+| TLS | Done | Standard TLS transport for `roched` and CLI/client connections when built with `-d:ssl`; `scripts/cluster_tls_smoke.sh` covers authenticated TLS, secret-key transport, JSON put/get, and plain-client rejection |
 | Authz / RBAC | PoC | `roched --allow-ring=prefix[,prefix...]` and `--role=user:password:reader|writer|admin[:prefixes]`; `scripts/cluster_authz_smoke.sh` and `scripts/cluster_rbac_smoke.sh` cover prefix and role matrix behavior |
 | Wire fuzz smoke | Done | `scripts/cluster_wire_fuzz_smoke.sh` runs deterministic malformed-frame cases, including oversized headers, and verifies the cluster stays healthy |
 | Dynamic membership / epoch migration | Planned | Current peer list is static |
@@ -124,7 +124,7 @@ Translations:
 | Secret key gate | Done | ID/password alone can be insufficient |
 | nimsodium encryption primitive | Partial | Used for auth transport; scope may expand |
 | Galaxy isolation | Done | Limits blast radius by galaxy |
-| TLS | Planned | Required for public-network deployments |
+| TLS | Done | Standard TCP transport TLS is implemented for `-d:ssl` builds; certificate rotation and managed CA workflows remain operational work |
 | Ring/galaxy authz | PoC | Ring prefix authorization is implemented for named-ring wire operations; richer role policy is pending |
 | Backup encryption | Done | `backupEncrypted` / `restoreEncryptedBackup` and `roche backup-encrypted` / `restore-encrypted` use nimsodium secretbox |
 | General audit log | Planned | Full append-only access/change audit for enterprise / regulated workloads. Warp jobs already persist attempts / retryAt / ack / dead-letter state, but that is job state, not a database-wide audit log |

--- a/docs/rochedb-status.zh.md
+++ b/docs/rochedb-status.zh.md
@@ -50,7 +50,7 @@ Release checklist: [release-checklist.md](./release-checklist.md)
 | Authz / RBAC | PoC | Ring prefix authz and role matrix smoke |
 | Wire fuzz smoke | Done | Malformed frame cases |
 | Dynamic membership | Planned | Current peer list is static |
-| TLS | Planned | Required for public-network deployments |
+| TLS | Done | Standard TLS transport is implemented; see the English canonical document for details |
 
 ## Drivers / Bindings
 
@@ -59,14 +59,14 @@ Release checklist: [release-checklist.md](./release-checklist.md)
 | Nim API | Done | Native public API |
 | C ABI | Done | ABI version / last error / put/get/retrieve/batch/atlas |
 | Python | Done | Native wire minimal |
-| Node.js / TypeScript / Bun | Partially published | npm `rochedb` v0.1.2. Bun remains experimental |
+| Node.js / TypeScript / Bun | Partially published | npm `rochedb` v0.1.3. Bun remains experimental |
 | Rust | Published | crates.io `rochedb` v0.1.3; see the English canonical document for links |
 | Go | Done | C ABI wrapper minimal |
 | PHP / Swift / Kotlin | Done | Docker smoke available |
 | C# / C++ | Done | OSS generic wrappers; Unity / Unreal official assets are separate candidates |
 | React Native / WASM | Post-v0.1 candidate | Browser / local state boundary |
 | Driver discovery CLI | Done | `roche driver list/info/install` prints official driver metadata and setup commands without executing remote scripts |
-| Package publishing | Partial | `nimble install rochedb`, `cargo add rochedb`, and `npm install rochedb` are available. Other registries remain future work |
+| Package publishing | Partial | `nimble install rochedb`, `cargo add rochedb`, `npm install rochedb`, `composer require rochedb/rochedb`, and `python3 -m pip install rochedb` are available. Other registries remain future work |
 
 ## Benchmarks / Demos
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -16,6 +16,7 @@ matrix used before releases.
 | CLI embedded usage | `scripts/cli_crud_smoke.sh` | Smoke-covered: help, put/get/query/list/count, readRing options, codec display, ring profile auto codec, shell, auth error text |
 | C ABI | `examples/cabi_contract.c`, `scripts/driver_compat.sh` | Contract-covered: ABI version, put/get, codec metadata, read ring page shape, validation errors, atlas |
 | Wire protocol | `tests/twire_driver.nim`, `scripts/cluster_wire_fuzz_smoke.sh` | Smoke-covered: driver-facing PUTR/GETID/QRYID, codec metadata negotiation, malformed frame behavior |
+| TLS transport | `scripts/cluster_tls_smoke.sh` | Smoke-covered: TLS-enabled `roched`/CLI build, authenticated TLS health, secret-key auth transport, JSON put/get, and plain-client rejection |
 | Cluster transactions | `tests/tcluster_tx.nim`, `scripts/cluster_tx_smoke.sh` | Smoke-covered: landing intent, apply retry, basic owner failure path |
 | Cluster auth / RBAC | `tests/tcluster_authz.nim`, `tests/tcluster_rbac.nim`, related scripts | Smoke-covered: username/password/secret key and role/ring-prefix authorization |
 | Cluster failure | `tests/tcluster_failure.nim`, `scripts/cluster_failure_smoke.sh` | Smoke-covered: owner restart and retry boundaries |
@@ -54,4 +55,3 @@ than hidden assumptions:
 - TLS deployment tests once transport TLS is added;
 - larger universe sync replay and backlog-pressure tests;
 - driver matrix CI across all published language repositories.
-

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -61,12 +61,16 @@ drivers.
   `scripts/cluster_wire_fuzz_smoke.sh`.
 - Core and cluster smoke entry points are available through
   `scripts/test_core.sh` and `scripts/test_all_smoke.sh`.
-- nimsodium secretbox for auth transport and encrypted backups.
+- Standard TLS for TCP transport when `roched` and clients are built with
+  `-d:ssl`.
+- nimsodium secretbox for secret-key auth transport and encrypted backups.
 - Galaxy binding in persistent data directories.
 
 ## Known Gaps
 
-- TLS is not implemented. Do not expose `roched` directly on untrusted networks.
+- TLS is implemented for `roched` TCP transport, but production deployments
+  still need certificate issuance, rotation, expiry monitoring, and policy
+  management.
 - Rich role policies are intentionally not implemented. RocheDB's primary
   isolation model is galaxy separation plus ring-prefix scope; roles are kept
   minimal for read/write/admin separation.

--- a/docs/tls-transport.md
+++ b/docs/tls-transport.md
@@ -1,0 +1,90 @@
+# TLS Transport
+
+RocheDB supports standard TLS for `roched` TCP connections when the server and
+client are built with Nim's SSL support:
+
+```sh
+nim c -d:ssl -d:release -o:src/roched src/roched.nim
+nim c -d:ssl -d:release -o:src/rochecli src/rochecli.nim
+```
+
+TLS is a transport layer. It is separate from RocheDB's username/password
+authentication, secret-key challenge response, and libsodium-backed secure frame
+mode. They can be combined:
+
+```text
+TCP -> TLS -> RocheDB wire protocol -> AUTH / AUTHCHAL -> optional secure frames
+```
+
+For public or VPC deployments, prefer TLS plus username/password plus
+`--secret-key`.
+
+## Server
+
+Start `roched` with a certificate and private key:
+
+```sh
+src/roched \
+  --id=0 \
+  --peers=127.0.0.1:7301 \
+  --data=/var/lib/rochedb \
+  --user=alice \
+  --password=change-me \
+  --secret-key=change-me-too \
+  --tls-cert=/etc/rochedb/server.crt \
+  --tls-key=/etc/rochedb/server.key \
+  --tls-ca=/etc/rochedb/ca.crt
+```
+
+`--tls-ca`, `--tls-server-name`, and `--tls-insecure-skip-verify` are used by
+the server's own peer client for cluster handoff and maintenance requests. In a
+single-node local smoke test they are less important; in a TLS cluster they
+should match the peer certificate policy.
+
+## CLI Client
+
+Use `--tls` to connect to a TLS-enabled `roched`:
+
+```sh
+src/rochecli health \
+  --peers=127.0.0.1:7301 \
+  --user=alice \
+  --password=change-me \
+  --secret-key=change-me-too \
+  --tls \
+  --tls-ca=/etc/rochedb/ca.crt
+```
+
+For local self-signed experiments only:
+
+```sh
+src/rochecli health \
+  --peers=127.0.0.1:7301 \
+  --user=alice \
+  --password=change-me \
+  --secret-key=change-me-too \
+  --tls \
+  --tls-insecure-skip-verify
+```
+
+Do not use `--tls-insecure-skip-verify` for production deployments.
+
+## C ABI
+
+The C ABI exposes `roche_connect_auth_tls` for native drivers and FFI wrappers.
+The existing `roche_connect` and `roche_connect_auth` entry points remain
+available for non-TLS and backward-compatible use.
+
+## Smoke Test
+
+The TLS smoke test builds TLS-enabled binaries, generates a short-lived
+self-signed certificate, starts `roched`, verifies authenticated TLS health,
+writes and reads JSON over TLS, and confirms that a plain TCP client cannot talk
+to the TLS listener:
+
+```sh
+scripts/cluster_tls_smoke.sh
+```
+
+This test opens a local TCP listener. In restricted sandboxes it may need to run
+outside the sandbox.

--- a/include/rochedb.h
+++ b/include/rochedb.h
@@ -88,6 +88,23 @@ void  *roche_connect_auth(const char *peers,
                           const char *auth_token,
                           const char *secret_key,
                           const char *galaxy);
+/* TLS-aware authenticated cluster connection. `tls` enables standard TLS over
+ * TCP when the RocheDB core library is built with -d:ssl.
+ *
+ * tls_ca_file may point to a CA/self-signed certificate PEM file.
+ * tls_server_name overrides hostname verification / SNI.
+ * tls_insecure_skip_verify is intended only for local smoke tests.
+ */
+void  *roche_connect_auth_tls(const char *peers,
+                              const char *username,
+                              const char *password,
+                              const char *auth_token,
+                              const char *secret_key,
+                              const char *galaxy,
+                              int tls,
+                              const char *tls_ca_file,
+                              const char *tls_server_name,
+                              int tls_insecure_skip_verify);
 void   roche_close(void *db);
 
 /* DB 時計（PoC は決定論のため手動クロック）。 */

--- a/scripts/cluster_tls_smoke.sh
+++ b/scripts/cluster_tls_smoke.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+DATA="${TMPDIR:-/tmp}/rochedb-cluster-tls-smoke-$$"
+PEERS="127.0.0.1:17651"
+CERT="$DATA/server.crt"
+KEY="$DATA/server.key"
+LOG="$DATA/roched.log"
+PID=""
+
+cleanup() {
+  if [ -n "${PID:-}" ]; then
+    kill "$PID" >/dev/null 2>&1 || true
+    wait "$PID" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$DATA"
+}
+trap cleanup EXIT
+
+mkdir -p "$DATA/node0"
+
+echo "[cluster-tls] generate self-signed test certificate"
+openssl req -x509 -nodes -newkey rsa:2048 -days 1 \
+  -keyout "$KEY" \
+  -out "$CERT" \
+  -subj "/CN=localhost" \
+  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" >/dev/null 2>&1
+
+echo "[cluster-tls] build TLS-enabled roched"
+nim c -d:ssl -d:release --nimcache:/tmp/nimcache_roched_tls \
+  -o:src/roched src/roched.nim >/dev/null
+
+echo "[cluster-tls] build TLS-enabled roche CLI"
+nim c -d:ssl -d:release --nimcache:/tmp/nimcache_rochecli_tls \
+  -o:src/rochecli src/rochecli.nim >/dev/null
+
+echo "[cluster-tls] start TLS roched on $PEERS"
+src/roched --id=0 --peers="$PEERS" --data="$DATA/node0" \
+  --user=alice --password=secret --secret-key=shared-secret \
+  --tls-cert="$CERT" --tls-key="$KEY" --tls-ca="$CERT" \
+  --slow-tick=0.05 >"$LOG" 2>&1 &
+PID=$!
+
+for _ in $(seq 1 60); do
+  if src/rochecli health --peers="$PEERS" --user=alice --password=secret \
+      --secret-key=shared-secret --tls --tls-ca="$CERT" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.1
+done
+
+echo "[cluster-tls] health over TLS"
+src/rochecli health --peers="$PEERS" --user=alice --password=secret \
+  --secret-key=shared-secret --tls --tls-ca="$CERT"
+
+echo "[cluster-tls] put JSON over TLS"
+PUT_OUTPUT="$(src/rochecli put --peers="$PEERS" --user=alice --password=secret \
+  --secret-key=shared-secret --tls --tls-ca="$CERT" \
+  --ring=secure/demo --codec=json --payload='{"title":"tls smoke","ok":true}')"
+echo "$PUT_OUTPUT"
+RAW_ID="$(printf '%s\n' "$PUT_OUTPUT" | sed -n 's/.*rawId=\([^ ]*\).*/\1/p')"
+test -n "$RAW_ID"
+
+echo "[cluster-tls] get JSON over TLS"
+GET_OUTPUT="$(src/rochecli get --peers="$PEERS" --user=alice --password=secret \
+  --secret-key=shared-secret --tls --tls-ca="$CERT" \
+  --ring=secure/demo --filter="{\"id\":\"$RAW_ID\"}" --selection='{ title ok }')"
+echo "$GET_OUTPUT"
+printf '%s\n' "$GET_OUTPUT" | grep -q '"title": "tls smoke"'
+printf '%s\n' "$GET_OUTPUT" | grep -q '"ok": true'
+
+echo "[cluster-tls] plain client must not pass against TLS listener"
+if src/rochecli health --peers="$PEERS" --user=alice --password=secret \
+    --secret-key=shared-secret >/dev/null 2>&1; then
+  echo "plain client unexpectedly succeeded against TLS listener" >&2
+  exit 1
+fi
+
+echo "[cluster-tls] OK"

--- a/src/roche/wire.nim
+++ b/src/roche/wire.nim
@@ -128,6 +128,10 @@ type
     password: string
     secretKey: string
     galaxy: string
+    tls: bool
+    tlsCaFile: string
+    tlsServerName: string
+    tlsInsecureSkipVerify: bool
     codecMetadata: Table[int, bool]
 
   SecureState = object
@@ -147,12 +151,19 @@ proc parsePeers*(s: string): seq[Peer] =
 
 proc newClusterClient*(peers: seq[Peer], username: string = "",
                        password: string = "", authToken: string = "",
-                       secretKey: string = "", galaxy: string = ""): ClusterClient =
+                       secretKey: string = "", galaxy: string = "",
+                       tls: bool = false, tlsCaFile: string = "",
+                       tlsServerName: string = "",
+                       tlsInsecureSkipVerify: bool = false): ClusterClient =
   if authToken.len > 0 and username.len == 0:
     return ClusterClient(peers: peers, username: "token", password: authToken,
-                         secretKey: secretKey, galaxy: galaxy)
+                         secretKey: secretKey, galaxy: galaxy, tls: tls,
+                         tlsCaFile: tlsCaFile, tlsServerName: tlsServerName,
+                         tlsInsecureSkipVerify: tlsInsecureSkipVerify)
   ClusterClient(peers: peers, username: username, password: password,
-                secretKey: secretKey, galaxy: galaxy)
+                secretKey: secretKey, galaxy: galaxy, tls: tls,
+                tlsCaFile: tlsCaFile, tlsServerName: tlsServerName,
+                tlsInsecureSkipVerify: tlsInsecureSkipVerify)
 
 proc close*(c: ClusterClient) =
   for _, s in c.socks:
@@ -291,6 +302,14 @@ proc socketFor(c: ClusterClient, node: int): Socket =
   result = newSocket()
   result.connect(c.peers[node].host, Port(c.peers[node].port))
   result.setSockOpt(OptNoDelay, true, level = IPPROTO_TCP.cint)  # short request/response frames dominate
+  if c.tls:
+    when defined(ssl):
+      let verifyMode = if c.tlsInsecureSkipVerify: CVerifyNone else: CVerifyPeerUseEnvVars
+      let ctx = newContext(verifyMode = verifyMode, caFile = c.tlsCaFile)
+      let hostname = if c.tlsServerName.len > 0: c.tlsServerName else: c.peers[node].host
+      ctx.wrapConnectedSocket(result, handshakeAsClient, hostname)
+    else:
+      raise newException(IOError, "TLS support requires building RocheDB with -d:ssl")
   if c.username.len > 0:
     if c.secretKey.len > 0:
       result.sendFrame("AUTHCHAL " & c.username)

--- a/src/rochecli.nim
+++ b/src/rochecli.nim
@@ -241,10 +241,14 @@ proc parseHostPort(endpoint: string): tuple[host: string, port: int] =
     (host: endpoint, port: 6379)
 
 proc openCliDb(dataDir, peers, username, password, authToken, secretKey,
-               galaxy: string): RocheDb =
+               galaxy: string, tls: bool = false, tlsCaFile: string = "",
+               tlsServerName: string = "",
+               tlsInsecureSkipVerify: bool = false): RocheDb =
   if peers.len > 0:
     connect(peers, username = username, password = password,
-            authToken = authToken, secretKey = secretKey, galaxy = galaxy)
+            authToken = authToken, secretKey = secretKey, galaxy = galaxy,
+            tls = tls, tlsCaFile = tlsCaFile, tlsServerName = tlsServerName,
+            tlsInsecureSkipVerify = tlsInsecureSkipVerify)
   else:
     open(dataDir = dataDir)
 
@@ -432,9 +436,14 @@ proc redisPipeline(sock: Socket, commands: seq[seq[string]]): seq[string] =
   for _ in 0 ..< commands.len:
     result.add sock.readRedisReply()
 
-proc runDemo(peers, username, password, authToken, secretKey, galaxy: string) =
+proc runDemo(peers, username, password, authToken, secretKey, galaxy: string,
+             tls: bool, tlsCaFile, tlsServerName: string,
+             tlsInsecureSkipVerify: bool) =
   var db = connect(peers, username = username, password = password,
-                   authToken = authToken, secretKey = secretKey, galaxy = galaxy)
+                   authToken = authToken, secretKey = secretKey, galaxy = galaxy,
+                   tls = tls, tlsCaFile = tlsCaFile,
+                   tlsServerName = tlsServerName,
+                   tlsInsecureSkipVerify = tlsInsecureSkipVerify)
   db.configureRing("docs", 12.0)   # short demo period: one orbit per 12 seconds
   let id = db.put(%*{
     "title": "ephemeris-based placement",
@@ -482,9 +491,14 @@ proc pickStableRing(db: RocheDb, horizon: float): string =
   result = "bench"
   db.configureRing(result, max(3600.0, horizon * 10.0))
 
-proc runBench(peers, username, password, authToken, secretKey, galaxy: string, n: int) =
+proc runBench(peers, username, password, authToken, secretKey, galaxy: string,
+              tls: bool, tlsCaFile, tlsServerName: string,
+              tlsInsecureSkipVerify: bool, n: int) =
   var db = connect(peers, username = username, password = password,
-                   authToken = authToken, secretKey = secretKey, galaxy = galaxy)
+                   authToken = authToken, secretKey = secretKey, galaxy = galaxy,
+                   tls = tls, tlsCaFile = tlsCaFile,
+                   tlsServerName = tlsServerName,
+                   tlsInsecureSkipVerify = tlsInsecureSkipVerify)
   let ring = db.pickStableRing(horizon = 60.0)
   var payload = newString(100)
   for i in 0 ..< 100: payload[i] = char(ord('a') + i mod 26)
@@ -514,52 +528,80 @@ proc runBench(peers, username, password, authToken, secretKey, galaxy: string, n
   echo &"  query(server-side projection)     {qryUs:8.1f} µs/op  ({1e6 / qryUs:8.0f} ops/s)"
   db.close()
 
-proc runHealth(peers, username, password, authToken, secretKey, galaxy: string) =
+proc runHealth(peers, username, password, authToken, secretKey, galaxy: string,
+               tls: bool, tlsCaFile, tlsServerName: string,
+               tlsInsecureSkipVerify: bool) =
   var db = connect(peers, username = username, password = password,
-                   authToken = authToken, secretKey = secretKey, galaxy = galaxy)
+                   authToken = authToken, secretKey = secretKey, galaxy = galaxy,
+                   tls = tls, tlsCaFile = tlsCaFile,
+                   tlsServerName = tlsServerName,
+                   tlsInsecureSkipVerify = tlsInsecureSkipVerify)
   for line in db.health():
     echo line
   db.close()
 
-proc runMetrics(peers, username, password, authToken, secretKey, galaxy: string) =
+proc runMetrics(peers, username, password, authToken, secretKey, galaxy: string,
+                tls: bool, tlsCaFile, tlsServerName: string,
+                tlsInsecureSkipVerify: bool) =
   var db = connect(peers, username = username, password = password,
-                   authToken = authToken, secretKey = secretKey, galaxy = galaxy)
+                   authToken = authToken, secretKey = secretKey, galaxy = galaxy,
+                   tls = tls, tlsCaFile = tlsCaFile,
+                   tlsServerName = tlsServerName,
+                   tlsInsecureSkipVerify = tlsInsecureSkipVerify)
   for line in db.metrics():
     echo line
   db.close()
 
-proc runShutdown(peers, username, password, authToken, secretKey, galaxy: string) =
+proc runShutdown(peers, username, password, authToken, secretKey, galaxy: string,
+                 tls: bool, tlsCaFile, tlsServerName: string,
+                 tlsInsecureSkipVerify: bool) =
   var db = connect(peers, username = username, password = password,
-                   authToken = authToken, secretKey = secretKey, galaxy = galaxy)
+                   authToken = authToken, secretKey = secretKey, galaxy = galaxy,
+                   tls = tls, tlsCaFile = tlsCaFile,
+                   tlsServerName = tlsServerName,
+                   tlsInsecureSkipVerify = tlsInsecureSkipVerify)
   for line in db.shutdownCluster():
     echo line
   db.close()
 
-proc runRings(peers, username, password, authToken, secretKey, galaxy: string) =
+proc runRings(peers, username, password, authToken, secretKey, galaxy: string,
+              tls: bool, tlsCaFile, tlsServerName: string,
+              tlsInsecureSkipVerify: bool) =
   var db = connect(peers, username = username, password = password,
-                   authToken = authToken, secretKey = secretKey, galaxy = galaxy)
+                   authToken = authToken, secretKey = secretKey, galaxy = galaxy,
+                   tls = tls, tlsCaFile = tlsCaFile,
+                   tlsServerName = tlsServerName,
+                   tlsInsecureSkipVerify = tlsInsecureSkipVerify)
   for rs in db.ringSummaries():
     echo &"ring={rs.ringKey} count={rs.count} score={rs.score:.4f}"
   db.close()
 
 proc runAtlas(dataDir, peers, username, password, authToken, secretKey,
-              galaxy: string) =
+              galaxy: string, tls: bool, tlsCaFile, tlsServerName: string,
+              tlsInsecureSkipVerify: bool) =
   var db =
     if peers.len > 0:
       connect(peers, username = username, password = password,
-              authToken = authToken, secretKey = secretKey, galaxy = galaxy)
+              authToken = authToken, secretKey = secretKey, galaxy = galaxy,
+              tls = tls, tlsCaFile = tlsCaFile,
+              tlsServerName = tlsServerName,
+              tlsInsecureSkipVerify = tlsInsecureSkipVerify)
     else:
       open(dataDir = dataDir)
   echo db.atlas().pretty
   db.close()
 
 proc runPut(dataDir, peers, username, password, authToken, secretKey,
-            galaxy, ring, payload, inPath, codecName: string) =
+            galaxy, ring, payload, inPath, codecName: string,
+            tls: bool, tlsCaFile, tlsServerName: string,
+            tlsInsecureSkipVerify: bool) =
   let actualDataDir = requireCliTarget(dataDir, peers)
   if ring.len == 0:
     raise newException(ValueError, "put requires --ring=RING")
   var db = openCliDb(actualDataDir, peers, username, password, authToken, secretKey,
-                     galaxy)
+                     galaxy, tls = tls, tlsCaFile = tlsCaFile,
+                     tlsServerName = tlsServerName,
+                     tlsInsecureSkipVerify = tlsInsecureSkipVerify)
   try:
     let codec =
       if codecName.toLowerAscii() == "auto":
@@ -694,7 +736,9 @@ proc readPaginationMode(value: string): RochePaginationMode =
 
 proc runGet(dataDir, peers, username, password, authToken, secretKey,
             galaxy, idArg, filterArg, ring, view, selection, cursor: string,
-            limit, page, pageLimit: int, paginationArg, sortArg, rsortArg: string) =
+            limit, page, pageLimit: int, paginationArg, sortArg, rsortArg: string,
+            tls: bool, tlsCaFile, tlsServerName: string,
+            tlsInsecureSkipVerify: bool) =
   let actualDataDir = requireCliTarget(dataDir, peers)
   let filterNode = parseFilter(filterArg)
   let resolvedId = resolveIdArg(idArg, filterArg)
@@ -702,7 +746,9 @@ proc runGet(dataDir, peers, username, password, authToken, secretKey,
   if ring.len == 0:
     raise newException(ValueError, "get requires --ring=RING")
   var db = openCliDb(actualDataDir, peers, username, password, authToken, secretKey,
-                     galaxy)
+                     galaxy, tls = tls, tlsCaFile = tlsCaFile,
+                     tlsServerName = tlsServerName,
+                     tlsInsecureSkipVerify = tlsInsecureSkipVerify)
   try:
     db.configureRing(ring, 60.0)
     let options = RocheReadOptions(
@@ -720,7 +766,9 @@ proc runGet(dataDir, peers, username, password, authToken, secretKey,
     db.close()
 
 proc runQuery(dataDir, peers, username, password, authToken, secretKey,
-              galaxy, idArg, whereArg, ring, selection: string) =
+              galaxy, idArg, whereArg, ring, selection: string,
+              tls: bool, tlsCaFile, tlsServerName: string,
+              tlsInsecureSkipVerify: bool) =
   let actualDataDir = requireCliTarget(dataDir, peers)
   let resolvedId = resolveIdArg(idArg, whereArg)
   if selection.len == 0:
@@ -728,7 +776,9 @@ proc runQuery(dataDir, peers, username, password, authToken, secretKey,
   if peers.len > 0 and ring.len == 0:
     raise newException(ValueError, "cluster query requires --ring=RING")
   var db = openCliDb(actualDataDir, peers, username, password, authToken, secretKey,
-                     galaxy)
+                     galaxy, tls = tls, tlsCaFile = tlsCaFile,
+                     tlsServerName = tlsServerName,
+                     tlsInsecureSkipVerify = tlsInsecureSkipVerify)
   try:
     if ring.len > 0:
       db.configureRing(ring, 60.0)
@@ -737,12 +787,16 @@ proc runQuery(dataDir, peers, username, password, authToken, secretKey,
     db.close()
 
 proc runListRing(dataDir, peers, username, password, authToken, secretKey,
-                 galaxy, ring, cursor: string, limit: int) =
+                 galaxy, ring, cursor: string, limit: int,
+                 tls: bool, tlsCaFile, tlsServerName: string,
+                 tlsInsecureSkipVerify: bool) =
   let actualDataDir = requireCliTarget(dataDir, peers)
   if ring.len == 0:
     raise newException(ValueError, "list-ring requires --ring=RING")
   var db = openCliDb(actualDataDir, peers, username, password, authToken, secretKey,
-                     galaxy)
+                     galaxy, tls = tls, tlsCaFile = tlsCaFile,
+                     tlsServerName = tlsServerName,
+                     tlsInsecureSkipVerify = tlsInsecureSkipVerify)
   try:
     let page = db.listByRing(ring, limit = limit, cursor = cursor)
     var items = newJArray()
@@ -758,7 +812,9 @@ proc runListRing(dataDir, peers, username, password, authToken, secretKey,
     db.close()
 
 proc runRingProfile(dataDir, peers, username, password, authToken, secretKey,
-                    galaxy, ring, codecName, charset, formatVersion: string) =
+                    galaxy, ring, codecName, charset, formatVersion: string,
+                    tls: bool, tlsCaFile, tlsServerName: string,
+                    tlsInsecureSkipVerify: bool) =
   let actualDataDir = requireCliTarget(dataDir, peers)
   if ring.len == 0:
     raise newException(ValueError, "ring-profile requires --ring=RING")
@@ -766,7 +822,9 @@ proc runRingProfile(dataDir, peers, username, password, authToken, secretKey,
     raise newException(ValueError,
       "ring-profile is currently configured through the embedded store; remote profile administration is not available yet")
   var db = openCliDb(actualDataDir, peers, username, password, authToken, secretKey,
-                     galaxy)
+                     galaxy, tls = tls, tlsCaFile = tlsCaFile,
+                     tlsServerName = tlsServerName,
+                     tlsInsecureSkipVerify = tlsInsecureSkipVerify)
   try:
     if codecName.toLowerAscii() != "auto" or charset.len > 0 or formatVersion.len > 0:
       let old = db.ringPayloadProfile(ring)
@@ -786,12 +844,15 @@ proc runRingProfile(dataDir, peers, username, password, authToken, secretKey,
     db.close()
 
 proc runCountRing(dataDir, peers, username, password, authToken, secretKey,
-                  galaxy, ring: string) =
+                  galaxy, ring: string, tls: bool, tlsCaFile,
+                  tlsServerName: string, tlsInsecureSkipVerify: bool) =
   let actualDataDir = requireCliTarget(dataDir, peers)
   if ring.len == 0:
     raise newException(ValueError, "count-ring requires --ring=RING")
   var db = openCliDb(actualDataDir, peers, username, password, authToken, secretKey,
-                     galaxy)
+                     galaxy, tls = tls, tlsCaFile = tlsCaFile,
+                     tlsServerName = tlsServerName,
+                     tlsInsecureSkipVerify = tlsInsecureSkipVerify)
   try:
     echo &"count-ring OK ring={ring} count={db.countByRing(ring)}"
   finally:
@@ -830,10 +891,13 @@ proc printShellHelp() =
   echo "  exit"
 
 proc runShell(dataDir, peers, username, password, authToken, secretKey,
-              galaxy: string) =
+              galaxy: string, tls: bool, tlsCaFile, tlsServerName: string,
+              tlsInsecureSkipVerify: bool) =
   let actualDataDir = requireCliTarget(dataDir, peers)
   var db = openCliDb(actualDataDir, peers, username, password, authToken, secretKey,
-                     galaxy)
+                     galaxy, tls = tls, tlsCaFile = tlsCaFile,
+                     tlsServerName = tlsServerName,
+                     tlsInsecureSkipVerify = tlsInsecureSkipVerify)
   try:
     echo "RocheDB shell. Type help or exit."
     while true:
@@ -921,9 +985,13 @@ proc runDescribeRing(dataDir, ring, description: string) =
   echo "describe-ring OK ring=" & ring
 
 proc runRetrieveBench(peers, username, password, authToken, secretKey, galaxy: string,
-                      n: int) =
+                      tls: bool, tlsCaFile, tlsServerName: string,
+                      tlsInsecureSkipVerify: bool, n: int) =
   var db = connect(peers, username = username, password = password,
-                   authToken = authToken, secretKey = secretKey, galaxy = galaxy)
+                   authToken = authToken, secretKey = secretKey, galaxy = galaxy,
+                   tls = tls, tlsCaFile = tlsCaFile,
+                   tlsServerName = tlsServerName,
+                   tlsInsecureSkipVerify = tlsInsecureSkipVerify)
   for i in 0 ..< n:
     let ring = if i mod 2 == 0: "ai" else: "logs"
     let v =
@@ -949,7 +1017,9 @@ proc runRetrieveBench(peers, username, password, authToken, secretKey, galaxy: s
   db.close()
 
 proc runRedisBench(n, payloadBytes: int, redisEndpoint, peers, username,
-                   password, authToken, secretKey, galaxy: string) =
+                   password, authToken, secretKey, galaxy: string,
+                   tls: bool, tlsCaFile, tlsServerName: string,
+                   tlsInsecureSkipVerify: bool) =
   ## Simple KV comparison between localhost Redis GET and RocheDB embedded get.
   ## The workload is favorable to Redis; the goal is to observe the latency band.
   let ep = parseHostPort(redisEndpoint)
@@ -979,7 +1049,9 @@ proc runRedisBench(n, payloadBytes: int, redisEndpoint, peers, username,
   if peers.len > 0:
     var tcp = connect(peers, username = username, password = password,
                       authToken = authToken, secretKey = secretKey,
-                      galaxy = galaxy)
+                      galaxy = galaxy, tls = tls, tlsCaFile = tlsCaFile,
+                      tlsServerName = tlsServerName,
+                      tlsInsecureSkipVerify = tlsInsecureSkipVerify)
     var tcpIds = newSeq[RocheId](n)
     t = getMonoTime()
     for i in 0 ..< n:
@@ -1901,13 +1973,18 @@ proc runUniverseSync(dataDir, targetDataDir: string, pruneAcked: bool) =
     source.close()
 
 proc runUniverseSyncRemote(dataDir, peers, username, password, authToken,
-                           secretKey, galaxy: string, pruneAcked: bool) =
+                           secretKey, galaxy: string, pruneAcked: bool,
+                           tls: bool, tlsCaFile, tlsServerName: string,
+                           tlsInsecureSkipVerify: bool) =
   if dataDir.len == 0 or peers.len == 0:
     raise newException(ValueError,
       "remote universe-sync requires --data=SOURCE_DIR --peers=host:port,...")
   var source = open(dataDir = dataDir)
   let client = newClusterClient(parsePeers(peers), username, password,
-                                authToken, secretKey, galaxy)
+                                authToken, secretKey, galaxy,
+                                tls = tls, tlsCaFile = tlsCaFile,
+                                tlsServerName = tlsServerName,
+                                tlsInsecureSkipVerify = tlsInsecureSkipVerify)
   var stats = UniverseSyncStats()
   try:
     for event in source.universeSyncEvents():
@@ -1930,7 +2007,9 @@ proc runUniverseSyncRemote(dataDir, peers, username, password, authToken,
   echo &"universe-sync OK read={stats.read} applied={stats.applied} skipped={stats.skipped} acked={stats.acked} pruned={stats.pruned} errors={stats.errors} source={dataDir} targetPeers={peers}"
 
 proc runUniverseStatus(dataDir, peers, username, password, authToken,
-                       secretKey, galaxy: string, metricsFormat: bool) =
+                       secretKey, galaxy: string, metricsFormat: bool,
+                       tls: bool, tlsCaFile, tlsServerName: string,
+                       tlsInsecureSkipVerify: bool) =
   if dataDir.len > 0:
     var db = open(dataDir = dataDir)
     var pending = 0
@@ -1955,7 +2034,10 @@ proc runUniverseStatus(dataDir, peers, username, password, authToken,
   elif peers.len > 0:
     let parsedPeers = parsePeers(peers)
     let client = newClusterClient(parsedPeers, username, password,
-                                  authToken, secretKey, galaxy)
+                                  authToken, secretKey, galaxy,
+                                  tls = tls, tlsCaFile = tlsCaFile,
+                                  tlsServerName = tlsServerName,
+                                  tlsInsecureSkipVerify = tlsInsecureSkipVerify)
     var pending = 0
     var applied = 0
     var appliedOps = 0
@@ -2066,6 +2148,10 @@ proc main() =
   var password = ""
   var authToken = ""
   var secretKey = ""
+  var tls = false
+  var tlsCaFile = ""
+  var tlsServerName = ""
+  var tlsInsecureSkipVerify = false
   var backupPassphrase = ""
   var galaxy = ""
   var universeName = ""
@@ -2158,6 +2244,10 @@ proc main() =
       of "password": password = val
       of "auth-token": authToken = val
       of "secret-key": secretKey = val
+      of "tls": tls = true
+      of "tls-ca": tlsCaFile = val
+      of "tls-server-name": tlsServerName = val
+      of "tls-insecure-skip-verify": tlsInsecureSkipVerify = true
       of "passphrase": backupPassphrase = val
       of "galaxy": galaxy = val
       of "universe", "lane": universeName = val
@@ -2188,41 +2278,64 @@ proc main() =
   case cmd
   of "put":
     runPut(dataDir, peers, username, password, authToken, secretKey, galaxy,
-           ringName, payload, inPath, codecName)
+           ringName, payload, inPath, codecName, tls, tlsCaFile,
+           tlsServerName, tlsInsecureSkipVerify)
   of "get":
     let readFilter = effectiveFilter(filterArg, whereArg)
     runGet(dataDir, peers, username, password, authToken, secretKey, galaxy,
            idArg, readFilter, ringName, view, selection, cursor, limit,
-           page, pageLimit, paginationArg, sortArg, rsortArg)
+           page, pageLimit, paginationArg, sortArg, rsortArg, tls, tlsCaFile,
+           tlsServerName, tlsInsecureSkipVerify)
   of "query":
     let readFilter = effectiveFilter(filterArg, whereArg)
     runQuery(dataDir, peers, username, password, authToken, secretKey, galaxy,
-             idArg, readFilter, ringName, selection)
+             idArg, readFilter, ringName, selection, tls, tlsCaFile,
+             tlsServerName, tlsInsecureSkipVerify)
   of "list-ring":
     runListRing(dataDir, peers, username, password, authToken, secretKey,
-                galaxy, ringName, cursor, limit)
+                galaxy, ringName, cursor, limit, tls, tlsCaFile,
+                tlsServerName, tlsInsecureSkipVerify)
   of "count-ring":
     runCountRing(dataDir, peers, username, password, authToken, secretKey,
-                 galaxy, ringName)
+                 galaxy, ringName, tls, tlsCaFile, tlsServerName,
+                 tlsInsecureSkipVerify)
   of "ring-profile":
     runRingProfile(dataDir, peers, username, password, authToken, secretKey,
-                   galaxy, ringName, codecName, charset, formatVersion)
+                   galaxy, ringName, codecName, charset, formatVersion, tls,
+                   tlsCaFile, tlsServerName, tlsInsecureSkipVerify)
   of "shell":
-    runShell(dataDir, peers, username, password, authToken, secretKey, galaxy)
-  of "demo": runDemo(peers, username, password, authToken, secretKey, galaxy)
-  of "bench": runBench(peers, username, password, authToken, secretKey, galaxy, n)
-  of "health": runHealth(peers, username, password, authToken, secretKey, galaxy)
-  of "metrics": runMetrics(peers, username, password, authToken, secretKey, galaxy)
-  of "shutdown": runShutdown(peers, username, password, authToken, secretKey, galaxy)
-  of "rings": runRings(peers, username, password, authToken, secretKey, galaxy)
+    runShell(dataDir, peers, username, password, authToken, secretKey, galaxy,
+             tls, tlsCaFile, tlsServerName, tlsInsecureSkipVerify)
+  of "demo":
+    runDemo(peers, username, password, authToken, secretKey, galaxy, tls,
+            tlsCaFile, tlsServerName, tlsInsecureSkipVerify)
+  of "bench":
+    runBench(peers, username, password, authToken, secretKey, galaxy, tls,
+             tlsCaFile, tlsServerName, tlsInsecureSkipVerify, n)
+  of "health":
+    runHealth(peers, username, password, authToken, secretKey, galaxy, tls,
+              tlsCaFile, tlsServerName, tlsInsecureSkipVerify)
+  of "metrics":
+    runMetrics(peers, username, password, authToken, secretKey, galaxy, tls,
+               tlsCaFile, tlsServerName, tlsInsecureSkipVerify)
+  of "shutdown":
+    runShutdown(peers, username, password, authToken, secretKey, galaxy, tls,
+                tlsCaFile, tlsServerName, tlsInsecureSkipVerify)
+  of "rings":
+    runRings(peers, username, password, authToken, secretKey, galaxy, tls,
+             tlsCaFile, tlsServerName, tlsInsecureSkipVerify)
   of "atlas": runAtlas(dataDir, peers, username, password, authToken, secretKey,
-                       galaxy)
+                       galaxy, tls, tlsCaFile, tlsServerName,
+                       tlsInsecureSkipVerify)
   of "describe-galaxy": runDescribeGalaxy(dataDir, description)
   of "describe-ring": runDescribeRing(dataDir, ringName, description)
-  of "retrieve-bench": runRetrieveBench(peers, username, password, authToken, secretKey, galaxy, n)
+  of "retrieve-bench":
+    runRetrieveBench(peers, username, password, authToken, secretKey, galaxy,
+                     tls, tlsCaFile, tlsServerName, tlsInsecureSkipVerify, n)
   of "redis-bench": runRedisBench(n, payloadBytes, redisEndpoint, peers,
                                   username, password, authToken, secretKey,
-                                  galaxy)
+                                  galaxy, tls, tlsCaFile, tlsServerName,
+                                  tlsInsecureSkipVerify)
   of "rag-bench": runRagBench(n, queries, budget, routedBudget)
   of "working-set-bench": runWorkingSetBench(n, ringCount, queries, budget)
   of "memory-pressure-bench": runMemoryPressureBench(n, ringCount, queries,
@@ -2278,10 +2391,12 @@ proc main() =
       runUniverseSync(dataDir, targetDataDir, pruneAcked)
     else:
       runUniverseSyncRemote(dataDir, peers, username, password, authToken,
-                            secretKey, galaxy, pruneAcked)
+                            secretKey, galaxy, pruneAcked, tls, tlsCaFile,
+                            tlsServerName, tlsInsecureSkipVerify)
   of "universe-status":
     runUniverseStatus(dataDir, peers, username, password, authToken, secretKey,
-                      galaxy, metricsFormat)
+                      galaxy, metricsFormat, tls, tlsCaFile, tlsServerName,
+                      tlsInsecureSkipVerify)
   else:
     printHelp()
     quit(1)

--- a/src/roched.nim
+++ b/src/roched.nim
@@ -43,6 +43,14 @@ type
     authUser: string
     authPassword: string
     authSecretKey: string
+    tlsEnabled: bool
+    tlsCertFile: string
+    tlsKeyFile: string
+    tlsCaFile: string
+    tlsServerName: string
+    tlsInsecureSkipVerify: bool
+    when defined(ssl):
+      tlsContext: SslContext
     users: Table[string, UserRule]
     galaxy: string
     allowedRingPrefixes: seq[string]
@@ -982,6 +990,11 @@ proc printUsage() =
   echo "  --password=TEXT               Password for cluster auth"
   echo "  --auth-token=TEXT             Token-style auth shortcut"
   echo "  --secret-key=TEXT             Additional secret-key gate"
+  echo "  --tls-cert=FILE               Enable TLS with certificate PEM (requires -d:ssl)"
+  echo "  --tls-key=FILE                TLS private key PEM (requires -d:ssl)"
+  echo "  --tls-ca=FILE                 CA/self-signed PEM for peer TLS verification"
+  echo "  --tls-server-name=NAME        Override peer TLS hostname verification / SNI"
+  echo "  --tls-insecure-skip-verify    Skip peer certificate verification for local smoke only"
   echo "  --galaxy=NAME                 Expected galaxy name"
   echo "  --allow-ring=PREFIX[,PREFIX]  Ring-prefix authorization"
   echo "  --role=user:password:role[:prefixes]"
@@ -1004,6 +1017,11 @@ proc main() =
   var authUser = ""
   var authPassword = ""
   var authSecretKey = ""
+  var tlsCertFile = ""
+  var tlsKeyFile = ""
+  var tlsCaFile = ""
+  var tlsServerName = ""
+  var tlsInsecureSkipVerify = false
   var users = initTable[string, UserRule]()
   var galaxy = ""
   var allowedRingPrefixes: seq[string] = @[]
@@ -1018,6 +1036,11 @@ proc main() =
       of "user": authUser = val
       of "password": authPassword = val
       of "secret-key": authSecretKey = val
+      of "tls-cert": tlsCertFile = val
+      of "tls-key": tlsKeyFile = val
+      of "tls-ca": tlsCaFile = val
+      of "tls-server-name": tlsServerName = val
+      of "tls-insecure-skip-verify": tlsInsecureSkipVerify = true
       of "galaxy": galaxy = val
       of "role":
         let parsed = parseUserRule(val)
@@ -1040,6 +1063,11 @@ proc main() =
       of "auth-token":
         authUser = "token"
         authPassword = val
+  if tlsCertFile.len > 0 or tlsKeyFile.len > 0:
+    if tlsCertFile.len == 0 or tlsKeyFile.len == 0:
+      raise newException(ValueError, "--tls-cert and --tls-key must be provided together")
+    when not defined(ssl):
+      raise newException(ValueError, "TLS support requires building roched with -d:ssl")
   let peers = parsePeers(peersStr)
   doAssert id >= 0 and id < peers.len, "--id と --peers を指定（id は peers 内の自分の位置）"
 
@@ -1049,18 +1077,33 @@ proc main() =
                   fs: newFieldState(),
                   peerLink: newClusterClient(peers, username = authUser,
                                              password = authPassword,
-                                             secretKey = authSecretKey),
+                                             secretKey = authSecretKey,
+                                             tls = tlsCertFile.len > 0,
+                                             tlsCaFile = tlsCaFile,
+                                             tlsServerName = tlsServerName,
+                                             tlsInsecureSkipVerify = tlsInsecureSkipVerify),
                   slowTickSec: slowTickSec,
                   running: true,
                   authUser: authUser,
                   authPassword: authPassword,
                   authSecretKey: authSecretKey,
+                  tlsEnabled: tlsCertFile.len > 0,
+                  tlsCertFile: tlsCertFile,
+                  tlsKeyFile: tlsKeyFile,
+                  tlsCaFile: tlsCaFile,
+                  tlsServerName: tlsServerName,
+                  tlsInsecureSkipVerify: tlsInsecureSkipVerify,
                   users: users,
                   galaxy: galaxy,
                   allowedRingPrefixes: allowedRingPrefixes,
                   preparedSelections: initTable[string, Selection](),
                   codecMetadata: initTable[int, bool](),
                   startedAt: epochTime())
+  when defined(ssl):
+    if sv.tlsEnabled:
+      sv.tlsContext = newContext(verifyMode = CVerifyNone,
+                                 certFile = sv.tlsCertFile,
+                                 keyFile = sv.tlsKeyFile)
   sv.st.setGalaxy(galaxy)
   sv.rebuildFieldState()
 
@@ -1080,7 +1123,8 @@ proc main() =
        (if authUser.len > 0:
           " auth=on user=" & authUser &
           (if authSecretKey.len > 0: " secret=on" else: " secret=off")
-        else: " auth=off")
+        else: " auth=off"),
+       (if tlsCertFile.len > 0: " tls=on" else: " tls=off")
 
   var sel = newSelector[int]()
   let listenerFd = listener.getFd
@@ -1099,6 +1143,14 @@ proc main() =
         var client: Socket
         listener.accept(client)
         client.setSockOpt(OptNoDelay, true, level = IPPROTO_TCP.cint)
+        when defined(ssl):
+          if sv.tlsEnabled:
+            try:
+              sv.tlsContext.wrapConnectedSocket(client, handshakeAsServer)
+            except CatchableError:
+              inc sv.errorResponses
+              client.close()
+              continue
         conns[client.getFd.int] = client
         inc sv.connectionsAccepted
         sv.activeConnections = conns.len

--- a/src/rochedb.nim
+++ b/src/rochedb.nim
@@ -511,7 +511,9 @@ proc open*(nodes: int = 8, dataDir: string = "",
 
 proc connect*(peers: string, username: string = "", password: string = "",
               authToken: string = "", secretKey: string = "",
-              galaxy: string = ""): RocheDb =
+              galaxy: string = "", tls: bool = false,
+              tlsCaFile: string = "", tlsServerName: string = "",
+              tlsInsecureSkipVerify: bool = false): RocheDb =
   ## クラスタモードで開く。peers = "host:port,host:port,..."（roched の並び順）。
   ## 時計は wall clock。API は open() と同じに使える。
   let ps = parsePeers(peers)
@@ -521,7 +523,11 @@ proc connect*(peers: string, username: string = "", password: string = "",
                                    password = password,
                                    authToken = authToken,
                                    secretKey = secretKey,
-                                   galaxy = galaxy),
+                                   galaxy = galaxy,
+                                   tls = tls,
+                                   tlsCaFile = tlsCaFile,
+                                   tlsServerName = tlsServerName,
+                                   tlsInsecureSkipVerify = tlsInsecureSkipVerify),
           plannerBackend: newHeuristicPlannerBackend(),
           galaxy: galaxy)
 
@@ -532,10 +538,16 @@ proc close*(db: RocheDb)
 
 proc addGalaxy*(r: GalaxyRouter, name, peers: string,
                 username: string = "", password: string = "",
-                authToken: string = "", secretKey: string = "") =
+                authToken: string = "", secretKey: string = "",
+                tls: bool = false, tlsCaFile: string = "",
+                tlsServerName: string = "",
+                tlsInsecureSkipVerify: bool = false) =
   r.galaxies[name] = connect(peers, username = username, password = password,
                              authToken = authToken, secretKey = secretKey,
-                             galaxy = name)
+                             galaxy = name, tls = tls,
+                             tlsCaFile = tlsCaFile,
+                             tlsServerName = tlsServerName,
+                             tlsInsecureSkipVerify = tlsInsecureSkipVerify)
 
 proc galaxy*(r: GalaxyRouter, name: string): RocheDb =
   r.galaxies[name]

--- a/src/rochedb_capi.nim
+++ b/src/rochedb_capi.nim
@@ -185,6 +185,30 @@ proc roche_connect_auth(peers, username, password, authToken, secretKey,
     setError(e)
     return nil
 
+proc roche_connect_auth_tls(peers, username, password, authToken, secretKey,
+                            galaxy: cstring, tls: cint, tlsCaFile,
+                            tlsServerName: cstring,
+                            tlsInsecureSkipVerify: cint): pointer {.exportc, cdecl, dynlib.} =
+  ## TLS-aware authenticated cluster connection. TLS requires a RocheDB core
+  ## build compiled with -d:ssl.
+  try:
+    clearError()
+    let db = rochedb.connect(optStr(peers),
+                             username = optStr(username),
+                             password = optStr(password),
+                             authToken = optStr(authToken),
+                             secretKey = optStr(secretKey),
+                             galaxy = optStr(galaxy),
+                             tls = tls != 0,
+                             tlsCaFile = optStr(tlsCaFile),
+                             tlsServerName = optStr(tlsServerName),
+                             tlsInsecureSkipVerify = tlsInsecureSkipVerify != 0)
+    GC_ref(db)
+    return cast[pointer](db)
+  except CatchableError as e:
+    setError(e)
+    return nil
+
 proc roche_close(h: pointer) {.exportc, cdecl, dynlib.} =
   if h != nil:
     let db = cast[RocheDb](h)


### PR DESCRIPTION
## Summary
- add optional TLS transport for roched, RocheDB Nim clients, CLI commands, and C ABI
- document TLS setup, CLI flags, config properties, threat-model impact, and test coverage
- add a TLS smoke test that verifies TLS health/put/get and rejects a plain client against a TLS listener

## Verification
- nim check src/rochedb.nim
- nim check src/rochecli.nim
- nim check src/roched.nim
- nim check src/rochedb_capi.nim
- nim check -d:ssl src/rochecli.nim
- nim check -d:ssl src/roched.nim
- nim check -d:ssl src/rochedb_capi.nim
- nim c --app:lib -d:release --nimcache:/tmp/nimcache_roche_capi_tls -o:lib/librochedb.so src/rochedb_capi.nim && gcc examples/cabi_contract.c -Iinclude -Llib -lrochedb -Wl,-rpath,'\''/../lib'\'' -o /tmp/roche_cabi_contract && LD_LIBRARY_PATH=lib /tmp/roche_cabi_contract
- scripts/cluster_tls_smoke.sh
- scripts/test_all_smoke.sh