### PR TITLE
release: prepare v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## v0.5.0
+
+### Added
+
+- Added stellar locality lens workflows. Existing rings can be attached to or
+  detached from a stellar coordinate, allowing related records to be read
+  together without copying payloads.
+- Added `readStellar` / `roche get --stellar=...` workflows with `--subring`,
+  filter, selection, and grouped ring output.
+- Added embedded all-or-nothing bulk helpers:
+  `batchPutAtomic`, `batchUpdateAtomic`, and `batchDeleteAtomic`.
+- Added opt-in embedded cooperative coordinate locks:
+  `acquireRingLock`, `acquireStellarLock`, `withRingLock`,
+  `withStellarLock`, `releaseLock`, and `lockActive`.
+- Added `docs/unique-data-model.md` and
+  `examples/stellar_data_model_demo.sh` to demonstrate RocheDB-specific
+  ring/stellar data modeling.
+
+### Changed
+
+- Updated Redis, PostgreSQL, Docker-Docker, working-set, memory-pressure, and
+  RAG benchmark documentation with the latest local verification numbers.
+- Documented that benchmark helpers use fresh temporary RocheDB/PostgreSQL
+  data directories, fresh Docker containers where applicable, or unique Redis
+  key prefixes that are deleted before exit.
+- Expanded public API and test coverage documentation for high-integrity
+  application workflows.
+- Bumped package metadata to `0.5.0`.
+
+### Fixed / Hardened
+
+- Added matrix coverage for atomic batch commit/rollback, update/delete
+  failure rollback, persistence replay, ring lock conflicts, stellar/member
+  lock conflicts, disjoint lock coexistence, TTL expiry, and release on
+  exception.
+- Kept cooperative locks opt-in so ordinary `put`, `get`, `list`, and
+  `retrieve` paths remain outside the lock-check path.
+
 ## v0.3.0
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,11 @@ Good reports include:
 
 Small documentation fixes are welcome.
 
+Development follows the branch policy documented in
+[Development Workflow](docs/development-workflow.md). In short, normal feature,
+test, and documentation work targets `devel`; `main` is reserved for released,
+tagged state and direct hotfixes.
+
 Implementation pull requests may be closed or redirected unless they were
 discussed first. RocheDB's data model, transaction behavior, persistence format,
 wire protocol, and recovery semantics are intentionally kept under central

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RocheDB
 
-**v0.3.0 Technical Preview / research OSS.** RocheDB is not yet presented as a
+**v0.5.0 Technical Preview / research OSS.** RocheDB is not yet presented as a
 production replacement for Redis, PostgreSQL, MongoDB, Apache Arrow, or a
 dedicated vector database. The current release target is a measurable prototype
 of ring/galaxy-oriented storage, retrieval, persistence, drivers, and cluster
@@ -57,7 +57,7 @@ corpus size toward semantic working-set size.
 - Detailed design: [docs/rochedb-design.md](docs/rochedb-design.md)
 - Feature status / roadmap: [docs/rochedb-status.md](docs/rochedb-status.md)
 - Release checklist: [docs/release-checklist.md](docs/release-checklist.md)
-- GitHub release draft: [docs/github-release-v0.3.0.md](docs/github-release-v0.3.0.md)
+- GitHub release draft: [docs/github-release-v0.5.0.md](docs/github-release-v0.5.0.md)
 - Driver / FFI roadmap: [docs/rochedb-driver-roadmap.md](docs/rochedb-driver-roadmap.md)
 - Driver installation guide: [docs/driver-installation.md](docs/driver-installation.md)
 - FAISS versioning policy: [docs/faiss-versioning.md](docs/faiss-versioning.md)
@@ -79,7 +79,7 @@ corpus size toward semantic working-set size.
 
 ## Installation
 
-RocheDB v0.3.x is a technical preview. The Nim package is available through
+RocheDB v0.5.x is a technical preview. The Nim package is available through
 Nimble. Rust, JavaScript / TypeScript, PHP, and Python drivers are published as
 language packages, while the remaining non-Nim language drivers are still
 repository-local foundations.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ corpus size toward semantic working-set size.
 - Configuration reference: [docs/config-reference.md](docs/config-reference.md)
 - CLI reference: [docs/cli-reference.md](docs/cli-reference.md)
 - How RocheDB differs from typical NoSQL: [docs/nosql-positioning.md](docs/nosql-positioning.md)
+- Unique data model and operating patterns: [docs/unique-data-model.md](docs/unique-data-model.md)
 - Concept: [docs/rochedb-concept.md](docs/rochedb-concept.md)
 - Detailed design: [docs/rochedb-design.md](docs/rochedb-design.md)
 - Feature status / roadmap: [docs/rochedb-status.md](docs/rochedb-status.md)
@@ -318,7 +319,7 @@ application processing.
 |---|---|---|
 | Working-set | 100 rings / 10k docs | scanned/query `10000 -> 100` (99% reduction) |
 | Memory-pressure | 100 rings / 100k docs / 512B payload | candidate memory/query `93.079 MiB -> 0.931 MiB` (99% reduction) |
-| Synthetic RAG | fixed recall | recall `1.000`, scanned/query `8000 -> 1000`, tokens/query `3960 -> 657.8` |
+| Synthetic RAG | fixed recall | recall `1.000`, scanned/query `8000 -> 1000`, tokens/query `3955 -> 657` |
 | AI/RAG case study | generated JSONL, 400 docs / 6 rings | recall `1.000`, scanned/query `400 -> 40`, tokens/query `615.2 -> 231.6` |
 | API minimum test | 2 rings / 4 vectors | `skippedVectors` and `candidateReduction` confirm pre-filtered search scope |
 
@@ -327,18 +328,21 @@ Reference latency results are tracked in
 in [docs/benchmark-comparison.md](docs/benchmark-comparison.md). The short
 version is:
 
-- RocheDB 3-node TCP with persistence enabled measured `45.9 us` per
-  single-key read and `47.7 us` per single-key write in the PostgreSQL
+- RocheDB 3-node TCP with persistence enabled measured `46.8 us` per
+  single-key read and `48.8 us` per single-key write in the PostgreSQL
   comparison helper run.
-- PostgreSQL 14.23 on the same machine measured `67 us` for primary-key read
-  and `79 us` for `synchronous_commit=off` single-row write over local TCP.
+- PostgreSQL 14.23 on the same machine measured `68 us` for primary-key read
+  and `80 us` for `synchronous_commit=off` single-row write over local TCP.
 - The PostgreSQL comparison also has a Docker-Docker reproduction helper; in
-  the included run RocheDB measured `53.5 us` read / `56.4 us` write, while
-  PostgreSQL measured `92 us` primary-key read / `130 us`
+  the included run RocheDB measured `61.3 us` read / `103.6 us` write, while
+  PostgreSQL measured `103 us` primary-key read / `149 us`
   `synchronous_commit=off` write.
-- Local Redis 6.0.16 measured `41.23 us/op` for single GET and `3.68 us/op`
-  for pipeline GET. RocheDB TCP GET measured `44.87 us/op`; RocheDB TCP BGET
-  measured `1.47 us/op` in the same local single-client benchmark shape.
+- Local Redis 6.0.16 measured `42.85 us/op` for single GET and `3.53 us/op`
+  for pipeline GET. RocheDB TCP GET measured `45.26 us/op`; RocheDB TCP BGET
+  measured `1.48 us/op` in the same local single-client benchmark shape.
+- In the Docker-Docker Redis comparison, Redis 7 measured `48.74 us/op` for
+  single GET and `2.06 us/op` for pipeline GET. RocheDB TCP GET measured
+  `55.78 us/op`; RocheDB TCP BGET measured `1.71 us/op`.
 
 These are not universal performance claims. They show that the local read path
 is already competitive enough for the working-set reduction story to matter.

--- a/docs/benchmark-comparison.md
+++ b/docs/benchmark-comparison.md
@@ -15,57 +15,79 @@ These are local measurements, not universal performance claims.
 
 Environment summary: same machine as RocheDB, AMD Ryzen 5 5600H, Linux 6.8,
 Nim 2.2.10, PostgreSQL 14.23, local TCP, single client, 100-byte payload where
-applicable.
+applicable. Measured on 2026-07-15.
 
 Reproduction helper: `N=10000 examples/postgres_bench.sh`.
+The helper creates a fresh temporary RocheDB data directory and a fresh
+temporary PostgreSQL cluster for each run, then removes them on exit.
 
 Docker reproduction helper: `N=10000 examples/postgres_docker_bench.sh`.
 
 | Group | Operation | us/op | Notes |
 |---|---|---:|---|
-| RocheDB | single-key read | 45.9 | Three `roched` nodes, persistence enabled |
-| RocheDB | single-row write | 47.7 | Three `roched` nodes, persistence enabled |
+| RocheDB | single-key read | 46.8 | Three `roched` nodes, persistence enabled |
+| RocheDB | single-row write | 48.8 | Three `roched` nodes, persistence enabled |
+| RocheDB | query projection | 53.3 | Server-side JSON projection |
 | RocheDB | strong-durability write | not measured | `durStrong` / `--durability=strong` was not part of this comparison |
-| PostgreSQL 14.23 | primary-key `SELECT` | 67 | `pgbench -M prepared`, 14,986 tps |
-| PostgreSQL 14.23 | single-row write, `synchronous_commit=off` | 79 | `pgbench -M prepared`, 12,699 tps |
-| PostgreSQL 14.23 | single-row write, `synchronous_commit=on` | 1998 | `pgbench -M prepared`, 501 tps |
+| PostgreSQL 14.23 | primary-key `SELECT` | 68 | `pgbench -M prepared`, 14,659 tps |
+| PostgreSQL 14.23 | single-row write, `synchronous_commit=off` | 80 | `pgbench -M prepared`, 12,433 tps |
+| PostgreSQL 14.23 | single-row write, `synchronous_commit=on` | 1935 | `pgbench -M prepared`, 517 tps |
 
 ## PostgreSQL Docker Reference
 
 Environment summary: same host as RocheDB, Docker `overlay2`, RocheDB image
 built from `examples/compose/Dockerfile`, PostgreSQL image `postgres:14`, same
 Docker network, single client, 100-byte payload, `n=10000`. Data directories
-are bind-mounted from the repository `.tmp` directory during the helper run.
+are bind-mounted from a temporary helper directory during the helper run.
+Measured on 2026-07-15.
 
 Reproduction helper: `N=10000 examples/postgres_docker_bench.sh`.
+The helper starts fresh RocheDB and PostgreSQL containers on a fresh Docker
+network and removes the containers, network, and temporary data directory on
+exit.
 
 | Group | Operation | us/op | Notes |
 |---|---|---:|---|
-| RocheDB Docker | single-key read | 53.5 | Three `roched` containers |
-| RocheDB Docker | single-row write | 56.4 | Three `roched` containers |
-| RocheDB Docker | query projection | 60.0 | Server-side JSON projection |
-| PostgreSQL 14 Docker | primary-key `SELECT` | 92 | `pgbench -M prepared`, 10,869 tps |
-| PostgreSQL 14 Docker | single-row write, `synchronous_commit=off` | 130 | `pgbench -M prepared`, 7,666 tps |
-| PostgreSQL 14 Docker | single-row write, `synchronous_commit=on` | 1134 | `pgbench -M prepared`, 882 tps |
+| RocheDB Docker | single-key read | 61.3 | Three `roched` containers |
+| RocheDB Docker | single-row write | 103.6 | Three `roched` containers |
+| RocheDB Docker | query projection | 65.3 | Server-side JSON projection |
+| PostgreSQL 14 Docker | primary-key `SELECT` | 103 | `pgbench -M prepared`, 9,669 tps |
+| PostgreSQL 14 Docker | single-row write, `synchronous_commit=off` | 149 | `pgbench -M prepared`, 6,720 tps |
+| PostgreSQL 14 Docker | single-row write, `synchronous_commit=on` | 1162 | `pgbench -M prepared`, 860 tps |
 
 ## Redis Reference
 
 Environment summary: same machine as RocheDB, AMD Ryzen 5 5600H, Linux 6.8,
 Nim 2.2.10, local Redis 6.0.16, one local `roched`, persistence disabled,
 local TCP, single client, 100-byte payload, `n=1000`, Redis pipeline batch size
-256.
+256. Measured on 2026-07-15.
 
 Local reproduction helper: `N=1000 examples/redis_local_bench.sh`.
+The helper starts RocheDB with a fresh temporary data directory and removes it on
+exit. Redis local uses the existing Redis server, but the benchmark writes under
+a unique `rochedb:bench:<timestamp>:` prefix and deletes those keys before exit.
 
 Docker reproduction helper: `N=1000 examples/redis_docker_bench.sh`.
+The Docker helper starts fresh Redis and RocheDB containers on a fresh Docker
+network and removes them on exit.
 
 | Group | Operation | us/op | Notes |
 |---|---|---:|---|
 | RocheDB | embedded get | 0.03 | In-process hot path; no TCP |
-| RocheDB | TCP GET | 44.87 | One request / one response |
-| RocheDB | TCP BGET | 1.47 | Batch read; comparable axis to Redis pipeline |
-| Redis 6.0.16 | TCP GET | 41.23 | Non-pipelined local Redis |
-| Redis 6.0.16 | pipeline GET | 3.68 | Batch size 256 |
+| RocheDB | TCP GET | 45.26 | One request / one response |
+| RocheDB | TCP BGET | 1.48 | Batch read; comparable axis to Redis pipeline |
+| Redis 6.0.16 | TCP GET | 42.85 | Non-pipelined local Redis |
+| Redis 6.0.16 | pipeline GET | 3.53 | Batch size 256 |
+
+Docker-Docker measurements under the same benchmark shape:
+
+| Group | Operation | us/op | Notes |
+|---|---|---:|---|
+| RocheDB Docker | embedded get | 0.04 | In-process hot path inside the benchmark container |
+| RocheDB Docker | TCP GET | 55.78 | One request / one response across Docker network |
+| RocheDB Docker | TCP BGET | 1.71 | Batch read; comparable axis to Redis pipeline |
+| Redis 7 Docker | TCP GET | 48.74 | Non-pipelined Redis on the same Docker network |
+| Redis 7 Docker | pipeline GET | 2.06 | Batch size 256 |
 
 ## Working-Set And Token Reduction
 
@@ -73,5 +95,5 @@ Docker reproduction helper: `N=1000 examples/redis_docker_bench.sh`.
 |---|---|---|
 | Working-set | 100 rings / 10k docs | scanned/query `10000 -> 100` |
 | Memory-pressure | 100 rings / 100k docs / 512-byte payload | candidate memory/query `93.079 MiB -> 0.931 MiB` |
-| Synthetic RAG | fixed recall | recall `1.000`, scanned/query `8000 -> 1000`, tokens/query `3960 -> 657.8` |
+| Synthetic RAG | fixed recall | recall `1.000`, scanned/query `8000 -> 1000`, tokens/query `3955 -> 657` |
 | AI/RAG case study | generated JSONL, 400 docs / 6 rings | recall `1.000`, scanned/query `400 -> 40`, tokens/query `615.2 -> 231.6` |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -118,6 +118,11 @@ running cluster. When `--data=DIR` is omitted, embedded commands use
 ```sh
 roche put --ring=docs/japan --payload='{"title":"Hello"}' --codec=json
 roche get --ring=docs/japan
+roche put --ring=orders --near=users/123 --payload='{"orderNo":"A-001"}' --codec=json
+roche get --ring=users/123 --subring=orders
+roche get --stellar=users/123 --filter='{"kind":"order"}' --subring=orders
+roche stellar attach --stellar=commerce/order/A-001 --ring=users/123
+roche stellar detach --stellar=commerce/order/A-001 --ring=users/123
 roche get --ring=docs/japan --limit=1 --rsort=time
 roche get --ring=docs/japan --pagination=on --page=2 --pagelimit=20 --sort=id
 roche get --ring=docs/japan --filter='{"id":"RAW_ID"}' --selection='{ title }'
@@ -151,8 +156,11 @@ roche get --ring=logs/raw --limit=1
 
 | Command | Required flags | Purpose |
 |---|---|---|
-| `put` | `--ring=RING` plus `--payload=TEXT` or `--in=FILE`; optional `--codec=auto|raw|json|nif|bif` | Store a document and print `id`, `rawId`, and codec. `auto` uses the ring profile. |
-| `get` | `--ring=RING`; optional `--filter=JSON`, `--selection=SEL`, `--limit=N`, `--cursor=CURSOR`, `--sort=id|time`, `--rsort=id|time`, `--pagination=on|off`, `--page=N`, `--pagelimit=N`, `--view=raw|auto|base64|hex` | Read from one ring. It always returns an `items` array with returned-item `count` and `nextCursor`; use `--limit=1` when you only want one item. Sorting is applied to the fetched page/filter window, not as a global full-ring sort. The default view is `auto`: payload codec is inferred from stored metadata. |
+| `put` | `--ring=RING` plus `--payload=TEXT` or `--in=FILE`; optional `--near=BASE_RING`, `--codec=auto|raw|json|nif|bif` | Store a document and print `id`, `rawId`, resolved ring, and codec. `--near=users/123 --ring=orders` stores into the nearby coordinate `users/123/orders`. `auto` uses the ring profile. |
+| `get` | `--ring=RING` or `--stellar=RING`; optional `--subring=a,b`, `--filter=JSON`, `--selection=SEL`, `--limit=N`, `--cursor=CURSOR`, `--sort=id|time`, `--rsort=id|time`, `--pagination=on|off`, `--page=N`, `--pagelimit=N`, `--view=raw|auto|base64|hex` | Read the ring or stellar coordinate's neighborhood. It always returns an `items` array and includes per-ring groups in `rings`. Use `--subring` to narrow the field of view. A `--filter='{"id":"RAW_ID"}'` read stays on the exact ring path for script compatibility. Sorting is applied to the fetched page/filter window, not as a global full-ring sort. The default view is `auto`: payload codec is inferred from stored metadata. |
+| `stellar attach` | `--stellar=RING --ring=RING` | Add an existing ring coordinate to a stellar coordinate's visible lens. Payloads are not copied. |
+| `stellar detach` | `--stellar=RING --ring=RING` | Remove a ring coordinate from a stellar coordinate's visible lens. Payloads are not deleted. |
+| `stellar list` | `--stellar=RING` | List rings attached to a stellar coordinate. |
 | `query` | `--ring=RING --filter='{"id":"ID"}' --selection=SEL`; optional `--id=ID` | Compatibility command for JSON projection by ID. Prefer `get --selection=...` for new CLI use. |
 | `list-ring` | `--ring=RING` | Compatibility command for listing records in one ring. Prefer `get --ring=...` for new CLI use. |
 | `count-ring` | `--ring=RING` | Count records in one ring. |
@@ -172,6 +180,40 @@ administration is not available in this release.
 `--filter` is a JSON object. `{"id":"RAW_ID"}` performs an exact read, while
 other top-level fields filter JSON records in the selected ring. `--where` is
 accepted as a compatibility alias for `--filter`.
+
+`--near` is a write-time placement hint, not a persistent relationship field.
+For example, `roche put --near=users/123 --ring=orders ...` writes the record to
+`users/123/orders`. Later reads use the coordinate itself:
+
+```sh
+roche get --ring=users/123
+roche get --stellar=users/123 --filter='{"kind":"order"}' --subring=orders
+roche get --ring=users/123/orders
+roche get --ring=users/123 --subring=orders
+```
+
+This is similar to pointing a telescope at a ring. Nearby satellites are in the
+same field of view; distant rings are not pulled in just to emulate a global
+join.
+
+`stellar attach` and `stellar detach` adjust a stellar coordinate's lens after
+data already exists:
+
+```sh
+roche put --ring=users/123 --payload='{"kind":"user"}' --codec=json
+roche put --ring=shops/1123 --payload='{"kind":"shop"}' --codec=json
+roche put --ring=orders/A-001 --payload='{"kind":"order"}' --codec=json
+
+roche stellar attach --stellar=commerce/order/A-001 --ring=users/123
+roche stellar attach --stellar=commerce/order/A-001 --ring=shops/1123
+roche stellar attach --stellar=commerce/order/A-001 --ring=orders/A-001
+
+roche get --stellar=commerce/order/A-001 --filter='{"kind":"shop"}'
+roche stellar detach --stellar=commerce/order/A-001 --ring=shops/1123
+```
+
+This is a lens relationship, not a copy operation. Compaction can later use the
+same metadata to place related coordinates more favorably on disk.
 
 `--sort=FIELD` sorts ascending and `--rsort=FIELD` sorts descending. Supported
 fields are `id` and `time` (`write` is accepted as a compatibility alias for

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -226,6 +226,7 @@ For scripts and reproducible examples, prefer the single-shot commands above.
 | Command | Required flags | Purpose |
 |---|---|---|
 | `compact` | `--data=DIR` | Compact WAL. |
+| `locality` | `--data=DIR`; optional `--metrics` | Inspect physical WAL locality by ring. |
 | `backup` | `--data=DIR --backup=DIR` | Create backup. |
 | `restore` | `--backup=DIR --data=DIR` | Restore backup. |
 | `backup-encrypted` | `--data=DIR --backup=DIR --passphrase=TEXT` | Create encrypted backup. |

--- a/docs/data-locality.md
+++ b/docs/data-locality.md
@@ -1,0 +1,122 @@
+# Data Locality
+
+RocheDB uses rings as logical locality hints, but locality is not only a
+logical concept. Persistent embedded stores also expose physical WAL locality
+metrics so users can inspect whether related live records are physically grouped
+after real write patterns.
+
+This document describes the current locality model and the first measurement
+surface. It is intentionally conservative: these metrics describe RocheDB's WAL
+layout, not a universal storage-performance claim.
+
+## Logical Locality
+
+Applications place records into rings. A ring is not just a directory-like
+route. It is the retrieval unit RocheDB uses to reduce unnecessary scans,
+candidate memory, and downstream payload work.
+
+For AI/RAG-style workloads, this means the application can make the natural
+structure of the corpus part of the retrieval model. For web workloads, it means
+user-, tenant-, topic-, region-, or time-oriented records can be grouped in a
+way that matches common reads.
+
+## Physical Locality
+
+Persistent embedded stores use an append-only WAL. Before compaction, physical
+record order mostly follows write order. If writes are interleaved across many
+rings, the physical layout can also be interleaved.
+
+Compaction rewrites a compact WAL snapshot from live state. RocheDB writes live
+particle records in stable `(ringKey, seq)` order during snapshot creation. That
+makes compaction locality-aware for the primary ring layout:
+
+- live records from the same ring are grouped together;
+- deleted or overwritten particle records are removed from the compact snapshot;
+- ring metadata and durable queues are written in deterministic order;
+- the append-only operational WAL remains simple between compactions.
+
+This is the first step toward answering locality questions with measurements
+rather than only design language.
+
+## Locality Report
+
+The embedded API exposes:
+
+```nim
+let report = db.localityReport()
+```
+
+The CLI exposes the same information:
+
+```bash
+roche locality --data=/var/lib/rochedb
+roche locality --data=/var/lib/rochedb --metrics
+```
+
+Important fields:
+
+| Field | Meaning |
+| --- | --- |
+| `walBytes` | Current WAL size in bytes |
+| `totalParticleRecords` | Particle records physically present in the WAL |
+| `liveParticleRecords` | Particle records that still match live store state |
+| `deadParticleRecords` | Older overwritten or removed particle records |
+| `ringCount` | Number of rings with live particle records |
+| `ringRuns` | Number of contiguous live particle runs by ring |
+| `fragmentedRings` | Rings that appear in more than one physical run |
+| `avgRunRecords` | Average live records per physical ring run |
+| `maxRunRecords` | Largest contiguous live ring run |
+| `localityScore` | `ringCount / ringRuns`; `1.0` means one run per ring |
+
+`ringRuns` is the most direct physical locality signal. If `ringCount=10` and
+`ringRuns=10`, each ring appears as one contiguous live run in the WAL. If
+`ringRuns=1000`, writes have fragmented ring locality and compaction may help.
+
+## Demo
+
+Run:
+
+```bash
+examples/locality_layout_demo.sh
+```
+
+Example output from a small local run:
+
+```text
+before_compact ... ringCount=4 ringRuns=43 fragmentedRings=4 avgRunRecords=1.023 localityScore=0.093023
+compact beforeBytes=4964 afterBytes=4968 items=44
+after_compact ... ringCount=4 ringRuns=4 fragmentedRings=0 avgRunRecords=11.000 localityScore=1.000000
+```
+
+The demo intentionally writes records in an interleaved pattern, then runs
+compaction. The important result is not the exact byte count; it is that the
+same live records become physically grouped by ring after compaction.
+
+## Current Scope
+
+This is not a full LSM-tree, B+ tree, or columnar layout. RocheDB's current
+layout bet is simpler:
+
+1. Use rings to reduce the logical working set before retrieval.
+2. Keep normal writes append-only.
+3. Use compaction to restore physical ring grouping for live records.
+4. Measure the effect directly through locality metrics.
+
+Secondary access paths should avoid fighting this primary layout. In the current
+design, secondary mechanisms should remain hints, projections, or lookup maps
+that point back into ring-local reads instead of becoming a competing primary
+layout.
+
+## What Still Needs Work
+
+The next locality work should add benchmark cases for:
+
+- random writes;
+- delete-heavy workloads;
+- backfill-heavy workloads;
+- hot/cold ring skew;
+- read latency before and after locality-aware compaction;
+- larger datasets where OS page cache and SSD read behavior become visible.
+
+Those cases are deliberately separate from the first metric surface so the core
+behavior remains easy to audit.

--- a/docs/data-locality.md
+++ b/docs/data-locality.md
@@ -20,6 +20,70 @@ structure of the corpus part of the retrieval model. For web workloads, it means
 user-, tenant-, topic-, region-, or time-oriented records can be grouped in a
 way that matches common reads.
 
+## Stellar Neighborhood Reads
+
+RocheDB treats nearby rings as a natural read neighborhood. The mental model is
+closer to a telescope than to a late join: when the read is centered on a ring,
+nearby child, parent, and sibling rings can be in the same field of view. Distant
+rings are not forced into the read path.
+
+For example, an application can store a user profile at `users/123` and then
+place orders and billing records nearby:
+
+```bash
+roche put --ring=users/123 \
+  --payload='{"kind":"user","name":"Alice"}' --codec=json
+
+roche put --ring=orders --near=users/123 \
+  --payload='{"kind":"order","orderNo":"A-001"}' --codec=json
+
+roche put --ring=billing --near=users/123 \
+  --payload='{"kind":"billing","plan":"pro"}' --codec=json
+```
+
+The `--near=users/123 --ring=orders` write resolves to the concrete coordinate
+`users/123/orders`. The `near` hint is not stored as a separate relationship.
+After the write, the coordinate is the relationship.
+
+Reading the user ring can naturally return the nearby user, order, and billing
+records:
+
+```bash
+roche get --ring=users/123
+roche get --stellar=users/123 --filter='{"kind":"order"}' --subring=orders
+```
+
+Reading from the order side also sees the nearby user because the order is in
+the same stellar neighborhood:
+
+```bash
+roche get --ring=users/123/orders
+```
+
+To narrow the field of view, use `--subring`:
+
+```bash
+roche get --ring=users/123 --subring=orders,billing
+```
+
+Existing coordinates can also be attached to or detached from a stellar
+coordinate's lens:
+
+```bash
+roche stellar attach --stellar=commerce/order/A-001 --ring=users/123
+roche stellar attach --stellar=commerce/order/A-001 --ring=shops/1123
+roche stellar attach --stellar=commerce/order/A-001 --ring=orders/A-001
+roche stellar detach --stellar=commerce/order/A-001 --ring=shops/1123
+```
+
+Attach/detach changes visibility metadata only. It does not copy payloads,
+delete payloads, or create a strict relational constraint.
+
+This is not a hidden global join. RocheDB only walks the configured nearby
+coordinate neighborhood, controlled by depth and branch budget. If a record is
+far away, such as `users/999/orders`, it is not read when the telescope is
+pointed at `users/123`.
+
 ## Physical Locality
 
 Persistent embedded stores use an append-only WAL. Before compaction, physical
@@ -106,6 +170,17 @@ Secondary access paths should avoid fighting this primary layout. In the current
 design, secondary mechanisms should remain hints, projections, or lookup maps
 that point back into ring-local reads instead of becoming a competing primary
 layout.
+
+Stellar attach/detach is part of that rule. It changes which coordinates are
+visible through a lens. The current compact implementation still groups live
+records by ring. A future compaction pass can use stellar lens metadata to place
+small nearby coordinates immediately when cheap, or defer large/crowded rings to
+scheduled compaction.
+
+Another future option is shadow compaction through a parallel universe: keep the
+active universe serving reads/writes, compact a synced universe in the
+background, verify it, then promote it. That is roadmap work; the current
+implementation keeps compaction simple and local.
 
 ## What Still Needs Work
 

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -1,0 +1,68 @@
+# Development Workflow
+
+RocheDB uses a stable-main workflow.
+
+## Branch Roles
+
+| Branch | Role |
+| --- | --- |
+| `main` | Released, tagged, public-stable state. Documentation and package metadata on `main` should describe what users can install or evaluate now. |
+| `devel` | Integration branch for the next release. Feature work targets `devel` first, not `main`. |
+| `feature/...` | Focused implementation branches created from `devel`. |
+| `docs/...` | Documentation-only branches created from `devel` unless they are patching released docs. |
+| `test/...` | Test and CI changes created from `devel` unless they are release hotfixes. |
+| `release/vX.Y.Z` | Short-lived release preparation branch cut from `devel` after the next release scope is ready. |
+| `hotfix/...` | Urgent fix branch cut from `main` when the released state needs a direct patch. |
+
+## Normal Feature Flow
+
+1. Update local `devel`.
+2. Create a focused branch from `devel`.
+3. Implement and test the change.
+4. Open a PR into `devel`.
+5. Merge only after CI passes.
+
+Feature branches should not target `main` directly. This keeps `main` aligned
+with released tags and avoids exposing half-integrated work as the public
+default state.
+
+## Release Flow
+
+1. Decide the next release scope on `devel`.
+2. Cut `release/vX.Y.Z` from `devel`.
+3. Update package metadata, release notes, and release checklist state.
+4. Open a PR from `release/vX.Y.Z` into `main`.
+5. Merge after CI passes.
+6. Tag the merge commit on `main`.
+7. Create the GitHub Release from the release notes.
+
+Tags are created only from `main`.
+
+## Hotfix Flow
+
+Use a hotfix only when the currently released state needs a direct correction.
+
+1. Create `hotfix/...` from `main`.
+2. Apply the smallest safe fix.
+3. PR into `main`.
+4. Tag a patch release after merge.
+5. Merge or cherry-pick the fix back into `devel`.
+
+## Work In Progress
+
+Large work should stay on a feature branch until it is coherent enough to enter
+`devel`. If work must pause while a release is prepared, stash or commit it on
+the feature branch. Do not apply unfinished feature work directly to `devel`.
+
+## CI Expectations
+
+The repository CI is the release gate for merged branches. Core checks include:
+
+- Nim semantic checks;
+- SSL-enabled checks;
+- C ABI contract checks;
+- core tests;
+- CLI, cluster, recovery, universe, and TLS smoke tests.
+
+Driver compatibility tests may remain optional when the relevant driver
+repositories are developed separately.

--- a/docs/github-release-v0.5.0.md
+++ b/docs/github-release-v0.5.0.md
@@ -1,0 +1,117 @@
+# RocheDB v0.5.0
+
+RocheDB v0.5.0 is a technical-preview release focused on making RocheDB's
+placement-aware data model more explicit and more useful for ordinary
+application workflows.
+
+Release:
+
+https://github.com/puffball1567/rochedb/releases/tag/v0.5.0
+
+RocheDB is still not presented as a production replacement for Redis,
+PostgreSQL, MongoDB, Apache Arrow, or a dedicated vector database. The stronger
+claim in this release is narrower: RocheDB can make meaningful data placement
+part of the read path, operating boundary, and high-integrity application
+workflow.
+
+## Main Changes
+
+- Added stellar locality lens workflows.
+- Added `roche get --stellar=...` with `--subring`, filter, selection, and
+  grouped output.
+- Added `roche stellar attach|detach|list`.
+- Added non-copy visibility metadata for existing rings.
+- Added embedded atomic bulk helpers:
+  - `batchPutAtomic`
+  - `batchUpdateAtomic`
+  - `batchDeleteAtomic`
+- Added opt-in embedded cooperative coordinate locks:
+  - `acquireRingLock`
+  - `acquireStellarLock`
+  - `withRingLock`
+  - `withStellarLock`
+  - `releaseLock`
+  - `lockActive`
+- Added `docs/unique-data-model.md`.
+- Added `examples/stellar_data_model_demo.sh`.
+- Updated benchmark comparison tables and benchmark notes with the latest local
+  and Docker-Docker measurements.
+
+## Why This Release Matters
+
+RocheDB's model is no longer only "place records in rings and retrieve from
+rings". This release adds a clearer shape for application data:
+
+```text
+ring     = meaningful coordinate
+stellar  = locality lens over related coordinates
+subring  = narrowed field of view
+lock     = opt-in coordination around a coordinate or lens
+atomic   = all-or-nothing embedded bulk workflow
+```
+
+This makes RocheDB more useful for ordinary application domains such as SaaS,
+CRM, support tools, catalogs, user/order detail views, and AI/RAG knowledge
+systems. It does not turn RocheDB into a payment ledger or a financial core
+database, but it gives application workflows stronger primitives around
+external payment systems, retries, webhooks, and coordinated updates.
+
+## Example
+
+```sh
+roche put --ring=users/123 \
+  --payload='{"kind":"user","name":"Alice"}' --codec=json
+
+roche put --ring=shops/1123 \
+  --payload='{"kind":"shop","name":"Orbit Store"}' --codec=json
+
+roche put --ring=orders/A-001 \
+  --payload='{"kind":"order","orderNo":"A-001","total":42}' --codec=json
+
+roche stellar attach --stellar=commerce/order/A-001 --ring=users/123
+roche stellar attach --stellar=commerce/order/A-001 --ring=shops/1123
+roche stellar attach --stellar=commerce/order/A-001 --ring=orders/A-001
+
+roche get --stellar=commerce/order/A-001 \
+  --selection='{ kind name orderNo total }'
+
+roche get --stellar=commerce/order/A-001 --subring=shops
+```
+
+## Benchmark Notes
+
+The benchmark documents were updated with the latest local verification pass.
+The headline working-set results remain stable:
+
+- Working-set benchmark: scanned/query `10000 -> 100`.
+- Memory-pressure benchmark: candidate memory/query `46.539 MiB -> 0.465 MiB`
+  in the light verification run.
+- Synthetic RAG benchmark: recall stayed `1.000` while scanned/query dropped
+  `8000 -> 1000` and estimated tokens/query dropped `3955 -> 657`.
+- Local Redis comparison: RocheDB single TCP GET remains in the same latency
+  class as Redis GET, while RocheDB batch get remains faster than Redis
+  pipeline GET in the local helper run.
+
+These are local benchmark results, not universal performance claims. The point
+is that the reduced working set is not being bought with an obviously slow
+local read path.
+
+## Verification
+
+The local verification pass included:
+
+- `nim check src/rochedb.nim`
+- `nim check src/rochecli.nim`
+- `scripts/test_core.sh`
+- `scripts/cli_crud_smoke.sh`
+- working-set, memory-pressure, RAG, Redis, PostgreSQL, and Docker-Docker
+  comparison helpers during the feature branch verification cycle
+- `git diff --check`
+
+## Known Boundaries
+
+- Cluster transaction coordinator redundancy is still planned.
+- Dynamic membership / arc-table based remapping is still planned.
+- Cooperative locks are embedded opt-in workflow guards in this release; normal
+  `put`, `get`, `list`, and `retrieve` paths do not check them.
+- RocheDB is not a payment ledger or a financial-core database.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ downstream AI/RAG or application logic.
 - [Cloud Operations Metrics](cloud-operations.md)
 - [Threat Model](threat-model.md)
 - [Test Coverage](test-coverage.md)
+- [Development Workflow](development-workflow.md)
 
 ## Drivers And Protocol
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ downstream AI/RAG or application logic.
 - [Configuration Reference](config-reference.md)
 - [CLI Reference](cli-reference.md)
 - [How RocheDB Differs From Typical NoSQL](nosql-positioning.md)
+- [Unique Data Model And Operating Patterns](unique-data-model.md)
 - [Feature Status / Roadmap](rochedb-status.md)
 - [Benchmark Notes](rochedb-bench.md)
 - [Benchmark Comparison Tables](benchmark-comparison.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,7 @@ downstream AI/RAG or application logic.
 - [Topology Configuration](topology-config.md)
 - [Topology Pattern Catalog](topology-examples.md)
 - [Universe Sync](universe-sync.md)
+- [Data Locality](data-locality.md)
 - [Cloud Operations Metrics](cloud-operations.md)
 - [Threat Model](threat-model.md)
 - [Test Coverage](test-coverage.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,4 +48,4 @@ downstream AI/RAG or application logic.
 ## Release
 
 - [Release Checklist](release-checklist.md)
-- [GitHub Release Draft](github-release-v0.4.1.md)
+- [GitHub Release Draft](github-release-v0.5.0.md)

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -113,6 +113,7 @@ The C ABI exposes matching additive functions: `roche_put_codec`,
 | `tunedRetrievalPlan(db, profile = "default", ...)` | Build a plan from a stored profile. |
 | `searchPlan(...)` | Build a plan from human-facing amount/scope/depth terms. |
 | `ringMetrics()` | Return low-level ring metrics. |
+| `localityReport()` | Return physical WAL locality metrics for embedded stores. |
 | `ringSummaries(queryVec = @[])` | Return ring centroids, coherence, mass, and optional similarity scores. |
 | `retrievalEnvelope(...)` | Return retrieval results with source metadata for RAG/MCP adapters. |
 

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -22,6 +22,7 @@ technical preview. The canonical Nim definitions live in `src/rochedb.nim`.
 | `RocheReadPage` | `ring`, `count`, `items`, `nextCursor`, `pagination`, `page`, `pageLimit`, `sortField`, `sortDirection` | Ring read result. `count` is the number of returned items; use `countByRing` for the total ring size. |
 | `RocheStellarOptions` | `filter`, `selection`, `limitPerRing`, `maxDepth`, `branchBudget`, `subrings`, `includeRoot`, `sortField`, `sortDirection` | Coordinate-near read options. A root ring behaves like a telescope target; nearby rings are visible unless narrowed by `subrings`. |
 | `RocheStellarPage` | `root`, `ringsVisited`, `count`, `rings` | Grouped result for a stellar neighborhood read. |
+| `RocheLockToken` | `scope`, `coordinate`, `token`, `expiresAt`, `keys` | Cooperative opt-in lock token for high-integrity embedded workflows. |
 | `RocheHit` | `id`, `score`, `payload` | Retrieval hit. `score` is cosine similarity, higher is closer. |
 
 `RocheId` should normally be treated as opaque. `toRaw` and `fromRaw` exist for
@@ -98,8 +99,11 @@ For application-facing tuning, prefer `SearchProfile` over raw numeric knobs:
 | `patch(id, patchDoc)` | Apply a JSON merge patch. |
 | `deleteById(id)` / `remove(id)` | Delete by ID. |
 | `batchPut(payloads, ring, vecs)` | Insert multiple records. |
+| `batchPutAtomic(payloads/docs, ring, vecs)` | Embedded all-or-nothing bulk insert. Rolls back every staged write if any step fails. |
 | `batchGet(ids)` | Fetch multiple IDs. |
 | `batchDelete(ids)` | Delete multiple IDs. |
+| `batchUpdateAtomic(ids, payloads/docs, vecs)` | Embedded all-or-nothing bulk replace. Every ID must exist before commit. |
+| `batchDeleteAtomic(ids)` | Embedded all-or-nothing bulk delete. |
 
 The C ABI exposes matching additive functions: `roche_put_codec`,
 `roche_put_vec_codec`, and `roche_get_codec`. See [Payload Codecs](payload-codecs.md).
@@ -145,6 +149,26 @@ The C ABI exposes matching additive functions: `roche_put_codec`,
 
 Cluster transactions are a PoC. They use a landing intent and retry apply, but
 coordinator redundancy is still planned.
+
+## Cooperative Locks
+
+Coordinate locks are opt-in guards for high-integrity embedded workflows. Normal
+`put`, `get`, `list`, and `retrieve` do not check these locks, so the lightweight
+NoSQL path remains unchanged. Use locks around workflows that need explicit
+coordination, idempotency, or rollback behavior.
+
+| API | Purpose |
+|---|---|
+| `acquireRingLock(ring, ttlSeconds = 30.0, waitMs = 0)` | Acquire a cooperative lock for one ring coordinate. |
+| `acquireStellarLock(stellar, ttlSeconds = 30.0, waitMs = 0)` | Acquire a cooperative lock for a stellar lens and its current member rings. |
+| `releaseLock(token)` | Release a lock if the owner token still matches. |
+| `withRingLock(ring, proc())` | Acquire/release a ring lock around a body. |
+| `withStellarLock(stellar, proc())` | Acquire/release a stellar lock around a body. |
+
+These locks are not presented as a payment-ledger or financial-core mechanism.
+They are intended for application workflows such as order state updates,
+webhook processing, retry-safe maintenance, and coordinated edits around a ring
+or stellar lens.
 
 ## Atlas And Descriptions
 

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -20,6 +20,8 @@ technical preview. The canonical Nim definitions live in `src/rochedb.nim`.
 | `RocheListPage` | `items`, `nextCursor` | Cursor-paginated list result. Empty `nextCursor` means there is no next page. |
 | `RocheReadOptions` | `filter`, `selection`, `limit`, `cursor`, `pagination`, `page`, `pageLimit`, `sortField`, `sortDirection` | Ring read options shared with CLI semantics. |
 | `RocheReadPage` | `ring`, `count`, `items`, `nextCursor`, `pagination`, `page`, `pageLimit`, `sortField`, `sortDirection` | Ring read result. `count` is the number of returned items; use `countByRing` for the total ring size. |
+| `RocheStellarOptions` | `filter`, `selection`, `limitPerRing`, `maxDepth`, `branchBudget`, `subrings`, `includeRoot`, `sortField`, `sortDirection` | Coordinate-near read options. A root ring behaves like a telescope target; nearby rings are visible unless narrowed by `subrings`. |
+| `RocheStellarPage` | `root`, `ringsVisited`, `count`, `rings` | Grouped result for a stellar neighborhood read. |
 | `RocheHit` | `id`, `score`, `payload` | Retrieval hit. `score` is cosine similarity, higher is closer. |
 
 `RocheId` should normally be treated as opaque. `toRaw` and `fromRaw` exist for
@@ -86,6 +88,7 @@ For application-facing tuning, prefer `SearchProfile` over raw numeric knobs:
 | `put(payload, ring = "default", vec = @[])` | Store a string payload in a ring. |
 | `put(doc: JsonNode, ring = "default", vec = @[])` | Store a JSON document. |
 | `put(encodedPayload(bytes, codec), ring, vec)` | Store `raw`, `json`, `nif`, or `bif` bytes with format metadata. |
+| `putNear(baseRing, payload/doc/encoded, ring, vec = @[])` | Store under a nearby coordinate derived from `baseRing/ring`, for example `users/123` + `orders` -> `users/123/orders`. The near hint is not stored separately. |
 | `get(id)` | Fetch by RocheDB ID. |
 | `getEncoded(id)` | Fetch payload bytes together with their `PayloadCodec`. |
 | `query(id, selection)` | Fetch a JSON projection using GraphQL-style selection syntax. |
@@ -107,6 +110,8 @@ The C ABI exposes matching additive functions: `roche_put_codec`,
 |---|---|
 | `listByRing(ring, limit = 100, cursor = "")` | List records in one ring with cursor pagination. |
 | `readRing(ring, options = defaultReadOptions())` | Read one ring with filter, selection, cursor/page limit, and page-local sort. |
+| `readStellar(root, options = defaultStellarOptions())` | Read the root ring and nearby coordinate rings. Parent, child, and sibling rings can be in the same field of view; distant rings are not forced into the read path. |
+| `nearRing(baseRing, ring)` | Resolve a write-time nearby coordinate, for example `nearRing("users/123", "orders") == "users/123/orders"`. |
 | `countByRing(ring)` | Count records in one ring. |
 | `retrieve(queryVec, ring = "", budget = 8, ...)` | Vector/RAG-style retrieval with ring-aware planning. |
 | `retrievalPlan(...)` | Build a readable retrieval plan without executing it. |

--- a/docs/rochedb-bench.md
+++ b/docs/rochedb-bench.md
@@ -96,7 +96,7 @@ measured layer: core `27.5 ns`, public API `54.7 ns`, and C ABI `77.7 ns`.
 
 # Cluster Mode and PostgreSQL Reference
 
-- Date: 2026-07-08, after the v0.2.5 read-path and benchmark-ring fixes
+- Date: 2026-07-15, after the locality/stellar branch verification run
 - Environment: same machine, AMD Ryzen 5 5600H / Linux 6.8 / Nim 2.2.10
 - RocheDB setup: three `roched` nodes, persistence enabled, single client,
   persistent TCP connection, 100-byte payload, `n=10000`
@@ -105,10 +105,14 @@ measured layer: core `27.5 ns`, public API `54.7 ns`, and C ABI `77.7 ns`.
 - Reproduction helper: `N=10000 examples/postgres_bench.sh` starts a temporary
   three-node RocheDB cluster and a temporary local PostgreSQL cluster, then runs
   both benchmark shapes. It requires `initdb`, `pg_ctl`, `psql`, and `pgbench`
-  from a local PostgreSQL installation.
+  from a local PostgreSQL installation. Both RocheDB and PostgreSQL use fresh
+  temporary data directories for each helper run, and the helper removes them on
+  exit.
 - Docker reproduction helper: `N=10000 examples/postgres_docker_bench.sh`
   starts three RocheDB containers and one PostgreSQL container on the same
   Docker network, then runs the same benchmark shapes from inside containers.
+  It creates fresh containers, a fresh Docker network, and temporary data
+  directories for each run.
 - Benchmark guard: the client configures a long-period benchmark ring and
   samples `locate` across the measurement horizon. The selected ring must stay
   on one owner during the run so handoff traffic is not mixed into the local
@@ -118,9 +122,9 @@ measured layer: core `27.5 ns`, public API `54.7 ns`, and C ABI `77.7 ns`.
 
 | Operation | us/op | ops/s |
 |---|---:|---:|
-| put, location calculation + 1 RTT + append log | 47.7 | 20,976 |
-| get, location calculation + 1 RTT | 45.9 | 21,797 |
-| query, server-side JSON projection | 50.2 | 19,904 |
+| put, location calculation + 1 RTT + append log | 48.8 | 20,490 |
+| get, location calculation + 1 RTT | 46.8 | 21,368 |
+| query, server-side JSON projection | 53.3 | 18,772 |
 
 ## PostgreSQL 14 Reference
 
@@ -131,61 +135,62 @@ thread, local TCP endpoint, `pgbench -M prepared`.
 
 | Operation | us/op | Notes |
 |---|---:|---|
-| single-key read | 45.9 | Three `roched` nodes, persistence enabled |
-| single-row write | 47.7 | Three `roched` nodes, persistence enabled |
+| single-key read | 46.8 | Three `roched` nodes, persistence enabled |
+| single-row write | 48.8 | Three `roched` nodes, persistence enabled |
+| query projection | 53.3 | Server-side JSON projection |
 | strong-durability write | not measured | `durStrong` / `--durability=strong` was not part of this comparison |
 
 ### PostgreSQL Measurements
 
 | Operation | us/op | Notes |
 |---|---:|---|
-| primary-key `SELECT` | 67 | 14,986 tps |
-| single-row write, `synchronous_commit=off` | 79 | 12,699 tps |
-| single-row write, `synchronous_commit=on` | 1998 | 501 tps |
+| primary-key `SELECT` | 68 | 14,659 tps |
+| single-row write, `synchronous_commit=off` | 80 | 12,433 tps |
+| single-row write, `synchronous_commit=on` | 1935 | 517 tps |
 
 Interpretation: this compares a thin KV/document path with a SQL RDBMS path that
 includes parsing, planning, MVCC, and index maintenance. The defensible claim is
 that RocheDB's network KV path is in the same latency class as PostgreSQL
 primary-key access and is ahead under these local conditions: PostgreSQL SELECT
-was about 1.5x slower than RocheDB read, and PostgreSQL
-`synchronous_commit=off` write was about 1.7x slower than RocheDB write in this
+was about 1.45x slower than RocheDB read, and PostgreSQL
+`synchronous_commit=off` write was about 1.64x slower than RocheDB write in this
 run. RocheDB's durability mode in this comparison was closer to
 `synchronous_commit=off`.
 RocheDB now has `durStrong` / `--durability=strong`, but that path was not part
-of the 2026-07-08 PostgreSQL comparison.
+of the 2026-07-15 PostgreSQL comparison.
 
 ## Docker-Docker PostgreSQL Reference
 
-- Date: 2026-07-08
+- Date: 2026-07-15
 - Environment: same host, Docker `overlay2`, RocheDB image built from
   `examples/compose/Dockerfile`, PostgreSQL image `postgres:14`
 - Setup: three RocheDB containers and one PostgreSQL container on the same
   Docker network, single client, 100-byte payload, `n=10000`
 - Data placement: RocheDB and PostgreSQL data directories are bind-mounted from
-  the repository `.tmp` directory during the helper run. They are not tmpfs
-  mounts.
+  a temporary helper directory during the run. They are not tmpfs mounts. The
+  helper removes the temporary data on exit.
 - Reproduction: `N=10000 examples/postgres_docker_bench.sh`
 
 ### RocheDB Docker Measurements
 
 | Operation | us/op | ops/s |
 |---|---:|---:|
-| put, location calculation + 1 RTT + append log | 56.4 | 17,744 |
-| get, location calculation + 1 RTT | 53.5 | 18,683 |
-| query, server-side JSON projection | 60.0 | 16,665 |
+| put, location calculation + 1 RTT + append log | 103.6 | 9,655 |
+| get, location calculation + 1 RTT | 61.3 | 16,323 |
+| query, server-side JSON projection | 65.3 | 15,310 |
 
 ### PostgreSQL Docker Measurements
 
 | Operation | us/op | Notes |
 |---|---:|---|
-| primary-key `SELECT` | 92 | 10,869 tps |
-| single-row write, `synchronous_commit=off` | 130 | 7,666 tps |
-| single-row write, `synchronous_commit=on` | 1134 | 882 tps |
+| primary-key `SELECT` | 103 | 9,669 tps |
+| single-row write, `synchronous_commit=off` | 149 | 6,720 tps |
+| single-row write, `synchronous_commit=on` | 1162 | 860 tps |
 
 Interpretation: this is a container-to-container comparison, not the same axis
 as the local-host PostgreSQL reference above. In this Docker run, PostgreSQL
 SELECT was about 1.7x slower than RocheDB read, and PostgreSQL
-`synchronous_commit=off` write was about 2.3x slower than RocheDB write.
+`synchronous_commit=off` write was about 1.4x slower than RocheDB write.
 
 ## Optimization History
 
@@ -215,7 +220,7 @@ revisit fixes this because movement is forward-only.
 
 # Redis Approximation and BGET
 
-- Date: 2026-07-08, after the v0.2.5 landing-zone read-path fix
+- Date: 2026-07-15
 - Environment: same machine, AMD Ryzen 5 5600H / Linux 6.8 / Nim 2.2.10
   `-d:release`
 - Redis: local `/usr/bin/redis-server`, Redis 6.0.16, endpoint
@@ -228,29 +233,44 @@ revisit fixes this because movement is forward-only.
   `roche redis-bench --n=1000 --payload-bytes=100 --redis=127.0.0.1:6379
   --peers=127.0.0.1:17301`
 - Local reproduction helper: `N=1000 examples/redis_local_bench.sh` starts one
-  local `roched` and compares it with an existing local Redis endpoint.
+  local `roched` with a fresh temporary data directory and compares it with an
+  existing local Redis endpoint. Redis keys use a unique
+  `rochedb:bench:<timestamp>:` prefix and are deleted before exit.
 - Docker reproduction helper: `N=1000 examples/redis_docker_bench.sh` builds a
   RocheDB Docker image, starts Redis and RocheDB on the same Docker network, and
-  runs the benchmark from inside that network.
+  runs the benchmark from inside that network. With an already-built image, use
+  `BUILD_IMAGE=0 N=1000 examples/redis_docker_bench.sh`.
 - Purpose: smoke-test whether RocheDB simple read and batch read are in the same
   latency class as Redis TCP and Redis pipeline under local constraints
 
 | Operation | us/op | Interpretation |
 |---|---:|---|
 | RocheDB embedded get | 0.03 | In-process hot path; no TCP |
-| RocheDB TCP get | 44.87 | One request / one response |
-| RocheDB TCP BGET | 1.47 | Batch read; comparable axis to Redis pipeline |
+| RocheDB TCP get | 45.26 | One request / one response |
+| RocheDB TCP BGET | 1.48 | Batch read; comparable axis to Redis pipeline |
 
 Redis measurements under the same local benchmark shape:
 
 | Operation | us/op | Interpretation |
 |---|---:|---|
-| Redis TCP GET | 41.23 | Local Redis, non-pipelined |
-| Redis pipeline GET | 3.68 | Batch size 256 |
+| Redis TCP GET | 42.85 | Local Redis, non-pipelined |
+| Redis pipeline GET | 3.53 | Batch size 256 |
+
+Docker-Docker measurements under the same benchmark shape:
+
+| Operation | us/op | Interpretation |
+|---|---:|---|
+| RocheDB embedded get | 0.04 | In-process hot path inside the benchmark container |
+| RocheDB TCP get | 55.78 | One request / one response across the Docker network |
+| RocheDB TCP BGET | 1.71 | Batch read; comparable axis to Redis pipeline |
+| Redis TCP GET | 48.74 | Redis 7 container, non-pipelined |
+| Redis pipeline GET | 2.06 | Batch size 256 |
 
 Interpretation: RocheDB TCP get is in the same latency class as non-pipelined
 Redis GET, but local Redis was slightly faster for single GET. In this smoke
-test, RocheDB TCP BGET was about 2.5x faster than Redis pipeline GET. This is
+test, RocheDB TCP BGET was about 2.4x faster than Redis pipeline GET. In the
+Docker-Docker run, RocheDB TCP BGET was about 1.2x faster than Redis pipeline
+GET. This is
 not a claim that RocheDB is always faster than Redis.
 Payload size, batch size, Redis configuration, network mode, and data size need
 broader measurement.
@@ -263,18 +283,18 @@ working set can still be read in a competitive latency class.
 
 # Semantic Working-Set Reduction
 
-- Date: 2026-07-04
+- Date: 2026-07-15
 - Environment: same machine, AMD Ryzen 5 5600H / Linux 6.8 / Nim 2.2.10
   `-d:release`, embedded mode, persistence disabled
 - Reproduction: `roche working-set-bench --n=10000 --rings=100
-  --queries=10 --budget=20`
+  --queries=50 --budget=20`
 - Purpose: measure whether ring routing reduces physically scanned records per
   query, rather than full-scanning the entire corpus faster
 
 | Condition | scanned/query | latency/query |
 |---|---:|---:|
-| global retrieve | 10000.0 | 2129.1 us |
-| routed retrieve | 100.0 | 31.6 us |
+| global retrieve | 10000.0 | 1954.9 us |
+| routed retrieve | 100.0 | 31.4 us |
 
 ```text
 reduction scanned=99.00%
@@ -316,7 +336,7 @@ fewer records.
 
 # Memory-Pressure Case Study
 
-- Date: 2026-07-05
+- Date: 2026-07-15
 - Environment: same machine, AMD Ryzen 5 5600H / Linux 6.8 / Nim 2.2.10
   `-d:release`, embedded mode, persistence disabled
 - Reproduction: `roche memory-pressure-bench --n=100000 --rings=100
@@ -327,8 +347,8 @@ fewer records.
 
 | Condition | scanned/query | candidate memory/query | latency/query |
 |---|---:|---:|---:|
-| global retrieve | 100000.0 | 93.079 MiB | 37186.3 us |
-| routed retrieve | 1000.0 | 0.931 MiB | 508.9 us |
+| global retrieve | 100000.0 | 93.079 MiB | 34750.2 us |
+| routed retrieve | 1000.0 | 0.931 MiB | 462.3 us |
 
 ```text
 reduction scanned=99.00% candidate_memory=99.00% memory_ratio=100.0x
@@ -349,7 +369,7 @@ Token reduction is covered by the RAG-style quality-fixed benchmark.
 
 # RAG-Style Quality-Fixed Benchmark
 
-- Date: 2026-07-04
+- Date: 2026-07-15
 - Environment: same machine, AMD Ryzen 5 5600H / Linux 6.8 / Nim 2.2.10
   `-d:release`, embedded mode, persistence disabled
 - Reproduction: `roche rag-bench --n=8000 --queries=80 --budget=20
@@ -359,8 +379,8 @@ Token reduction is covered by the RAG-style quality-fixed benchmark.
 
 | Condition | recall | scanned/query | tokens/query | budget |
 |---|---:|---:|---:|---:|
-| global | 1.000 | 8000.0 | 3960.0 | 20 |
-| routed | 1.000 | 1000.0 | 657.8 | 3 |
+| global | 1.000 | 8000.0 | 3955.0 | 20 |
+| routed | 1.000 | 1000.0 | 657.0 | 3 |
 
 Interpretation: synthetic data showed no recall loss while reducing scanned
 records to 1/8 and estimated tokens to roughly 1/6. This supports the first

--- a/docs/rochedb-status.md
+++ b/docs/rochedb-status.md
@@ -41,7 +41,8 @@ Translations:
 |---|---|---|
 | Append-only WAL | Done | Batched flush by default; `durStrong` / `--durability=strong` adds flush + fsync write boundaries |
 | Reopen recovery | Done | Items / vectors / ring metadata / descriptions |
-| Transaction | Done | Embedded atomic transaction |
+| Transaction | Done | Embedded atomic transaction plus all-or-nothing `batchPutAtomic`, `batchUpdateAtomic`, and `batchDeleteAtomic` helpers |
+| Cooperative coordinate locks | Done | Embedded opt-in `ring` and `stellar` locks for high-integrity workflows; normal NoSQL read/write paths do not check locks |
 | Cluster transaction landing | PoC | node0 landing. `scripts/cluster_tx_smoke.sh` covers apply smoke; `scripts/cluster_failure_smoke.sh` covers owner crash/restart retry; redundancy is not implemented yet |
 | Cluster CRUD/list/count | PoC | `update`, `deleteById`, JSON `patch`, `listByRing`, `countByRing` use landing intents or node fan-out; `scripts/cluster_tx_smoke.sh` covers smoke |
 | Compact | Done | Rebuilds WAL from live records |

--- a/docs/rochedb-status.md
+++ b/docs/rochedb-status.md
@@ -107,6 +107,7 @@ Translations:
 | Redis comparison | Done | Smoke test with conditions and limits documented |
 | C ABI bench | Done | `examples/cbench.c` |
 | Docker case study | Partial | memory pressure / PHP / Swift smoke |
+| Unique data model demo | Done | `examples/stellar_data_model_demo.sh` demonstrates separate rings, stellar attach/detach, narrowed reads, and non-copy visibility changes |
 | Cluster transaction smoke | Partial | `scripts/cluster_tx_smoke.sh` starts 3 local nodes and verifies apply / retrieve |
 | Cluster failure retry smoke | Partial | `scripts/cluster_failure_smoke.sh` kills the owner node, verifies the intent remains pending, restarts the owner, and verifies retry apply |
 | Universe sync demo | Done | `examples/universe_sync_demo.sh` builds a small source/target pair, demonstrates API-level sync, then demonstrates the CLI export/sync/prune boundary. `scripts/universe_sync_failure_smoke.sh` verifies malformed JSONL handling, replay idempotency, and explicit ack/prune. `scripts/universe_sync_remote_smoke.sh` verifies remote `--peers` delivery and target-down retry behavior |

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -56,3 +56,19 @@ than hidden assumptions:
 - TLS deployment tests once transport TLS is added;
 - larger universe sync replay and backlog-pressure tests;
 - driver matrix CI across all published language repositories.
+
+## High-Integrity Workflow Matrix
+
+`tests/tapi.nim` includes focused coverage for the opt-in integrity path:
+
+| Area | Cases covered |
+|---|---|
+| Atomic put | multi-record commit, staged write rollback on exception, persistence replay |
+| Atomic update | length mismatch rejection, missing ID rollback, previous payload preservation |
+| Atomic delete | successful multi-delete, missing ID rollback, previous payload preservation |
+| Ring lock | same-ring conflict, disjoint-ring coexistence, release, TTL expiry |
+| Stellar lock | member-ring conflict, ring-to-stellar conflict, unrelated stellar coexistence |
+| Lock helper | `withRingLock` transaction body, `withStellarLock` release on exception |
+
+These tests intentionally keep locks opt-in. Ordinary `put`, `get`, `list`, and
+`retrieve` remain outside the lock check path.

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -12,8 +12,8 @@ matrix used before releases.
 | Field / halo movement | `tests/tfield.nim` | Unit-covered: field state and ring movement behavior |
 | Selection parser | `tests/tselect.nim` | Unit-covered: GraphQL-like selection parsing and projection basics |
 | Store / WAL | `tests/tstore.nim` | Unit-covered: codec persistence, torn-tail repair, transaction replay, compact, locality report, backup/restore |
-| Public embedded API | `tests/tapi.nim` | Unit-covered: put/get, codec-aware projection, ring profiles, readRing filtering, pagination, sorting, warp, universe sync |
-| CLI embedded usage | `scripts/cli_crud_smoke.sh` | Smoke-covered: help, put/get/query/list/count, readRing options, codec display, ring profile auto codec, shell, auth error text |
+| Public embedded API | `tests/tapi.nim` | Unit-covered: put/get, codec-aware projection, ring profiles, readRing filtering, pagination, sorting, stellar neighborhood reads from either side, stellar attach/detach persistence, warp, universe sync |
+| CLI embedded usage | `scripts/cli_crud_smoke.sh` | Smoke-covered: help, put/get/query/list/count, readRing options, `--near` placement, `--stellar`, stellar attach/detach, `--subring` neighborhood narrowing, codec display, ring profile auto codec, shell, auth error text |
 | C ABI | `examples/cabi_contract.c`, `scripts/driver_compat.sh` | Contract-covered: ABI version, put/get, codec metadata, read ring page shape, validation errors, atlas |
 | Wire protocol | `tests/twire_driver.nim`, `scripts/cluster_wire_fuzz_smoke.sh` | Smoke-covered: driver-facing PUTR/GETID/QRYID, codec metadata negotiation, malformed frame behavior |
 | TLS transport | `scripts/cluster_tls_smoke.sh` | Smoke-covered: TLS-enabled `roched`/CLI build, authenticated TLS health, secret-key auth transport, JSON put/get, and plain-client rejection |
@@ -23,6 +23,7 @@ matrix used before releases.
 | Universe sync | `examples/universe_sync_demo.nim`, `scripts/universe_sync_*_smoke.sh` | Smoke-covered: local export/apply, remote apply, idempotency, malformed JSONL handling |
 | Recovery | `scripts/recovery_smoke.sh` | Smoke-covered: backup/restore and recovery status paths |
 | Driver compatibility | `scripts/driver_compat.sh` | Optional smoke: C, C++, and published driver-facing C ABI paths when enabled |
+| Data model demos | `examples/stellar_data_model_demo.sh`, `examples/locality_layout_demo.sh` | Demo-covered: non-copy stellar visibility, narrowed stellar reads, original ring preservation after detach, and compaction locality reporting |
 
 ## Release Gate
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -12,7 +12,7 @@ matrix used before releases.
 | Field / halo movement | `tests/tfield.nim` | Unit-covered: field state and ring movement behavior |
 | Selection parser | `tests/tselect.nim` | Unit-covered: GraphQL-like selection parsing and projection basics |
 | Store / WAL | `tests/tstore.nim` | Unit-covered: codec persistence, torn-tail repair, transaction replay, compact, locality report, backup/restore |
-| Public embedded API | `tests/tapi.nim` | Unit-covered: put/get, codec-aware projection, ring profiles, readRing filtering, pagination, sorting, stellar neighborhood reads from either side, stellar attach/detach persistence, warp, universe sync |
+| Public embedded API | `tests/tapi.nim` | Unit-covered: put/get, codec-aware projection, ring profiles, readRing filtering, pagination, sorting, stellar neighborhood reads from either side, stellar attach/detach persistence, atomic batch rollback, cooperative ring/stellar locks, warp, universe sync |
 | CLI embedded usage | `scripts/cli_crud_smoke.sh` | Smoke-covered: help, put/get/query/list/count, readRing options, `--near` placement, `--stellar`, stellar attach/detach, `--subring` neighborhood narrowing, codec display, ring profile auto codec, shell, auth error text |
 | C ABI | `examples/cabi_contract.c`, `scripts/driver_compat.sh` | Contract-covered: ABI version, put/get, codec metadata, read ring page shape, validation errors, atlas |
 | Wire protocol | `tests/twire_driver.nim`, `scripts/cluster_wire_fuzz_smoke.sh` | Smoke-covered: driver-facing PUTR/GETID/QRYID, codec metadata negotiation, malformed frame behavior |

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -11,7 +11,7 @@ matrix used before releases.
 | Orbital placement core | `tests/tcore.nim` | Unit-covered: angle wrapping, ownership, future arrival, conjunctions |
 | Field / halo movement | `tests/tfield.nim` | Unit-covered: field state and ring movement behavior |
 | Selection parser | `tests/tselect.nim` | Unit-covered: GraphQL-like selection parsing and projection basics |
-| Store / WAL | `tests/tstore.nim` | Unit-covered: codec persistence, torn-tail repair, transaction replay, compact, backup/restore |
+| Store / WAL | `tests/tstore.nim` | Unit-covered: codec persistence, torn-tail repair, transaction replay, compact, locality report, backup/restore |
 | Public embedded API | `tests/tapi.nim` | Unit-covered: put/get, codec-aware projection, ring profiles, readRing filtering, pagination, sorting, warp, universe sync |
 | CLI embedded usage | `scripts/cli_crud_smoke.sh` | Smoke-covered: help, put/get/query/list/count, readRing options, codec display, ring profile auto codec, shell, auth error text |
 | C ABI | `examples/cabi_contract.c`, `scripts/driver_compat.sh` | Contract-covered: ABI version, put/get, codec metadata, read ring page shape, validation errors, atlas |

--- a/docs/unique-data-model.md
+++ b/docs/unique-data-model.md
@@ -1,0 +1,134 @@
+# Unique Data Model And Operating Patterns
+
+RocheDB's current direction is not only "a faster key/value path". Its more
+important direction is a placement-aware data model: the application stores
+records at meaningful coordinates, and those coordinates become part of the
+read path, maintenance path, dump/import boundary, and recovery topology.
+
+This document describes the RocheDB-specific shapes that are emerging from the
+current implementation.
+
+## Core Idea
+
+Most databases separate these concerns:
+
+- where data is stored;
+- how related data is found;
+- how a query is tuned;
+- how data is dumped, restored, synchronized, or isolated.
+
+RocheDB tries to make those concerns line up. A `ring` is not just a collection
+name. It is a coordinate that can reduce the working set before filtering,
+reranking, projection, or LLM/context processing.
+
+## RocheDB-Specific Shapes
+
+| Shape | What It Expresses | Why It Matters |
+|---|---|---|
+| `ring` | A meaningful locality coordinate such as `users/123`, `docs/japan`, or `tenant/acme/orders` | Reads can start from a smaller candidate set instead of scanning a broad collection |
+| ring hierarchy | Natural parent/child scope such as `users/123/orders` | Listing, dump, backup, and retrieval scope can follow application structure |
+| `stellar` lens | A coordinate-centered visibility lens over existing rings | Related records can be read together without copying payloads or creating a hidden global join |
+| `subring` | A narrowed field of view inside a ring or stellar read | The caller can ask for a nearby subset such as `orders` or `billing` |
+| projection / selection | Return only requested fields | Reduced ring scope can be combined with reduced payload shape |
+| galaxy | Isolation boundary for authentication, blast radius, and deployment topology | Different logical databases can use the same engine without forcing one global trust domain |
+| universe sync | Delayed convergence / recovery topology | Same-name galaxies can eventually converge across topology boundaries without turning all writes into one global transaction |
+
+## Example: User, Shop, And Order
+
+A traditional relational design often models this with tables and joins:
+
+```text
+users.id = orders.user_id
+shops.id = orders.shop_id
+```
+
+RocheDB can store the same facts as separate coordinates:
+
+```bash
+roche put --ring=users/123 \
+  --payload='{"kind":"user","name":"Alice"}' --codec=json
+
+roche put --ring=shops/1123 \
+  --payload='{"kind":"shop","name":"Orbit Store"}' --codec=json
+
+roche put --ring=orders/A-001 \
+  --payload='{"kind":"order","orderNo":"A-001","total":42}' --codec=json
+```
+
+Then it can attach those existing coordinates to a stellar lens:
+
+```bash
+roche stellar attach --stellar=commerce/order/A-001 --ring=users/123
+roche stellar attach --stellar=commerce/order/A-001 --ring=shops/1123
+roche stellar attach --stellar=commerce/order/A-001 --ring=orders/A-001
+```
+
+Now the order-centered read can see the nearby facts:
+
+```bash
+roche get --stellar=commerce/order/A-001
+```
+
+The caller can narrow the visible field:
+
+```bash
+roche get --stellar=commerce/order/A-001 --subring=shops
+roche get --stellar=commerce/order/A-001 --filter='{"kind":"order"}'
+roche get --stellar=commerce/order/A-001 --selection='{ kind name orderNo total }'
+```
+
+Attach/detach does not copy the payload. It changes the visibility metadata of
+the stellar lens:
+
+```bash
+roche stellar detach --stellar=commerce/order/A-001 --ring=shops/1123
+```
+
+This is not the same as a relational constraint. It is also not a global
+secondary index. It is a locality lens that points reads toward coordinates that
+are expected to be useful together.
+
+## Why This Can Help Data Processing
+
+This model can help when the expensive part is not only the final operation, but
+the amount of unrelated data that reaches it.
+
+Examples:
+
+- RAG and agent context: fewer unrelated chunks need to be scanned, reranked, or
+  placed into a context window.
+- Web systems: user, tenant, product, region, or lifecycle reads can avoid broad
+  application-side filtering.
+- Operational recovery: dump, restore, sync, and authorization can follow the
+  same locality boundaries used for reads.
+- Physical locality: compaction can use ring order today, and future compaction
+  can use stellar lens metadata as an additional placement hint.
+
+## Where It Is Not A Fit
+
+RocheDB should not pretend this model replaces every database shape.
+
+It is weaker when:
+
+- queries are mostly ad-hoc full-corpus analytics;
+- every field needs independent secondary-index lookup;
+- strict relational constraints are the main requirement;
+- global serial transaction order is mandatory;
+- the application cannot express useful placement.
+
+The stronger claim is narrower: when the application has meaningful locality,
+RocheDB can make that locality part of the database model instead of rebuilding
+it after every query.
+
+## Demo
+
+Run:
+
+```bash
+examples/stellar_data_model_demo.sh
+```
+
+The demo inserts user, shop, and order records into separate rings, attaches
+them to a stellar lens, reads them together, narrows the read with `--subring`,
+then detaches one coordinate to show that visibility changes without deleting
+payloads.

--- a/docs/unique-data-model.md
+++ b/docs/unique-data-model.md
@@ -30,6 +30,7 @@ reranking, projection, or LLM/context processing.
 | `stellar` lens | A coordinate-centered visibility lens over existing rings | Related records can be read together without copying payloads or creating a hidden global join |
 | `subring` | A narrowed field of view inside a ring or stellar read | The caller can ask for a nearby subset such as `orders` or `billing` |
 | projection / selection | Return only requested fields | Reduced ring scope can be combined with reduced payload shape |
+| cooperative coordinate lock | Opt-in lock around a ring or stellar lens | High-integrity workflows can coordinate updates without slowing ordinary reads/writes |
 | galaxy | Isolation boundary for authentication, blast radius, and deployment topology | Different logical databases can use the same engine without forcing one global trust domain |
 | universe sync | Delayed convergence / recovery topology | Same-name galaxies can eventually converge across topology boundaries without turning all writes into one global transaction |
 
@@ -87,6 +88,21 @@ roche stellar detach --stellar=commerce/order/A-001 --ring=shops/1123
 This is not the same as a relational constraint. It is also not a global
 secondary index. It is a locality lens that points reads toward coordinates that
 are expected to be useful together.
+
+When an application needs stronger coordination around the same shape, it can
+use opt-in locks and atomic batches:
+
+```nim
+db.withStellarLock("commerce/order/A-001", proc() =
+  db.transaction(proc(tx: RocheTx) =
+    discard tx.put("""{"kind":"event","status":"processing"}""",
+                   ring = "orders/A-001/events")
+  )
+)
+```
+
+Normal `put`, `get`, `list`, and `retrieve` calls do not check these locks. The
+high-integrity path is explicit so the lightweight NoSQL path stays lightweight.
 
 ## Why This Can Help Data Processing
 

--- a/examples/locality_layout_demo.nim
+++ b/examples/locality_layout_demo.nim
@@ -1,0 +1,59 @@
+## Physical locality demo for RocheDB's WAL layout.
+
+import std/[json, os, strformat, strutils, tempfiles]
+import ../src/rochedb
+
+proc argValue(name, defaultValue: string): string =
+  let prefix = "--" & name & "="
+  for arg in commandLineParams():
+    if arg.startsWith(prefix):
+      return arg[prefix.len .. ^1]
+  defaultValue
+
+proc argInt(name: string, defaultValue: int): int =
+  parseInt(argValue(name, $defaultValue))
+
+proc printReport(label: string, r: LocalityReport) =
+  echo &"{label} persistent={r.persistent} walBytes={r.walBytes} totalParticleRecords={r.totalParticleRecords} liveParticleRecords={r.liveParticleRecords} deadParticleRecords={r.deadParticleRecords} ringCount={r.ringCount} ringRuns={r.ringRuns} fragmentedRings={r.fragmentedRings} avgRunRecords={r.avgRunRecords:.3f} maxRunRecords={r.maxRunRecords} localityScore={r.localityScore:.6f}"
+
+when isMainModule:
+  let rings = max(1, argInt("rings", 8))
+  let perRing = max(1, argInt("per-ring", 200))
+  let backfill = max(0, argInt("backfill", 64))
+  let explicitDataDir = argValue("data", "")
+  let dataDir =
+    if explicitDataDir.len > 0: explicitDataDir
+    else: createTempDir("rochedb", "locality-layout-demo")
+  let cleanup = explicitDataDir.len == 0
+
+  if dirExists(dataDir):
+    removeDir(dataDir)
+  createDir(dataDir)
+
+  var db = open(dataDir = dataDir)
+  try:
+    for i in 0 ..< perRing:
+      for r in 0 ..< rings:
+        discard db.put(%*{
+          "phase": "interleaved",
+          "ring": r,
+          "i": i,
+          "body": "record-" & $r & "-" & $i
+        }, ring = "locality/ring-" & $r)
+
+    for i in 0 ..< backfill:
+      let r = (i * 7 + 3) mod rings
+      discard db.put(%*{
+        "phase": "backfill",
+        "ring": r,
+        "i": i
+      }, ring = "locality/ring-" & $r)
+
+    printReport("before_compact", db.localityReport())
+    let stats = db.compact()
+    echo &"compact beforeBytes={stats.beforeBytes} afterBytes={stats.afterBytes} items={stats.items}"
+    printReport("after_compact", db.localityReport())
+  finally:
+    db.close()
+    if cleanup:
+      removeDir(dataDir)

--- a/examples/locality_layout_demo.sh
+++ b/examples/locality_layout_demo.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RINGS="${RINGS:-8}"
+PER_RING="${PER_RING:-200}"
+BACKFILL="${BACKFILL:-64}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+mkdir -p bin
+nim c -d:release --nimcache:/tmp/nimcache_roche_locality_layout_demo \
+  -o:bin/locality_layout_demo examples/locality_layout_demo.nim
+
+bin/locality_layout_demo \
+  --rings="$RINGS" \
+  --per-ring="$PER_RING" \
+  --backfill="$BACKFILL"

--- a/examples/stellar_data_model_demo.sh
+++ b/examples/stellar_data_model_demo.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DATA="${TMPDIR:-/tmp}/rochedb-stellar-demo-$$"
+
+cleanup() {
+  rm -rf "$DATA"
+}
+trap cleanup EXIT
+
+cd "$ROOT"
+mkdir -p bin "$DATA"
+
+nim c -d:release --nimcache:/tmp/nimcache_roche_stellar_demo \
+  -o:bin/roche src/rochecli.nim >/dev/null
+
+ROCHE=(bin/roche --data="$DATA")
+
+echo "== Insert separate coordinates =="
+"${ROCHE[@]}" put --ring=users/123 \
+  --payload='{"kind":"user","name":"Alice","country":"JP"}' --codec=json
+"${ROCHE[@]}" put --ring=shops/1123 \
+  --payload='{"kind":"shop","name":"Orbit Store","market":"JP"}' --codec=json
+"${ROCHE[@]}" put --ring=orders/A-001 \
+  --payload='{"kind":"order","orderNo":"A-001","total":42}' --codec=json
+
+echo
+echo "== Attach existing coordinates to a stellar lens =="
+"${ROCHE[@]}" stellar attach --stellar=commerce/order/A-001 --ring=users/123
+"${ROCHE[@]}" stellar attach --stellar=commerce/order/A-001 --ring=shops/1123
+"${ROCHE[@]}" stellar attach --stellar=commerce/order/A-001 --ring=orders/A-001
+
+echo
+echo "== Read the order-centered stellar lens =="
+"${ROCHE[@]}" get --stellar=commerce/order/A-001 \
+  --selection='{ kind name orderNo total }'
+
+echo
+echo "== Narrow the field of view to shops =="
+"${ROCHE[@]}" get --stellar=commerce/order/A-001 --subring=shops \
+  --selection='{ kind name }'
+
+echo
+echo "== Detach the shop coordinate without deleting its payload =="
+"${ROCHE[@]}" stellar detach --stellar=commerce/order/A-001 --ring=shops/1123
+
+echo
+echo "== The stellar lens no longer sees the shop =="
+"${ROCHE[@]}" get --stellar=commerce/order/A-001 --filter='{"kind":"shop"}'
+
+echo
+echo "== The original shop ring still exists =="
+"${ROCHE[@]}" get --ring=shops/1123 --selection='{ kind name }'

--- a/rochedb.nimble
+++ b/rochedb.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version     = "0.4.1"
+version     = "0.5.0"
 author      = "puffball1567"
 description = "Ring-oriented NoSQL document/vector store for smaller working sets"
 license     = "Apache-2.0"

--- a/scripts/cli_crud_smoke.sh
+++ b/scripts/cli_crud_smoke.sh
@@ -58,6 +58,58 @@ bin/roche get --ring=docs/japan --filter='{"status":"draft"}' --selection='{ tit
 bin/roche query --ring=docs/japan --filter="{\"id\":\"$raw_id\"}" --selection='{ title }' |
   grep -q '"title": "Hello"'
 
+echo "[cli-crud] stellar-near ring reads"
+bin/roche put --ring=users/123 \
+  --payload='{"kind":"user","name":"Alice"}' --codec=json >/dev/null
+bin/roche put --ring=orders --near=users/123 \
+  --payload='{"kind":"order","orderNo":"A-001"}' --codec=json >/dev/null
+bin/roche put --ring=billing --near=users/123 \
+  --payload='{"kind":"billing","plan":"pro"}' --codec=json >/dev/null
+bin/roche put --ring=users/999/orders \
+  --payload='{"kind":"order","orderNo":"B-999"}' --codec=json >/dev/null
+stellar_user="$(bin/roche get --ring=users/123 --limit=10)"
+grep -q '"ring": "users/123/orders"' <<<"$stellar_user"
+grep -q '"ring": "users/123/billing"' <<<"$stellar_user"
+if grep -q 'B-999' <<<"$stellar_user"; then
+  echo "stellar user read included a distant ring" >&2
+  exit 1
+fi
+stellar_order="$(bin/roche get --ring=users/123/orders --limit=10)"
+grep -q '"ring": "users/123"' <<<"$stellar_order"
+grep -q '"orderNo": "A-001"' <<<"$stellar_order"
+stellar_subring="$(bin/roche get --ring=users/123 --subring=orders --limit=10)"
+grep -q '"ring": "users/123/orders"' <<<"$stellar_subring"
+if grep -q '"ring": "users/123/billing"' <<<"$stellar_subring"; then
+  echo "subring read included billing" >&2
+  exit 1
+fi
+stellar_named="$(bin/roche get --stellar=users/123 --filter='{"kind":"order"}' --subring=orders --limit=10)"
+grep -q '"ring": "users/123/orders"' <<<"$stellar_named"
+grep -q '"orderNo": "A-001"' <<<"$stellar_named"
+if grep -q '"ring": "users/123/billing"' <<<"$stellar_named"; then
+  echo "stellar read included billing" >&2
+  exit 1
+fi
+bin/roche put --ring=shops/1123 \
+  --payload='{"kind":"shop","name":"Shop 1123"}' --codec=json >/dev/null
+bin/roche put --ring=orders/A-002 \
+  --payload='{"kind":"order","orderNo":"A-002","userId":"123","shopId":"1123"}' --codec=json >/dev/null
+bin/roche stellar attach --stellar=commerce/order/A-002 --ring=users/123 |
+  grep -q '"status": "attached"'
+bin/roche stellar attach --stellar=commerce/order/A-002 --ring=shops/1123 |
+  grep -q '"status": "attached"'
+bin/roche stellar attach --stellar=commerce/order/A-002 --ring=orders/A-002 |
+  grep -q '"status": "attached"'
+stellar_attached="$(bin/roche get --stellar=commerce/order/A-002 --filter='{"kind":"shop"}' --limit=10)"
+grep -q '"ring": "shops/1123"' <<<"$stellar_attached"
+bin/roche stellar detach --stellar=commerce/order/A-002 --ring=shops/1123 |
+  grep -q '"status": "detached"'
+stellar_detached="$(bin/roche get --stellar=commerce/order/A-002 --filter='{"kind":"shop"}' --limit=10)"
+if grep -q '"ring": "shops/1123"' <<<"$stellar_detached"; then
+  echo "detached stellar member remained visible" >&2
+  exit 1
+fi
+
 echo "[cli-crud] explicit and profile-driven codecs"
 printf '(object (title "NIF text"))' >"$WORK/payload.nif"
 nif_out="$(bin/roche put --ring=artifacts/nif \

--- a/src/roche/store.nim
+++ b/src/roche/store.nim
@@ -30,7 +30,7 @@
 ##   UA <len>\n<eventKey>\n                         universe sync event applied marker
 ##   Q <nextTxId>\n                                      次の transaction id
 
-import std/[tables, os, streams, strutils, monotimes, times, posix, json]
+import std/[algorithm, tables, os, streams, strutils, monotimes, times, posix, json]
 import nimsodium
 import payload
 
@@ -116,6 +116,22 @@ type
     appliedClusterTx*: int
     warpJobs*: int
     universeSyncEvents*: int
+
+  StoreLocalityReport* = object
+    ## Physical WAL locality measured from particle record order.
+    ## ringRuns is the number of contiguous live particle runs by ring.
+    ## Lower ringRuns/ringCount means related records are physically grouped.
+    persistent*: bool
+    walBytes*: BiggestInt
+    totalParticleRecords*: int
+    liveParticleRecords*: int
+    deadParticleRecords*: int
+    ringCount*: int
+    ringRuns*: int
+    fragmentedRings*: int
+    avgRunRecords*: float
+    maxRunRecords*: int
+    localityScore*: float
 
   StoreBackupStats* = object
     bytes*: BiggestInt
@@ -608,16 +624,31 @@ proc writeSnapshotFile(s: Store, path: string) =
       file.write(s.galaxyDescription)
       file.write("\n")
     file.write("Q " & $s.nextTxId & "\n")
-    for ringKey, name in s.ringNames:
+    var ringNameKeys: seq[uint64] = @[]
+    for ringKey in s.ringNames.keys:
+      ringNameKeys.add ringKey
+    ringNameKeys.sort()
+    for ringKey in ringNameKeys:
+      let name = s.ringNames[ringKey]
       file.write("N " & $ringKey & " " & $name.len & "\n")
       file.write(name)
       file.write("\n")
-    for ringKey, desc in s.ringDescriptions:
+    var ringDescKeys: seq[uint64] = @[]
+    for ringKey in s.ringDescriptions.keys:
+      ringDescKeys.add ringKey
+    ringDescKeys.sort()
+    for ringKey in ringDescKeys:
+      let desc = s.ringDescriptions[ringKey]
       if desc.len > 0:
         file.write("RD " & $ringKey & " " & $desc.len & "\n")
         file.write(desc)
         file.write("\n")
-    for ringKey, profile in s.ringPayloadProfiles:
+    var profileKeys: seq[uint64] = @[]
+    for ringKey in s.ringPayloadProfiles.keys:
+      profileKeys.add ringKey
+    profileKeys.sort()
+    for ringKey in profileKeys:
+      let profile = s.ringPayloadProfiles[ringKey]
       let raw = $(%*{
         "defaultCodec": profile.defaultCodec.payloadCodecName,
         "charset": profile.charset,
@@ -626,14 +657,40 @@ proc writeSnapshotFile(s: Store, path: string) =
       file.write("RP " & $ringKey & " " & $raw.len & "\n")
       file.write(raw)
       file.write("\n")
-    for ringKey, meta in s.ringMeta:
+    var metaKeys: seq[uint64] = @[]
+    for ringKey in s.ringMeta.keys:
+      metaKeys.add ringKey
+    metaKeys.sort()
+    for ringKey in metaKeys:
+      let meta = s.ringMeta[ringKey]
       file.write("R " & $ringKey & " " & $meta.period & " " & $meta.head & "\n")
-    for _, p in s.items:
+    var itemKeys: seq[(uint64, uint32)] = @[]
+    for k in s.items.keys:
+      itemKeys.add k
+    itemKeys.sort(proc(a, b: (uint64, uint32)): int =
+      result = cmp(a[0], b[0])
+      if result == 0:
+        result = cmp(a[1], b[1]))
+    for k in itemKeys:
+      let p = s.items[k]
       file.writeParticleRecord("", 0, p)
-    for old, f in s.forwarders:
+    var forwarderKeys: seq[(uint64, uint32)] = @[]
+    for k in s.forwarders.keys:
+      forwarderKeys.add k
+    forwarderKeys.sort(proc(a, b: (uint64, uint32)): int =
+      result = cmp(a[0], b[0])
+      if result == 0:
+        result = cmp(a[1], b[1]))
+    for old in forwarderKeys:
+      let f = s.forwarders[old]
       file.write("F " & $old[0] & " " & $old[1] & " " & $f.newParent & " " &
                  $f.newSeq & " " & $f.newTWrite & " " & $f.expiresAt & "\n")
-    for _, intent in s.clusterTx:
+    var clusterKeys: seq[uint64] = @[]
+    for txid in s.clusterTx.keys:
+      clusterKeys.add txid
+    clusterKeys.sort()
+    for txid in clusterKeys:
+      let intent = s.clusterTx[txid]
       file.write("CT " & $intent.id & "\n")
       for op in intent.ops:
         file.writeClusterTxOp(intent.id, op)
@@ -641,18 +698,38 @@ proc writeSnapshotFile(s: Store, path: string) =
         file.write("CC " & $intent.id & "\n")
       if intent.applied:
         file.write("CA " & $intent.id & "\n")
-    for txid, applied in s.appliedClusterTx:
+    var appliedClusterKeys: seq[uint64] = @[]
+    for txid in s.appliedClusterTx.keys:
+      appliedClusterKeys.add txid
+    appliedClusterKeys.sort()
+    for txid in appliedClusterKeys:
+      let applied = s.appliedClusterTx[txid]
       if applied and txid notin s.clusterTx:
         file.write("CA " & $txid & "\n")
-    for jobId, blob in s.warpJobs:
+    var warpKeys: seq[uint64] = @[]
+    for jobId in s.warpJobs.keys:
+      warpKeys.add jobId
+    warpKeys.sort()
+    for jobId in warpKeys:
+      let blob = s.warpJobs[jobId]
       file.write("WJ " & $jobId & " " & $blob.len & "\n")
       file.write(blob)
       file.write("\n")
-    for eventId, blob in s.universeSyncEvents:
+    var universeKeys: seq[uint64] = @[]
+    for eventId in s.universeSyncEvents.keys:
+      universeKeys.add eventId
+    universeKeys.sort()
+    for eventId in universeKeys:
+      let blob = s.universeSyncEvents[eventId]
       file.write("UJ " & $eventId & " " & $blob.len & "\n")
       file.write(blob)
       file.write("\n")
-    for eventKey, applied in s.appliedUniverseSyncEvents:
+    var appliedUniverseKeys: seq[string] = @[]
+    for eventKey in s.appliedUniverseSyncEvents.keys:
+      appliedUniverseKeys.add eventKey
+    appliedUniverseKeys.sort()
+    for eventKey in appliedUniverseKeys:
+      let applied = s.appliedUniverseSyncEvents[eventKey]
       if applied:
         file.write("UA " & $eventKey.len & "\n")
         file.write(eventKey)
@@ -681,6 +758,102 @@ proc snapshotStatsFromFile(path, source: string): StoreBackupStats =
   var s = Store(lastFlush: getMonoTime(), nextTxId: 1)
   s.replay(path, repair = false)
   result = s.snapshotStats(path, source)
+
+proc isLiveParticle(s: Store, p: Particle): bool =
+  let k = key(p.parent, p.seq)
+  if k notin s.items:
+    return false
+  let live = s.items[k]
+  live.parent == p.parent and live.seq == p.seq and
+    abs(live.tWrite - p.tWrite) < 1e-9
+
+proc localityReport*(s: Store): StoreLocalityReport =
+  ## Inspect the physical WAL particle order and report ring locality.
+  result.persistent = s.persistent
+  result.walBytes = s.logSize()
+  if not s.persistent or s.logPath.len == 0 or not fileExists(s.logPath):
+    result.liveParticleRecords = s.items.len
+    result.ringCount = s.itemsByRing.len
+    result.ringRuns = result.ringCount
+    result.avgRunRecords = if result.ringRuns == 0: 0.0
+                           else: float(result.liveParticleRecords) / float(result.ringRuns)
+    result.maxRunRecords = result.liveParticleRecords
+    result.localityScore = 1.0
+    return
+
+  if s.persistent:
+    s.flushMaybe(force = true)
+
+  let fs = newFileStream(s.logPath, fmRead)
+  if fs.isNil:
+    return
+  defer: fs.close()
+
+  var line = ""
+  var lastRing = 0'u64
+  var haveLast = false
+  var currentRun = 0
+  var runCounts = initTable[uint64, int]()
+  var rings = initTable[uint64, bool]()
+
+  while fs.readLine(line):
+    if line.len == 0:
+      continue
+    let parts = line.split(' ')
+    try:
+      case parts[0]
+      of "P":
+        inc result.totalParticleRecords
+        let p = fs.readParticleRecord(parts, 1)
+        if s.isLiveParticle(p):
+          inc result.liveParticleRecords
+          rings[p.parent] = true
+          if not haveLast or p.parent != lastRing:
+            if haveLast and currentRun > 0:
+              result.maxRunRecords = max(result.maxRunRecords, currentRun)
+            inc result.ringRuns
+            runCounts[p.parent] = runCounts.getOrDefault(p.parent, 0) + 1
+            lastRing = p.parent
+            haveLast = true
+            currentRun = 1
+          else:
+            inc currentRun
+        else:
+          inc result.deadParticleRecords
+      of "XP":
+        inc result.totalParticleRecords
+        let p = fs.readParticleRecord(parts, 2)
+        if s.isLiveParticle(p):
+          inc result.liveParticleRecords
+          rings[p.parent] = true
+          if not haveLast or p.parent != lastRing:
+            if haveLast and currentRun > 0:
+              result.maxRunRecords = max(result.maxRunRecords, currentRun)
+            inc result.ringRuns
+            runCounts[p.parent] = runCounts.getOrDefault(p.parent, 0) + 1
+            lastRing = p.parent
+            haveLast = true
+            currentRun = 1
+          else:
+            inc currentRun
+        else:
+          inc result.deadParticleRecords
+      else:
+        discard
+    except CatchableError:
+      break
+  if haveLast and currentRun > 0:
+    result.maxRunRecords = max(result.maxRunRecords, currentRun)
+
+  result.ringCount = rings.len
+  for _, runs in runCounts:
+    if runs > 1:
+      inc result.fragmentedRings
+  result.avgRunRecords = if result.ringRuns == 0: 0.0
+                         else: float(result.liveParticleRecords) / float(result.ringRuns)
+  result.localityScore =
+    if result.ringRuns == 0: 1.0
+    else: float(max(1, result.ringCount)) / float(result.ringRuns)
 
 proc compact*(s: Store): StoreCompactStats =
   ## 生存レコードだけで WAL を再構築する。

--- a/src/roche/store.nim
+++ b/src/roche/store.nim
@@ -15,6 +15,7 @@
 ##   RD <ringKey> <len>\n<description>\n                     環説明
 ##   R <ringKey> <period> <head>\n                             環メタ
 ##   RP <ringKey> <len>\n<json>\n                              環payload profile
+##   SM <len>\n<json>\n                                    stellar coordinate map
 ##   P <parent> <seq> <period> <head> <tWrite> <len> <dim> <codec>\n<payload><vec>\n
 ##                                                               粒子 upsert
 ##   E <parent> <seq> <dim>\n<dim×float32>\n                    埋め込み
@@ -155,6 +156,7 @@ type
     ringNames*: Table[uint64, string]
     ringDescriptions*: Table[uint64, string]
     ringPayloadProfiles*: Table[uint64, RingPayloadProfile]
+    stellarMaps*: Table[string, string]
     galaxy*: string
     galaxyDescription*: string
     clusterTx*: Table[uint64, ClusterTxIntent]
@@ -417,6 +419,17 @@ proc replay(s: Store, path: string, repair = true) =
           charset: profile{"charset"}.getStr(""),
           formatVersion: profile{"formatVersion"}.getStr(""))
         fs.readRecordSep()
+      of "SM":
+        let len = parseInt(parts[1])
+        let raw = fs.readExactStr(len)
+        let node = parseJson(raw)
+        let stellar = node{"stellar"}.getStr("")
+        if stellar.len > 0:
+          if node{"deleted"}.getBool(false):
+            s.stellarMaps.del stellar
+          else:
+            s.stellarMaps[stellar] = raw
+        fs.readRecordSep()
       of "P":
         let p = fs.readParticleRecord(parts, 1)
         s.applyOp(TxOp(kind: txUpsert, p: p))
@@ -655,6 +668,15 @@ proc writeSnapshotFile(s: Store, path: string) =
         "formatVersion": profile.formatVersion
       })
       file.write("RP " & $ringKey & " " & $raw.len & "\n")
+      file.write(raw)
+      file.write("\n")
+    var stellarKeys: seq[string] = @[]
+    for stellar in s.stellarMaps.keys:
+      stellarKeys.add stellar
+    stellarKeys.sort()
+    for stellar in stellarKeys:
+      let raw = s.stellarMaps[stellar]
+      file.write("SM " & $raw.len & "\n")
       file.write(raw)
       file.write("\n")
     var metaKeys: seq[uint64] = @[]
@@ -1070,6 +1092,25 @@ proc putRingPayloadProfile*(s: Store, ringKey: uint64,
     })
     s.logFile.write("RP " & $ringKey & " " & $raw.len & "\n")
     s.logFile.write(raw)
+    s.logFile.write("\n")
+    s.flushMaybe(force = true)
+
+proc putStellarMap*(s: Store, stellar, blob: string) =
+  if stellar.len == 0:
+    raise newException(ValueError, "stellar coordinate is empty")
+  if blob.len == 0:
+    s.stellarMaps.del stellar
+    if s.persistent:
+      let raw = $(%*{"stellar": stellar, "deleted": true})
+      s.logFile.write("SM " & $raw.len & "\n")
+      s.logFile.write(raw)
+      s.logFile.write("\n")
+      s.flushMaybe(force = true)
+    return
+  s.stellarMaps[stellar] = blob
+  if s.persistent:
+    s.logFile.write("SM " & $blob.len & "\n")
+    s.logFile.write(blob)
     s.logFile.write("\n")
     s.flushMaybe(force = true)
 

--- a/src/rochecli.nim
+++ b/src/rochecli.nim
@@ -1361,6 +1361,27 @@ proc runCompact(dataDir: string) =
   db.close()
   echo &"compact OK before={stats.beforeBytes} after={stats.afterBytes} items={stats.items} rings={stats.ringMeta} names={stats.ringNames} clusterTx={stats.clusterTx}"
 
+proc runLocality(dataDir: string, metricsFormat: bool) =
+  if dataDir.len == 0:
+    raise newException(ValueError, "locality requires --data=DIR")
+  var db = open(dataDir = dataDir)
+  let report = db.localityReport()
+  db.close()
+  if metricsFormat:
+    echo &"localityPersistent {int(report.persistent)}"
+    echo &"localityWalBytes {report.walBytes}"
+    echo &"localityTotalParticleRecords {report.totalParticleRecords}"
+    echo &"localityLiveParticleRecords {report.liveParticleRecords}"
+    echo &"localityDeadParticleRecords {report.deadParticleRecords}"
+    echo &"localityRingCount {report.ringCount}"
+    echo &"localityRingRuns {report.ringRuns}"
+    echo &"localityFragmentedRings {report.fragmentedRings}"
+    echo &"localityAvgRunRecords {report.avgRunRecords:.3f}"
+    echo &"localityMaxRunRecords {report.maxRunRecords}"
+    echo &"localityScore {report.localityScore:.6f}"
+  else:
+    echo &"locality OK persistent={report.persistent} walBytes={report.walBytes} totalParticleRecords={report.totalParticleRecords} liveParticleRecords={report.liveParticleRecords} deadParticleRecords={report.deadParticleRecords} ringCount={report.ringCount} ringRuns={report.ringRuns} fragmentedRings={report.fragmentedRings} avgRunRecords={report.avgRunRecords:.3f} maxRunRecords={report.maxRunRecords} localityScore={report.localityScore:.6f}"
+
 proc runBackup(dataDir, backupDir: string) =
   if dataDir.len == 0 or backupDir.len == 0:
     raise newException(ValueError, "backup requires --data=DIR --backup=DIR")
@@ -2091,6 +2112,7 @@ proc printHelp() =
   echo "  roche health|metrics|rings --peers=host:port,..."
   echo "  roche driver list|info|install [LANG] [--manifest-path=FILE] [--execute]"
   echo "  roche compact --data=DIR"
+  echo "  roche locality --data=DIR [--metrics]"
   echo "  roche backup --data=DIR --backup=DIR"
   echo "  roche restore --backup=DIR --data=DIR [--overwrite]"
   echo "  roche dump --data=DIR [--out=FILE] [--no-vectors]"
@@ -2346,6 +2368,7 @@ proc main() =
     runDriver(driverArgs, driverManifestPath, driverProjectDir,
               executeDriverInstall)
   of "compact": runCompact(dataDir)
+  of "locality": runLocality(dataDir, metricsFormat)
   of "backup": runBackup(dataDir, backupDir)
   of "restore": runRestore(backupDir, dataDir, overwrite)
   of "backup-encrypted": runBackupEncrypted(dataDir, backupDir, backupPassphrase)

--- a/src/rochecli.nim
+++ b/src/rochecli.nim
@@ -1,8 +1,8 @@
 ## roche - RocheDB command-line client
 ##
 ## usage:
-##   roche put [--data=DIR | --peers=host:port,...] --ring=RING [--payload=TEXT | --in=FILE] [--codec=raw|json|nif|bif]
-##   roche get [--data=DIR | --peers=host:port,...] --ring=RING [--filter='{"id":"RAW_ID"}'] [--selection=SEL] [--sort=id|time] [--rsort=id|time]
+##   roche put [--data=DIR | --peers=host:port,...] --ring=RING [--near=BASE_RING] [--payload=TEXT | --in=FILE] [--codec=raw|json|nif|bif]
+##   roche get [--data=DIR | --peers=host:port,...] [--ring=RING | --stellar=RING] [--subring=orders,billing] [--filter='{"id":"RAW_ID"}'] [--selection=SEL] [--sort=id|time] [--rsort=id|time]
 ##   roche query [--data=DIR | --peers=host:port,...] --ring=RING [--filter='{"id":"RAW_ID"}' | --id=RAW_ID] --selection=SEL
 ##   roche list-ring [--data=DIR | --peers=host:port,...] --ring=RING [--limit=N] [--cursor=CURSOR]
 ##   roche count-ring [--data=DIR | --peers=host:port,...] --ring=RING
@@ -592,7 +592,7 @@ proc runAtlas(dataDir, peers, username, password, authToken, secretKey,
   db.close()
 
 proc runPut(dataDir, peers, username, password, authToken, secretKey,
-            galaxy, ring, payload, inPath, codecName: string,
+            galaxy, ring, nearRingBase, payload, inPath, codecName: string,
             tls: bool, tlsCaFile, tlsServerName: string,
             tlsInsecureSkipVerify: bool) =
   let actualDataDir = requireCliTarget(dataDir, peers)
@@ -603,13 +603,18 @@ proc runPut(dataDir, peers, username, password, authToken, secretKey,
                      tlsServerName = tlsServerName,
                      tlsInsecureSkipVerify = tlsInsecureSkipVerify)
   try:
+    let targetRing =
+      if nearRingBase.len > 0:
+        nearRing(nearRingBase, ring)
+      else:
+        ring
     let codec =
       if codecName.toLowerAscii() == "auto":
-        db.ringPayloadProfile(ring).defaultCodec
+        db.ringPayloadProfile(targetRing).defaultCodec
       else:
         parsePayloadCodec(codecName)
-    let id = db.put(encodedPayload(cliPayload(payload, inPath), codec), ring = ring)
-    echo &"put OK id={id} rawId={cliIdString(id)} ring={ring} codec={codec.payloadCodecName}"
+    let id = db.put(encodedPayload(cliPayload(payload, inPath), codec), ring = targetRing)
+    echo &"put OK id={id} rawId={cliIdString(id)} ring={targetRing} codec={codec.payloadCodecName}"
   finally:
     db.close()
 
@@ -718,6 +723,44 @@ proc readPageNode(page: RocheReadPage, view: string): JsonNode =
     "nextCursor": page.nextCursor
   }
 
+proc stellarPageNode(page: RocheStellarPage, view, sortField: string,
+                     sortDirection: RocheReadSortDirection): JsonNode =
+  var rings = newJArray()
+  var flatItems = newJArray()
+  for ringPage in page.rings:
+    var items = newJArray()
+    for item in ringPage.items:
+      let display = recordPayloadDisplay(item, view)
+      var node = %*{
+        "id": $item.id,
+        "rawId": item.id.cliIdString(),
+        "codec": item.codec.payloadCodecName,
+        "encoding": display["encoding"].getStr(),
+        "payload": display["payload"]
+      }
+      if display.hasKey("adapter"):
+        node["adapter"] = display["adapter"]
+      items.add node
+      var flatNode = node.copy()
+      flatNode["ring"] = %ringPage.ring
+      flatItems.add flatNode
+    rings.add %*{
+      "ring": ringPage.ring,
+      "count": ringPage.count,
+      "items": items
+    }
+  %*{
+    "root": page.root,
+    "maxDepth": page.maxDepth,
+    "branchBudget": page.branchBudget,
+    "ringsVisited": page.ringsVisited,
+    "count": page.count,
+    "sort": sortField,
+    "sortDirection": sortDirection.sortDirectionName,
+    "items": flatItems,
+    "rings": rings
+  }
+
 proc readSortOptions(sortArg, rsortArg: string): tuple[field: string, direction: RocheReadSortDirection] =
   if sortArg.len > 0 and rsortArg.len > 0:
     raise newException(ValueError, "--sort and --rsort cannot be used together")
@@ -734,9 +777,18 @@ proc readPaginationMode(value: string): RochePaginationMode =
   else:
     raise newException(ValueError, "pagination must be on or off")
 
+proc parseSubrings(value: string): seq[string] =
+  if value.len == 0:
+    return @[]
+  for part in value.split(","):
+    let clean = part.strip(chars = {' ', '\t', '\r', '\n', '/'})
+    if clean.len > 0:
+      result.add clean
+
 proc runGet(dataDir, peers, username, password, authToken, secretKey,
-            galaxy, idArg, filterArg, ring, view, selection, cursor: string,
-            limit, page, pageLimit: int, paginationArg, sortArg, rsortArg: string,
+            galaxy, idArg, filterArg, ring, subringArg, view, selection,
+            cursor: string, limit, page, pageLimit, depth, branchBudget: int,
+            paginationArg, sortArg, rsortArg: string,
             tls: bool, tlsCaFile, tlsServerName: string,
             tlsInsecureSkipVerify: bool) =
   let actualDataDir = requireCliTarget(dataDir, peers)
@@ -751,6 +803,7 @@ proc runGet(dataDir, peers, username, password, authToken, secretKey,
                      tlsInsecureSkipVerify = tlsInsecureSkipVerify)
   try:
     db.configureRing(ring, 60.0)
+    let subrings = parseSubrings(subringArg)
     let options = RocheReadOptions(
       filter: filterWithId(filterNode, resolvedId),
       selection: selection,
@@ -761,7 +814,20 @@ proc runGet(dataDir, peers, username, password, authToken, secretKey,
       pageLimit: pageLimit,
       sortField: sortOptions.field,
       sortDirection: sortOptions.direction)
-    echo db.readRing(ring, options).readPageNode(view).pretty
+    if subrings.len > 0 or resolvedId.len == 0:
+      let stellar = db.readStellar(ring, RocheStellarOptions(
+        filter: options.filter,
+        selection: selection,
+        limitPerRing: limit,
+        maxDepth: depth,
+        branchBudget: branchBudget,
+        subrings: subrings,
+        includeRoot: true,
+        sortField: sortOptions.field,
+        sortDirection: sortOptions.direction))
+      echo stellar.stellarPageNode(view, sortOptions.field, sortOptions.direction).pretty
+    else:
+      echo db.readRing(ring, options).readPageNode(view).pretty
   finally:
     db.close()
 
@@ -840,6 +906,52 @@ proc runRingProfile(dataDir, peers, username, password, authToken, secretKey,
       "charset": profile.charset,
       "formatVersion": profile.formatVersion
     }).pretty
+  finally:
+    db.close()
+
+proc runStellar(dataDir, peers, username, password, authToken, secretKey,
+                galaxy: string, args: seq[string], stellarName, ringName: string,
+                tls: bool, tlsCaFile, tlsServerName: string,
+                tlsInsecureSkipVerify: bool) =
+  let actualDataDir = requireCliTarget(dataDir, peers)
+  if args.len < 2:
+    raise newException(ValueError, "stellar requires attach, detach, or list")
+  let action = args[1]
+  var db = openCliDb(actualDataDir, peers, username, password, authToken, secretKey,
+                     galaxy, tls = tls, tlsCaFile = tlsCaFile,
+                     tlsServerName = tlsServerName,
+                     tlsInsecureSkipVerify = tlsInsecureSkipVerify)
+  try:
+    case action
+    of "attach":
+      if stellarName.len == 0 or ringName.len == 0:
+        raise newException(ValueError, "stellar attach requires --stellar=RING --ring=RING")
+      db.attachStellar(stellarName, ringName)
+      echo (%*{
+        "status": "attached",
+        "stellar": stellarName,
+        "ring": ringName,
+        "members": db.stellarMembers(stellarName)
+      }).pretty
+    of "detach":
+      if stellarName.len == 0 or ringName.len == 0:
+        raise newException(ValueError, "stellar detach requires --stellar=RING --ring=RING")
+      db.detachStellar(stellarName, ringName)
+      echo (%*{
+        "status": "detached",
+        "stellar": stellarName,
+        "ring": ringName,
+        "members": db.stellarMembers(stellarName)
+      }).pretty
+    of "list":
+      if stellarName.len == 0:
+        raise newException(ValueError, "stellar list requires --stellar=RING")
+      echo (%*{
+        "stellar": stellarName,
+        "members": db.stellarMembers(stellarName)
+      }).pretty
+    else:
+      raise newException(ValueError, "unknown stellar action: " & action)
   finally:
     db.close()
 
@@ -2101,8 +2213,9 @@ proc printHelp() =
   echo "RocheDB command-line client"
   echo ""
   echo "Usage:"
-  echo "  roche put [--data=DIR | --peers=host:port,...] --ring=RING [--payload=TEXT | --in=FILE] [--codec=auto|raw|json|nif|bif]"
-  echo "  roche get [--data=DIR | --peers=host:port,...] --ring=RING [--filter='{\"id\":\"RAW_ID\"}'] [--selection=SEL] [--limit=N] [--cursor=CURSOR] [--sort=id|time] [--rsort=id|time] [--pagination=on|off] [--page=N] [--pagelimit=N]"
+  echo "  roche put [--data=DIR | --peers=host:port,...] --ring=RING [--near=BASE_RING] [--payload=TEXT | --in=FILE] [--codec=auto|raw|json|nif|bif]"
+  echo "  roche get [--data=DIR | --peers=host:port,...] [--ring=RING | --stellar=RING] [--subring=orders,billing] [--filter='{\"id\":\"RAW_ID\"}'] [--selection=SEL] [--limit=N] [--cursor=CURSOR] [--sort=id|time] [--rsort=id|time] [--pagination=on|off] [--page=N] [--pagelimit=N]"
+  echo "  roche stellar attach|detach|list --stellar=RING [--ring=RING]"
   echo "  roche query [--data=DIR | --peers=host:port,...] --ring=RING [--filter='{\"id\":\"RAW_ID\"}' | --id=RAW_ID] --selection=SEL"
   echo "  roche list-ring [--data=DIR | --peers=host:port,...] --ring=RING [--limit=N] [--cursor=CURSOR]"
   echo "  roche count-ring [--data=DIR | --peers=host:port,...] --ring=RING"
@@ -2147,6 +2260,8 @@ proc main() =
   var formatVersion = ""
   var view = "auto"
   var idArg = ""
+  var nearRingBase = ""
+  var subringArg = ""
   var whereArg = ""
   var filterArg = ""
   var sortArg = ""
@@ -2156,6 +2271,7 @@ proc main() =
   var cursor = ""
   var defaultRing = "imported"
   var ringName = ""
+  var stellarName = ""
   var description = ""
   var ringField = ""
   var ringPrefix = ""
@@ -2199,6 +2315,8 @@ proc main() =
   var limit = 100
   var page = 1
   var pageLimit = 20
+  var depth = 1
+  var branchBudget = 0
   var positionals: seq[string] = @[]
   for kind, key, val in getopt():
     case kind
@@ -2225,6 +2343,8 @@ proc main() =
       of "format-version": formatVersion = val
       of "view": view = val
       of "id": idArg = val
+      of "near": nearRingBase = val
+      of "subring", "subrings": subringArg = val
       of "where": whereArg = val
       of "filter": filterArg = val
       of "sort":
@@ -2246,11 +2366,14 @@ proc main() =
       of "pagination": paginationArg = val
       of "page": page = parseInt(val)
       of "pagelimit", "page-limit": pageLimit = parseInt(val)
+      of "depth": depth = parseInt(val)
+      of "branch-budget": branchBudget = parseInt(val)
       of "select": selection = val
       of "selection": selection = val
       of "cursor": cursor = val
       of "default-ring": defaultRing = val
       of "ring": ringName = val
+      of "stellar": stellarName = val
       of "description": description = val
       of "ring-field": ringField = val
       of "ring-prefix": ringPrefix = val
@@ -2297,17 +2420,25 @@ proc main() =
   if help or cmd.len == 0:
     printHelp()
     quit 0
+  if cmd == "get" and stellarName.len > 0:
+    if ringName.len > 0 and ringName != stellarName:
+      raise newException(ValueError, "--ring and --stellar cannot differ")
+    ringName = stellarName
   case cmd
   of "put":
     runPut(dataDir, peers, username, password, authToken, secretKey, galaxy,
-           ringName, payload, inPath, codecName, tls, tlsCaFile,
-           tlsServerName, tlsInsecureSkipVerify)
+           ringName, nearRingBase, payload, inPath, codecName, tls,
+           tlsCaFile, tlsServerName, tlsInsecureSkipVerify)
   of "get":
     let readFilter = effectiveFilter(filterArg, whereArg)
     runGet(dataDir, peers, username, password, authToken, secretKey, galaxy,
-           idArg, readFilter, ringName, view, selection, cursor, limit,
-           page, pageLimit, paginationArg, sortArg, rsortArg, tls, tlsCaFile,
-           tlsServerName, tlsInsecureSkipVerify)
+           idArg, readFilter, ringName, subringArg, view, selection, cursor,
+           limit, page, pageLimit, depth, branchBudget, paginationArg, sortArg,
+           rsortArg, tls, tlsCaFile, tlsServerName, tlsInsecureSkipVerify)
+  of "stellar":
+    runStellar(dataDir, peers, username, password, authToken, secretKey, galaxy,
+               positionals, stellarName, ringName, tls, tlsCaFile,
+               tlsServerName, tlsInsecureSkipVerify)
   of "query":
     let readFilter = effectiveFilter(filterArg, whereArg)
     runQuery(dataDir, peers, username, password, authToken, secretKey, galaxy,

--- a/src/rochedb.nim
+++ b/src/rochedb.nim
@@ -159,6 +159,8 @@ type
     ringWriteAckModes: Table[uint64, WriteAckMode]
     ringApplyPolicies: Table[uint64, RingApplyPolicy]
     ringChildren: Table[uint64, seq[uint64]]
+    stellarMembers: Table[string, seq[string]]
+    stellarByMember: Table[string, seq[string]]
     retrievalTunings: Table[string, RetrievalTuning]
     searchProfiles: Table[string, SearchProfile]
     lastRingName: string        # 1エントリキャッシュ（putのホットパス最適化, §16.2）
@@ -248,6 +250,34 @@ type
     pageLimit*: int
     sortField*: string
     sortDirection*: RocheReadSortDirection
+
+  RocheStellarOptions* = object
+    ## Read a coordinate-local stellar neighborhood.
+    ## A root ring behaves like a telescope target: nearby child rings are in
+    ## the same field of view unless subrings narrow the view. Distant rings
+    ## are not forced into the read path.
+    filter*: JsonNode
+    selection*: string
+    limitPerRing*: int
+    maxDepth*: int
+    branchBudget*: int
+    subrings*: seq[string]
+    includeRoot*: bool
+    sortField*: string
+    sortDirection*: RocheReadSortDirection
+
+  RocheStellarRingPage* = object
+    ring*: string
+    count*: int
+    items*: seq[RocheRecord]
+
+  RocheStellarPage* = object
+    root*: string
+    maxDepth*: int
+    branchBudget*: int
+    ringsVisited*: int
+    count*: int
+    rings*: seq[RocheStellarRingPage]
 
   RetrieveStats* = object
     totalVectors*: int
@@ -354,6 +384,9 @@ proc addRingChild(db: RocheDb, parent, child: uint64)
 proc ringNameOf(db: RocheDb, key: uint64): string
 proc ringKey(db: RocheDb, name: string, persist = true): uint64
 proc ringKeyForRead(db: RocheDb, ring: string): uint64
+proc descendantRingKeys(db: RocheDb, root: uint64, maxDepth, branchBudget: int): seq[uint64]
+proc addUniqueRingKey(keys: var seq[uint64], key: uint64)
+proc stellarNeighborKeys(db: RocheDb, root: uint64, maxDepth, branchBudget: int): seq[uint64]
 proc put*(db: RocheDb, payload: string, ring: string = "default",
           vec: seq[float32] = @[]): RocheId
 proc enqueueUniverseSyncEvent*(db: RocheDb, sourceUniverse, sourceGalaxy,
@@ -419,6 +452,47 @@ proc tuningFromSearchProfile*(profile: SearchProfile): RetrievalTuning =
     result.branchBudget = 8
   result.note = profile.note
 
+proc normalizedCoordinate(name: string): string =
+  name.strip(chars = {' ', '\t', '\r', '\n', '/'})
+
+proc addUniqueString(items: var seq[string], value: string) =
+  if value.len > 0 and value notin items:
+    items.add value
+
+proc removeString(items: var seq[string], value: string) =
+  var next: seq[string] = @[]
+  for item in items:
+    if item != value:
+      next.add item
+  items = next
+
+proc rebuildStellarMembership(db: RocheDb) =
+  db.stellarByMember.clear()
+  for stellar, members in db.stellarMembers:
+    for member in members:
+      var stellars = db.stellarByMember.getOrDefault(member, @[])
+      stellars.addUniqueString stellar
+      db.stellarByMember[member] = stellars
+
+proc loadStellarMap(db: RocheDb, raw: string) =
+  if raw.len == 0:
+    return
+  let node = parseJson(raw)
+  let stellar = normalizedCoordinate(node{"stellar"}.getStr(""))
+  if stellar.len == 0:
+    return
+  var members: seq[string] = @[]
+  if node.hasKey("members") and node["members"].kind == JArray:
+    for item in node["members"]:
+      members.addUniqueString normalizedCoordinate(item.getStr())
+  db.stellarMembers[stellar] = members
+
+proc stellarMapBlob(stellar: string, members: seq[string]): string =
+  var arr = newJArray()
+  for member in members:
+    arr.add %member
+  $(%*{"stellar": stellar, "members": arr})
+
 # ---------------------------------------------------------------- 開閉と時計
 
 proc open*(nodes: int = 8, dataDir: string = "",
@@ -440,6 +514,9 @@ proc open*(nodes: int = 8, dataDir: string = "",
     result.ringDescriptions[key] = desc
   for key, profile in result.st.ringPayloadProfiles:
     result.ringPayloadProfiles[key] = profile
+  for _, blob in result.st.stellarMaps:
+    result.loadStellarMap(blob)
+  result.rebuildStellarMembership()
   result.galaxyDescription = result.st.galaxyDescription
   for _, blob in result.st.warpJobs:
     let raw = parseJson(blob)
@@ -1494,6 +1571,18 @@ proc defaultReadOptions*(): RocheReadOptions =
     sortField: "",
     sortDirection: rsDesc)
 
+proc defaultStellarOptions*(): RocheStellarOptions =
+  RocheStellarOptions(
+    filter: newJObject(),
+    selection: "",
+    limitPerRing: 20,
+    maxDepth: 1,
+    branchBudget: 0,
+    subrings: @[],
+    includeRoot: true,
+    sortField: "time",
+    sortDirection: rsDesc)
+
 proc normalizedReadOptions(options: RocheReadOptions): RocheReadOptions =
   result = options
   if result.filter.isNil:
@@ -1596,6 +1685,193 @@ proc readRing*(db: RocheDb, ring: string,
     result.items.add projectReadRecord(matched[i], opts.selection)
   result.count = result.items.len
   result.nextCursor = nextCursor
+
+proc anchorRingName(db: RocheDb, anchor: RocheId): string =
+  result = db.ringKeyNames.getOrDefault(anchor.parent, "")
+  if result.len == 0:
+    raise newException(ValueError,
+      "anchor ring is unknown in this RocheDB handle; configure or read the ring map first")
+
+proc nearRing*(db: RocheDb, anchor: RocheId, relation: string): string =
+  ## Resolve a temporary proximity hint into a normal ring coordinate.
+  ## The relation is not persisted as metadata; only the resulting ring stores data.
+  let root = db.anchorRingName(anchor)
+  let clean = relation.strip(chars = {'/'})
+  if clean.len == 0: root else: root & "/" & clean
+
+proc nearRing*(baseRing, ring: string): string =
+  ## Resolve a write-time coordinate hint into a concrete nearby ring name.
+  ## Example: baseRing=users/123 and ring=orders becomes users/123/orders.
+  let base = baseRing.strip(chars = {'/'})
+  let child = ring.strip(chars = {'/'})
+  if base.len == 0:
+    child
+  elif child.len == 0:
+    base
+  else:
+    base & "/" & child
+
+proc putNear*(db: RocheDb, baseRing: string, encoded: EncodedPayload,
+              ring: string, vec: seq[float32] = @[]): RocheId =
+  ## Store data under a nearby coordinate derived from baseRing + ring.
+  ## Example: baseRing users/123 and ring orders stores into users/123/orders.
+  ## The hint is write-time only; reads use the resulting ring coordinate.
+  db.put(encoded, ring = nearRing(baseRing, ring), vec = vec)
+
+proc putNear*(db: RocheDb, baseRing, payload, ring: string,
+              vec: seq[float32] = @[]): RocheId =
+  db.putNear(baseRing, encodedPayload(payload), ring = ring, vec = vec)
+
+proc putNear*(db: RocheDb, baseRing: string, doc: JsonNode, ring: string,
+              vec: seq[float32] = @[]): RocheId =
+  db.putNear(baseRing, encodedPayload($doc, pcJson), ring = ring, vec = vec)
+
+proc putNear*(db: RocheDb, anchor: RocheId, encoded: EncodedPayload,
+              relation = "context", vec: seq[float32] = @[]): RocheId =
+  ## Store related data in the same stellar coordinate neighborhood as anchor.
+  ## This converts the relation hint to a nearby ring, then uses normal put.
+  db.put(encoded, ring = db.nearRing(anchor, relation), vec = vec)
+
+proc putNear*(db: RocheDb, anchor: RocheId, payload: string,
+              relation = "context", vec: seq[float32] = @[]): RocheId =
+  db.putNear(anchor, encodedPayload(payload), relation = relation, vec = vec)
+
+proc putNear*(db: RocheDb, anchor: RocheId, doc: JsonNode,
+              relation = "context", vec: seq[float32] = @[]): RocheId =
+  db.putNear(anchor, encodedPayload($doc, pcJson), relation = relation, vec = vec)
+
+proc attachStellar*(db: RocheDb, stellar, ring: string) =
+  ## Attach a ring coordinate to a stellar coordinate's visible lens.
+  ## This does not copy payloads or create a strict foreign-key constraint.
+  let stellarCoord = normalizedCoordinate(stellar)
+  let member = normalizedCoordinate(ring)
+  if stellarCoord.len == 0:
+    raise newException(ValueError, "stellar coordinate must not be empty")
+  if member.len == 0:
+    raise newException(ValueError, "stellar member ring must not be empty")
+  discard db.ringKey(stellarCoord)
+  discard db.ringKey(member)
+  var members = db.stellarMembers.getOrDefault(stellarCoord, @[])
+  members.addUniqueString member
+  db.stellarMembers[stellarCoord] = members
+  db.rebuildStellarMembership()
+  if db.mode == mEmbedded:
+    db.st.putStellarMap(stellarCoord, stellarMapBlob(stellarCoord, members))
+
+proc detachStellar*(db: RocheDb, stellar, ring: string) =
+  ## Remove a ring coordinate from a stellar coordinate's visible lens.
+  let stellarCoord = normalizedCoordinate(stellar)
+  let member = normalizedCoordinate(ring)
+  if stellarCoord.len == 0:
+    raise newException(ValueError, "stellar coordinate must not be empty")
+  if member.len == 0:
+    raise newException(ValueError, "stellar member ring must not be empty")
+  var members = db.stellarMembers.getOrDefault(stellarCoord, @[])
+  members.removeString member
+  if members.len == 0:
+    db.stellarMembers.del stellarCoord
+    if db.mode == mEmbedded:
+      db.st.putStellarMap(stellarCoord, "")
+  else:
+    db.stellarMembers[stellarCoord] = members
+    if db.mode == mEmbedded:
+      db.st.putStellarMap(stellarCoord, stellarMapBlob(stellarCoord, members))
+  db.rebuildStellarMembership()
+
+proc stellarMembers*(db: RocheDb, stellar: string): seq[string] =
+  db.stellarMembers.getOrDefault(normalizedCoordinate(stellar), @[])
+
+proc stellarCoordinatesFor*(db: RocheDb, ring: string): seq[string] =
+  db.stellarByMember.getOrDefault(normalizedCoordinate(ring), @[])
+
+proc normalizedStellarOptions(options: RocheStellarOptions): RocheStellarOptions =
+  result = options
+  if result.filter.isNil:
+    result.filter = newJObject()
+  if result.limitPerRing <= 0:
+    result.limitPerRing = 20
+  if result.maxDepth < 0:
+    result.maxDepth = 0
+  if result.branchBudget < 0:
+    result.branchBudget = 0
+  for i, value in result.subrings:
+    result.subrings[i] = value.strip(chars = {'/'})
+  if result.sortField.len == 0:
+    result.sortField = "time"
+  if result.sortField == "write":
+    result.sortField = "time"
+  if result.sortField notin ["id", "time"]:
+    raise newException(ValueError, "sort field must be id, time, or write")
+
+proc subringMatches(root, ringName: string, subrings: seq[string]): bool =
+  if subrings.len == 0:
+    return true
+  let rootClean = normalizedCoordinate(root)
+  let ringClean = normalizedCoordinate(ringName)
+  for subring in subrings:
+    let sub = normalizedCoordinate(subring)
+    if sub.len == 0:
+      continue
+    if ringClean == rootClean & "/" & sub:
+      return true
+    if ringClean == sub or ringClean.startsWith(sub & "/"):
+      return true
+    if ringClean.endsWith("/" & sub):
+      return true
+  false
+
+proc readStellar*(db: RocheDb, root: string,
+                  options: RocheStellarOptions = defaultStellarOptions()): RocheStellarPage =
+  ## Read a stellar neighborhood: the root ring and nearby child coordinates.
+  ## It is similar to pointing a telescope at a ring: nearby satellites are
+  ## naturally visible, and subrings narrow the field when needed. It does not
+  ## chase distant coordinates just to emulate a global join.
+  let opts = normalizedStellarOptions(options)
+  result.root = root
+  result.maxDepth = opts.maxDepth
+  result.branchBudget = opts.branchBudget
+  if root notin db.ringNames:
+    return
+  let rootKey = db.ringNames[root]
+  var keys: seq[uint64] = @[]
+  if opts.subrings.len > 0:
+    if opts.includeRoot:
+      keys.add rootKey
+    for subring in opts.subrings:
+      if subring.len == 0:
+        continue
+      let ringName = root.strip(chars = {'/'}) & "/" & subring
+      if ringName in db.ringNames:
+        keys.add db.ringNames[ringName]
+  else:
+    keys = db.stellarNeighborKeys(rootKey, opts.maxDepth, opts.branchBudget)
+    if not opts.includeRoot and keys.len > 0 and keys[0] == rootKey:
+      keys.delete(0)
+  var visibleCoordinates = db.stellarMembers.getOrDefault(root, @[])
+  for stellar in db.stellarByMember.getOrDefault(root, @[]):
+    visibleCoordinates.addUniqueString stellar
+    for member in db.stellarMembers.getOrDefault(stellar, @[]):
+      visibleCoordinates.addUniqueString member
+  for ringName in visibleCoordinates:
+    if not subringMatches(root, ringName, opts.subrings):
+      continue
+    if ringName in db.ringNames:
+      keys.addUniqueRingKey db.ringNames[ringName]
+  for key in keys:
+    let ringName = db.ringNameOf(key)
+    let page = db.readRing(ringName, RocheReadOptions(
+      filter: opts.filter,
+      selection: opts.selection,
+      limit: opts.limitPerRing,
+      sortField: opts.sortField,
+      sortDirection: opts.sortDirection))
+    if page.items.len == 0:
+      continue
+    result.rings.add RocheStellarRingPage(ring: ringName,
+                                          count: page.count,
+                                          items: page.items)
+    result.count += page.count
+  result.ringsVisited = keys.len
 
 proc batchPut*(db: RocheDb, payloads: seq[string], ring: string = "default",
                vecs: seq[seq[float32]] = @[]): seq[RocheId] =
@@ -2050,6 +2326,37 @@ proc descendantRingKeys(db: RocheDb, root: uint64, maxDepth, branchBudget: int):
     for child in children:
       result.add child
       queue.add (key: child, depth: current.depth + 1)
+
+proc parentRingKey(db: RocheDb, key: uint64): uint64 =
+  let name = db.ringNameOf(key)
+  let parentName = parentRingName(name)
+  if parentName.len > 0 and parentName in db.ringNames:
+    db.ringNames[parentName]
+  else:
+    0'u64
+
+proc stellarNeighborKeys(db: RocheDb, root: uint64, maxDepth, branchBudget: int): seq[uint64] =
+  ## Coordinate-near read set. It includes the target ring, its nearby
+  ## descendants, and parent/sibling rings inside the configured field of view.
+  result.add root
+  if maxDepth <= 0:
+    return
+
+  for key in db.descendantRingKeys(root, maxDepth, branchBudget):
+    result.addUniqueRingKey(key)
+
+  var current = root
+  for depth in 1 .. maxDepth:
+    let parent = db.parentRingKey(current)
+    if parent == 0'u64:
+      break
+    result.addUniqueRingKey(parent)
+    var siblings = db.ringChildren.getOrDefault(parent, @[])
+    if branchBudget > 0 and siblings.len > branchBudget:
+      siblings.setLen(branchBudget)
+    for sibling in siblings:
+      result.addUniqueRingKey(sibling)
+    current = parent
 
 proc addUniqueRingKey(keys: var seq[uint64], key: uint64) =
   if key notin keys:

--- a/src/rochedb.nim
+++ b/src/rochedb.nim
@@ -49,6 +49,26 @@ type
   Mode = enum
     mEmbedded, mCluster
 
+  RocheLockScope* = enum
+    rlsRing
+    rlsStellar
+
+  RocheLockToken* = object
+    ## Cooperative lock token for high-integrity application workflows.
+    ## Normal put/get paths do not check these locks; use them around
+    ## transaction/bulk workflows that need retry safety.
+    scope*: RocheLockScope
+    coordinate*: string
+    token*: string
+    expiresAt*: float
+    keys*: seq[string]
+
+  RocheLockState = object
+    scope: RocheLockScope
+    coordinate: string
+    token: string
+    expiresAt: float
+
   RetrievalTuning* = object
     ## 内部 tuning knob。通常は SearchProfile を使う。
     budget*: int
@@ -161,6 +181,7 @@ type
     ringChildren: Table[uint64, seq[uint64]]
     stellarMembers: Table[string, seq[string]]
     stellarByMember: Table[string, seq[string]]
+    activeLocks: Table[string, RocheLockState]
     retrievalTunings: Table[string, RetrievalTuning]
     searchProfiles: Table[string, SearchProfile]
     lastRingName: string        # 1エントリキャッシュ（putのホットパス最適化, §16.2）
@@ -492,6 +513,105 @@ proc stellarMapBlob(stellar: string, members: seq[string]): string =
   for member in members:
     arr.add %member
   $(%*{"stellar": stellar, "members": arr})
+
+proc lockKey(scope: RocheLockScope, coordinate: string): string =
+  case scope
+  of rlsRing: "ring:" & normalizedCoordinate(coordinate)
+  of rlsStellar: "stellar:" & normalizedCoordinate(coordinate)
+
+proc purgeExpiredLocks(db: RocheDb, now = epochTime()) =
+  var expired: seq[string] = @[]
+  for key, state in db.activeLocks:
+    if state.expiresAt <= now:
+      expired.add key
+  for key in expired:
+    db.activeLocks.del key
+
+proc newLockToken(keys: seq[string]): string =
+  ## Cooperative lock token. This is not an auth secret; it prevents accidental
+  ## unlock by callers that do not own the lock.
+  $epochTime() & ":" & $keys.len & ":" & $hash(keys.join("|"))
+
+proc acquireLockKeys(db: RocheDb, scope: RocheLockScope, coordinate: string,
+                     keys: seq[string], ttlSeconds = 30.0,
+                     waitMs = 0): RocheLockToken =
+  doAssert db.mode == mEmbedded, "coordinate locks are embedded mode only in this release"
+  if ttlSeconds <= 0:
+    raise newException(ValueError, "ttlSeconds must be positive")
+  let deadline = epochTime() + float(max(waitMs, 0)) / 1000.0
+  var uniqueKeys: seq[string] = @[]
+  for key in keys:
+    if key.len > 0 and key notin uniqueKeys:
+      uniqueKeys.add key
+  if uniqueKeys.len == 0:
+    raise newException(ValueError, "lock key set is empty")
+
+  while true:
+    let now = epochTime()
+    db.purgeExpiredLocks(now)
+    var busy = ""
+    for key in uniqueKeys:
+      if key in db.activeLocks:
+        busy = key
+        break
+    if busy.len == 0:
+      let token = newLockToken(uniqueKeys)
+      let expiresAt = now + ttlSeconds
+      for key in uniqueKeys:
+        db.activeLocks[key] = RocheLockState(scope: scope,
+                                             coordinate: coordinate,
+                                             token: token,
+                                             expiresAt: expiresAt)
+      return RocheLockToken(scope: scope, coordinate: coordinate,
+                            token: token, expiresAt: expiresAt,
+                            keys: uniqueKeys)
+    if waitMs <= 0 or epochTime() >= deadline:
+      raise newException(IOError, "coordinate lock is busy: " & busy)
+    sleep(10)
+
+proc acquireRingLock*(db: RocheDb, ring: string, ttlSeconds = 30.0,
+                      waitMs = 0): RocheLockToken =
+  ## Acquire an opt-in cooperative lock for one ring coordinate.
+  let coord = normalizedCoordinate(ring)
+  if coord.len == 0:
+    raise newException(ValueError, "ring is required")
+  db.acquireLockKeys(rlsRing, coord, @[lockKey(rlsRing, coord)],
+                     ttlSeconds, waitMs)
+
+proc acquireStellarLock*(db: RocheDb, stellar: string, ttlSeconds = 30.0,
+                         waitMs = 0): RocheLockToken =
+  ## Acquire a cooperative lock for a stellar lens and its current member rings.
+  ## The member set is captured at acquisition time.
+  let coord = normalizedCoordinate(stellar)
+  if coord.len == 0:
+    raise newException(ValueError, "stellar is required")
+  var keys = @[lockKey(rlsStellar, coord), lockKey(rlsRing, coord)]
+  for member in db.stellarMembers.getOrDefault(coord, @[]):
+    keys.add lockKey(rlsRing, member)
+  db.acquireLockKeys(rlsStellar, coord, keys, ttlSeconds, waitMs)
+
+proc releaseLock*(db: RocheDb, token: RocheLockToken) =
+  ## Release a cooperative lock. A mismatched token is ignored so callers cannot
+  ## accidentally release another workflow's lock after TTL expiry/reacquire.
+  for key in token.keys:
+    if key in db.activeLocks and db.activeLocks[key].token == token.token:
+      db.activeLocks.del key
+
+proc withRingLock*(db: RocheDb, ring: string, body: proc(),
+                   ttlSeconds = 30.0, waitMs = 0) =
+  let token = db.acquireRingLock(ring, ttlSeconds, waitMs)
+  try:
+    body()
+  finally:
+    db.releaseLock(token)
+
+proc withStellarLock*(db: RocheDb, stellar: string, body: proc(),
+                      ttlSeconds = 30.0, waitMs = 0) =
+  let token = db.acquireStellarLock(stellar, ttlSeconds, waitMs)
+  try:
+    body()
+  finally:
+    db.releaseLock(token)
 
 # ---------------------------------------------------------------- 開閉と時計
 
@@ -1288,6 +1408,87 @@ proc transaction*(db: RocheDb, body: proc(tx: RocheTx)) =
   let tx = db.beginTransaction()
   try:
     body(tx)
+    tx.commit()
+  except CatchableError:
+    tx.rollback()
+    raise
+
+proc batchPutAtomic*(db: RocheDb, payloads: seq[string],
+                     ring: string = "default",
+                     vecs: seq[seq[float32]] = @[]): seq[RocheId] =
+  ## Embedded all-or-nothing bulk insert. If any staged write or commit fails,
+  ## no partial payloads become visible.
+  doAssert db.mode == mEmbedded, "batchPutAtomic is embedded mode only"
+  let tx = db.beginTransaction()
+  try:
+    for i, payload in payloads:
+      let vec = if i < vecs.len: vecs[i] else: @[]
+      result.add tx.put(payload, ring = ring, vec = vec)
+    tx.commit()
+  except CatchableError:
+    tx.rollback()
+    result.setLen(0)
+    raise
+
+proc batchPutAtomic*(db: RocheDb, docs: seq[JsonNode],
+                     ring: string = "default",
+                     vecs: seq[seq[float32]] = @[]): seq[RocheId] =
+  ## Embedded all-or-nothing bulk JSON insert.
+  doAssert db.mode == mEmbedded, "batchPutAtomic is embedded mode only"
+  let tx = db.beginTransaction()
+  try:
+    for i, doc in docs:
+      let vec = if i < vecs.len: vecs[i] else: @[]
+      result.add tx.put(doc, ring = ring, vec = vec)
+    tx.commit()
+  except CatchableError:
+    tx.rollback()
+    result.setLen(0)
+    raise
+
+proc batchUpdateAtomic*(db: RocheDb, ids: seq[RocheId],
+                        payloads: seq[string],
+                        vecs: seq[seq[float32]] = @[]) =
+  ## Embedded all-or-nothing bulk replace. Every ID must exist before commit.
+  doAssert db.mode == mEmbedded, "batchUpdateAtomic is embedded mode only"
+  if ids.len != payloads.len:
+    raise newException(ValueError, "ids and payloads length mismatch")
+  let tx = db.beginTransaction()
+  try:
+    for i, id in ids:
+      let vec = if i < vecs.len: vecs[i] else: @[]
+      tx.update(id, payloads[i], vec = vec)
+    tx.commit()
+  except CatchableError:
+    tx.rollback()
+    raise
+
+proc batchUpdateAtomic*(db: RocheDb, ids: seq[RocheId],
+                        docs: seq[JsonNode],
+                        vecs: seq[seq[float32]] = @[]) =
+  ## Embedded all-or-nothing bulk JSON replace.
+  doAssert db.mode == mEmbedded, "batchUpdateAtomic is embedded mode only"
+  if ids.len != docs.len:
+    raise newException(ValueError, "ids and docs length mismatch")
+  let tx = db.beginTransaction()
+  try:
+    for i, id in ids:
+      let vec = if i < vecs.len: vecs[i] else: @[]
+      tx.update(id, docs[i], vec = vec)
+    tx.commit()
+  except CatchableError:
+    tx.rollback()
+    raise
+
+proc batchDeleteAtomic*(db: RocheDb, ids: seq[RocheId]) =
+  ## Embedded all-or-nothing bulk delete. Every remove is committed together.
+  doAssert db.mode == mEmbedded, "batchDeleteAtomic is embedded mode only"
+  let tx = db.beginTransaction()
+  try:
+    for id in ids:
+      if not db.st.contains(id.parent, id.seq):
+        raise newException(KeyError, "id not found")
+      tx.remove(id)
     tx.commit()
   except CatchableError:
     tx.rollback()

--- a/src/rochedb.nim
+++ b/src/rochedb.nim
@@ -314,6 +314,7 @@ type
 
   CompactStats* = StoreCompactStats
   BackupStats* = StoreBackupStats
+  LocalityReport* = StoreLocalityReport
 
   DumpStats* = object
     bytes*: BiggestInt
@@ -611,6 +612,13 @@ proc compact*(db: RocheDb): CompactStats =
   if db.mode != mEmbedded:
     raise newException(ValueError, "cluster connection cannot compact remote stores")
   db.st.compact()
+
+proc localityReport*(db: RocheDb): LocalityReport =
+  ## 組み込み Store の WAL 物理配置を調べる。
+  ## ringRuns が ringCount に近いほど、同じ ring の live record が物理的にもまとまっている。
+  if db.mode != mEmbedded:
+    raise newException(ValueError, "cluster connection cannot inspect local WAL locality")
+  db.st.localityReport()
 
 proc backup*(db: RocheDb, dstDir: string): BackupStats =
   ## 現在の embedded Store 状態を compact 済み WAL として dstDir に退避する。

--- a/src/rochedb.nim
+++ b/src/rochedb.nim
@@ -597,6 +597,18 @@ proc releaseLock*(db: RocheDb, token: RocheLockToken) =
     if key in db.activeLocks and db.activeLocks[key].token == token.token:
       db.activeLocks.del key
 
+proc lockActive*(db: RocheDb, token: RocheLockToken): bool =
+  ## Return true when every key in the token is still owned by the same token.
+  db.purgeExpiredLocks()
+  if token.keys.len == 0:
+    return false
+  for key in token.keys:
+    if key notin db.activeLocks:
+      return false
+    if db.activeLocks[key].token != token.token:
+      return false
+  true
+
 proc withRingLock*(db: RocheDb, ring: string, body: proc(),
                    ttlSeconds = 30.0, waitMs = 0) =
   let token = db.acquireRingLock(ring, ttlSeconds, waitMs)

--- a/tests/tapi.nim
+++ b/tests/tapi.nim
@@ -1185,6 +1185,67 @@ suite "transaction":
     check not (id in db)
     db.close()
 
+  test "atomic batch put rolls back every staged write on failure":
+    var db = open()
+    var ids: seq[RocheId] = @[]
+    expect ValueError:
+      db.transaction(proc(tx: RocheTx) =
+        ids.add tx.put("a", ring = "bulk")
+        ids.add tx.put("b", ring = "bulk")
+        raise newException(ValueError, "bulk validation failed")
+      )
+    check ids.len == 2
+    check not (ids[0] in db)
+    check not (ids[1] in db)
+    db.close()
+
+  test "batchUpdateAtomic rolls back earlier staged updates when one id fails":
+    var db = open()
+    let id = db.put("before", ring = "bulk")
+    let missing = fromRaw(id.toRaw().parent, id.toRaw().epoch,
+                          id.toRaw().seq + 100'u32, id.toRaw().tWrite)
+    expect KeyError:
+      db.batchUpdateAtomic(@[id, missing], @["after", "missing"])
+    check db.get(id) == "before"
+    db.close()
+
+  test "batchPutAtomic commits all writes together":
+    var db = open()
+    let ids = db.batchPutAtomic(@["a", "b", "c"], ring = "bulk")
+    check ids.len == 3
+    check db.get(ids[0]) == "a"
+    check db.get(ids[1]) == "b"
+    check db.get(ids[2]) == "c"
+    db.close()
+
+  test "ring and stellar locks are opt-in cooperative guards":
+    var db = open()
+    discard db.put("user", ring = "users/123")
+    discard db.put("order", ring = "orders/A-001")
+    db.attachStellar("commerce/order/A-001", "users/123")
+    db.attachStellar("commerce/order/A-001", "orders/A-001")
+
+    let stellarLock = db.acquireStellarLock("commerce/order/A-001", ttlSeconds = 5)
+    expect IOError:
+      discard db.acquireRingLock("users/123", ttlSeconds = 5)
+    db.releaseLock(stellarLock)
+
+    let ringLock = db.acquireRingLock("users/123", ttlSeconds = 5)
+    expect IOError:
+      discard db.acquireStellarLock("commerce/order/A-001", ttlSeconds = 5)
+    db.releaseLock(ringLock)
+
+    var ran = false
+    db.withRingLock("users/123", proc() =
+      ran = true
+      db.transaction(proc(tx: RocheTx) =
+        discard tx.put("audit", ring = "users/123/audit")
+      )
+    )
+    check ran
+    check db.readRing("users/123/audit").count == 1
+    db.close()
+
 suite "galaxy router":
   test "コードから複数銀河を別 DB として扱える":
     let dirA = createTempDir("rochedb", "galaxy-a")

--- a/tests/tapi.nim
+++ b/tests/tapi.nim
@@ -1246,6 +1246,125 @@ suite "transaction":
     check db.readRing("users/123/audit").count == 1
     db.close()
 
+  test "atomic batch matrix covers commit, rollback, mismatch, delete, and replay":
+    let dir = createTempDir("rochedb", "atomic-matrix")
+    var db = open(dataDir = dir)
+
+    block putSuccess:
+      let ids = db.batchPutAtomic(@["a", "b"], ring = "matrix")
+      check ids.len == 2
+      check db.get(ids[0]) == "a"
+      check db.get(ids[1]) == "b"
+
+    block updateLengthMismatch:
+      let id = db.put("unchanged", ring = "matrix")
+      expect ValueError:
+        db.batchUpdateAtomic(@[id], @["x", "extra"])
+      check db.get(id) == "unchanged"
+
+    block updateMissingIdRollback:
+      let first = db.put("first-before", ring = "matrix")
+      let second = db.put("second-before", ring = "matrix")
+      let raw = second.toRaw()
+      let missing = fromRaw(raw.parent, raw.epoch, raw.seq + 999'u32, raw.tWrite)
+      expect KeyError:
+        db.batchUpdateAtomic(@[first, missing], @["first-after", "missing"])
+      check db.get(first) == "first-before"
+      check db.get(second) == "second-before"
+
+    block deleteMissingIdRollback:
+      let keepA = db.put("keep-a", ring = "matrix")
+      let keepB = db.put("keep-b", ring = "matrix")
+      let raw = keepB.toRaw()
+      let missing = fromRaw(raw.parent, raw.epoch, raw.seq + 999'u32, raw.tWrite)
+      expect KeyError:
+        db.batchDeleteAtomic(@[keepA, missing])
+      check keepA in db
+      check keepB in db
+      check db.get(keepA) == "keep-a"
+      check db.get(keepB) == "keep-b"
+
+    block deleteSuccess:
+      let goneA = db.put("gone-a", ring = "matrix")
+      let goneB = db.put("gone-b", ring = "matrix")
+      db.batchDeleteAtomic(@[goneA, goneB])
+      check not (goneA in db)
+      check not (goneB in db)
+
+    block replay:
+      let persisted = db.batchPutAtomic(@["persist-a", "persist-b"], ring = "matrix")
+      db.close()
+      var reopened = open(dataDir = dir)
+      check reopened.get(persisted[0]) == "persist-a"
+      check reopened.get(persisted[1]) == "persist-b"
+      reopened.close()
+      removeDir(dir)
+
+  test "coordinate lock conflict matrix covers overlap, disjoint, ttl, and finally release":
+    var db = open()
+    discard db.put("user", ring = "users/123")
+    discard db.put("order", ring = "orders/A-001")
+    discard db.put("shop", ring = "shops/1123")
+    db.attachStellar("commerce/order/A-001", "users/123")
+    db.attachStellar("commerce/order/A-001", "orders/A-001")
+    db.attachStellar("commerce/order/A-001", "shops/1123")
+
+    block sameRingConflicts:
+      let lock = db.acquireRingLock("users/123", ttlSeconds = 5)
+      check db.lockActive(lock)
+      expect IOError:
+        discard db.acquireRingLock("users/123", ttlSeconds = 5)
+      db.releaseLock(lock)
+      check not db.lockActive(lock)
+
+    block disjointRingsDoNotConflict:
+      let a = db.acquireRingLock("users/123", ttlSeconds = 5)
+      let b = db.acquireRingLock("products/9", ttlSeconds = 5)
+      check db.lockActive(a)
+      check db.lockActive(b)
+      db.releaseLock(a)
+      db.releaseLock(b)
+
+    block stellarConflictsWithMemberRings:
+      let stellar = db.acquireStellarLock("commerce/order/A-001", ttlSeconds = 5)
+      for ring in ["users/123", "orders/A-001", "shops/1123"]:
+        expect IOError:
+          discard db.acquireRingLock(ring, ttlSeconds = 5)
+      db.releaseLock(stellar)
+
+    block memberRingConflictsWithStellar:
+      let orderLock = db.acquireRingLock("orders/A-001", ttlSeconds = 5)
+      expect IOError:
+        discard db.acquireStellarLock("commerce/order/A-001", ttlSeconds = 5)
+      db.releaseLock(orderLock)
+
+    block unrelatedStellarDoesNotConflict:
+      let one = db.acquireStellarLock("commerce/order/A-001", ttlSeconds = 5)
+      let other = db.acquireStellarLock("support/ticket/T-001", ttlSeconds = 5)
+      check db.lockActive(one)
+      check db.lockActive(other)
+      db.releaseLock(one)
+      db.releaseLock(other)
+
+    block ttlExpiryReleasesLock:
+      let short = db.acquireRingLock("users/123", ttlSeconds = 0.01)
+      sleep(30)
+      check not db.lockActive(short)
+      let next = db.acquireRingLock("users/123", ttlSeconds = 5)
+      check db.lockActive(next)
+      db.releaseLock(next)
+
+    block finallyReleaseOnException:
+      expect ValueError:
+        db.withStellarLock("commerce/order/A-001", proc() =
+          raise newException(ValueError, "workflow failed")
+        )
+      let after = db.acquireRingLock("users/123", ttlSeconds = 5)
+      check db.lockActive(after)
+      db.releaseLock(after)
+
+    db.close()
+
 suite "galaxy router":
   test "コードから複数銀河を別 DB として扱える":
     let dirA = createTempDir("rochedb", "galaxy-a")

--- a/tests/tapi.nim
+++ b/tests/tapi.nim
@@ -240,6 +240,132 @@ suite "public api":
     check db.countByRing("users") == 0
     db.close()
 
+  test "stellar neighborhood reads nearby rings from either side":
+    var db = open()
+    let profile = db.put(%*{"kind": "user", "name": "alice"}, ring = "users/123")
+    let order = db.putNear("users/123", %*{"kind": "order", "orderNo": "A-001"},
+                           ring = "orders")
+    let billing = db.putNear("users/123", %*{"kind": "billing", "plan": "pro"},
+                             ring = "billing")
+    let distant = db.put(%*{"kind": "order", "orderNo": "B-999"}, ring = "users/999/orders")
+
+    let stellar = db.readStellar("users/123", RocheStellarOptions(
+      filter: newJObject(),
+      selection: "{ kind }",
+      limitPerRing: 10,
+      maxDepth: 1,
+      includeRoot: true,
+      sortField: "id",
+      sortDirection: rsAsc))
+    check stellar.count == 3
+    var sawRoot = false
+    var sawOrders = false
+    var sawBilling = false
+    var sawDistant = false
+    for ringPage in stellar.rings:
+      if ringPage.ring == "users/123": sawRoot = true
+      if ringPage.ring == "users/123/orders": sawOrders = true
+      if ringPage.ring == "users/123/billing": sawBilling = true
+      if ringPage.ring == "users/999/orders": sawDistant = true
+    check sawRoot
+    check sawOrders
+    check sawBilling
+    check not sawDistant
+
+    let fromOrders = db.readStellar("users/123/orders", RocheStellarOptions(
+      filter: newJObject(),
+      selection: "{ kind }",
+      limitPerRing: 10,
+      maxDepth: 1,
+      includeRoot: true,
+      sortField: "id",
+      sortDirection: rsAsc))
+    var ordersSawUser = false
+    var ordersSawOrder = false
+    var ordersSawDistant = false
+    for ringPage in fromOrders.rings:
+      if ringPage.ring == "users/123": ordersSawUser = true
+      if ringPage.ring == "users/123/orders": ordersSawOrder = true
+      if ringPage.ring == "users/999/orders": ordersSawDistant = true
+    check ordersSawUser
+    check ordersSawOrder
+    check not ordersSawDistant
+
+    let onlyOrders = db.readStellar("users/123", RocheStellarOptions(
+      filter: newJObject(),
+      limitPerRing: 10,
+      maxDepth: 1,
+      subrings: @["orders"],
+      includeRoot: false,
+      sortField: "id",
+      sortDirection: rsAsc))
+    check onlyOrders.count == 1
+    check onlyOrders.rings.len == 1
+    check onlyOrders.rings[0].ring == "users/123/orders"
+    check onlyOrders.rings[0].items[0].id == order
+    check profile.toRaw().parent != order.toRaw().parent
+    check nearRing("users/123", "orders") == "users/123/orders"
+    check billing.toRaw().parent != distant.toRaw().parent
+    db.close()
+
+  test "stellar attach/detach links existing coordinates without copying data":
+    let dir = createTempDir("rochedb", "stellar")
+    var db = open(dataDir = dir)
+    discard db.put(%*{"kind": "user", "id": "123"}, ring = "users/123")
+    discard db.put(%*{"kind": "shop", "id": "1123"}, ring = "shops/1123")
+    discard db.put(%*{"kind": "order", "id": "A-001", "userId": "123", "shopId": "1123"},
+                   ring = "orders/A-001")
+
+    db.attachStellar("commerce/order/A-001", "users/123")
+    db.attachStellar("commerce/order/A-001", "shops/1123")
+    db.attachStellar("commerce/order/A-001", "orders/A-001")
+    check db.stellarMembers("commerce/order/A-001").len == 3
+
+    let fromStellar = db.readStellar("commerce/order/A-001", RocheStellarOptions(
+      filter: newJObject(),
+      limitPerRing: 10,
+      maxDepth: 1,
+      includeRoot: true,
+      sortField: "id",
+      sortDirection: rsAsc))
+    check fromStellar.count == 3
+
+    let fromShop = db.readStellar("shops/1123", RocheStellarOptions(
+      filter: %*{"kind": "user"},
+      limitPerRing: 10,
+      maxDepth: 1,
+      includeRoot: true,
+      sortField: "id",
+      sortDirection: rsAsc))
+    check fromShop.count == 1
+    check fromShop.rings[0].ring == "users/123"
+
+    let usersOnly = db.readStellar("commerce/order/A-001", RocheStellarOptions(
+      filter: newJObject(),
+      limitPerRing: 10,
+      maxDepth: 1,
+      subrings: @["users"],
+      includeRoot: false,
+      sortField: "id",
+      sortDirection: rsAsc))
+    check usersOnly.count == 1
+    check usersOnly.rings[0].ring == "users/123"
+    db.close()
+
+    var reopened = open(dataDir = dir)
+    check reopened.stellarMembers("commerce/order/A-001").len == 3
+    reopened.detachStellar("commerce/order/A-001", "users/123")
+    let afterDetach = reopened.readStellar("shops/1123", RocheStellarOptions(
+      filter: %*{"kind": "user"},
+      limitPerRing: 10,
+      maxDepth: 1,
+      includeRoot: true,
+      sortField: "id",
+      sortDirection: rsAsc))
+    check afterDetach.count == 0
+    reopened.close()
+    removeDir(dir)
+
   test "warp は小惑星帯のように登録順で少しずつ patch を落とす":
     var db = open()
     let a1 = db.put(%*{"orderId": "o1", "status": "paid"},

--- a/tests/tstore.nim
+++ b/tests/tstore.nim
@@ -334,6 +334,50 @@ suite "store persistence":
     st2.close()
     removeDir(dir)
 
+  test "locality report は interleaved WAL と compact 後の ring grouping を測る":
+    let dir = createTempDir("roche-store", "locality")
+    var st = openStore(dir)
+    for i in 0'u32 ..< 12'u32:
+      let ring = uint64((i mod 3) + 1)
+      st.upsert Particle(parent: ring, seq: i div 3, period: 60.0,
+                         head: float(ring), tWrite: float(i),
+                         payload: "p" & $i, codec: pcRaw)
+
+    let before = st.localityReport()
+    check before.persistent
+    check before.liveParticleRecords == 12
+    check before.ringCount == 3
+    check before.ringRuns == 12
+    check before.fragmentedRings == 3
+    check before.localityScore < 1.0
+
+    discard st.compact()
+    let after = st.localityReport()
+    check after.liveParticleRecords == 12
+    check after.ringCount == 3
+    check after.ringRuns == 3
+    check after.fragmentedRings == 0
+    check after.localityScore == 1.0
+    check after.avgRunRecords == 4.0
+    st.close()
+    removeDir(dir)
+
+  test "locality report は上書き済み particle record を dead として数える":
+    let dir = createTempDir("roche-store", "locality-dead")
+    var st = openStore(dir)
+    st.upsert Particle(parent: 7'u64, seq: 0'u32, period: 60.0,
+                       head: 0.0, tWrite: 1.0, payload: "old",
+                       codec: pcRaw)
+    st.upsert Particle(parent: 7'u64, seq: 0'u32, period: 60.0,
+                       head: 0.0, tWrite: 2.0, payload: "new",
+                       codec: pcRaw)
+    let report = st.localityReport()
+    check report.totalParticleRecords == 2
+    check report.liveParticleRecords == 1
+    check report.deadParticleRecords == 1
+    st.close()
+    removeDir(dir)
+
   test "strong durability の compact 後も WAL は復元できる":
     let dir = createTempDir("roche-store", "strong-compact")
     var st = openStore(dir, durability = durStrong)


### PR DESCRIPTION
## Summary

- release RocheDB v0.5.0 from devel
- include stellar locality lens workflows
- include embedded atomic batch helpers and opt-in coordinate locks
- include updated benchmark docs, unique data model docs, and demos

## Verification

- PR #29 into devel passed all CI checks
- nimble check passed locally
- scripts/test_core.sh passed locally after atomic workflow matrix expansion
- benchmark/search reduction helpers were re-run during feature verification

## Notes

Tags will be created from main after this release PR is merged.