### PR TITLE
release: prepare v0.4.0

### DIFF
--- a/docs/github-release-v0.4.0.md
+++ b/docs/github-release-v0.4.0.md
@@ -1,0 +1,63 @@
+# RocheDB v0.4.0
+
+RocheDB v0.4.0 adds TLS transport support and repository-level CI coverage.
+
+Release:
+
+https://github.com/puffball1567/rochedb/releases/tag/v0.4.0
+
+## Main Changes
+
+- Added optional TLS transport for `roched`, RocheDB Nim clients, CLI commands,
+  and the C ABI.
+- Added `roche_connect_auth_tls` as an additive C ABI entry point.
+- Added TLS CLI flags:
+  - `--tls`
+  - `--tls-ca=FILE`
+  - `--tls-server-name=NAME`
+  - `--tls-insecure-skip-verify`
+- Added TLS server flags:
+  - `--tls-cert=FILE`
+  - `--tls-key=FILE`
+  - `--tls-ca=FILE`
+  - `--tls-server-name=NAME`
+  - `--tls-insecure-skip-verify`
+- Added `docs/tls-transport.md`.
+- Added a TLS smoke test that verifies:
+  - TLS health check;
+  - authenticated JSON put/get over TLS;
+  - plain clients are rejected by a TLS listener.
+- Added GitHub Actions CI for:
+  - Nim semantic checks;
+  - SSL-enabled semantic checks;
+  - C ABI contract coverage;
+  - core tests;
+  - CLI, cluster, recovery, and universe smoke tests;
+  - TLS transport smoke tests.
+
+## Build Note
+
+TLS support requires building RocheDB with Nim's SSL support:
+
+```sh
+nim c -d:ssl -d:release -o:bin/roched src/roched.nim
+nim c -d:ssl -d:release -o:bin/roche src/rochecli.nim
+```
+
+Without `-d:ssl`, non-TLS operation remains available.
+
+## Verification
+
+Before release, the following checks passed locally or in GitHub Actions:
+
+- `nim check src/rochedb.nim`
+- `nim check src/rochecli.nim`
+- `nim check src/roched.nim`
+- `nim check src/rochedb_capi.nim`
+- `nim check -d:ssl src/rochecli.nim`
+- `nim check -d:ssl src/roched.nim`
+- `nim check -d:ssl src/rochedb_capi.nim`
+- C ABI contract test
+- `scripts/cluster_tls_smoke.sh`
+- `scripts/test_all_smoke.sh`
+- GitHub Actions CI jobs added in this release

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,4 +45,4 @@ downstream AI/RAG or application logic.
 ## Release
 
 - [Release Checklist](release-checklist.md)
-- [GitHub Release Draft](github-release-v0.3.0.md)
+- [GitHub Release Draft](github-release-v0.4.0.md)

--- a/rochedb.nimble
+++ b/rochedb.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version     = "0.3.0"
+version     = "0.4.0"
 author      = "puffball1567"
 description = "Ring-oriented NoSQL document/vector store for smaller working sets"
 license     = "Apache-2.0"


### PR DESCRIPTION
## Summary
- bump RocheDB package version to 0.4.0
- add v0.4.0 release draft for TLS transport and CI coverage
- update docs index to point at the v0.4.0 release draft

## Notes
- This tags the already-merged TLS transport and CI smoke coverage work.
- Local nimble validation reported the package as valid; final verification is handled by the newly added CI workflow.