### PR TITLE
feat: add safe filter builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ corpus size toward semantic working-set size.
 - Vector backend selection: [docs/vector-backends.md](docs/vector-backends.md)
 - Protocol compatibility: [docs/protocol-compatibility.md](docs/protocol-compatibility.md)
 - TLS transport: [docs/tls-transport.md](docs/tls-transport.md)
+- Query safety: [docs/query-safety.md](docs/query-safety.md)
 - Payload codecs and prepared selections: [docs/payload-codecs.md](docs/payload-codecs.md)
 - Universe sync: [docs/universe-sync.md](docs/universe-sync.md)
 - Threat model: [docs/threat-model.md](docs/threat-model.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,7 @@ downstream AI/RAG or application logic.
 - [Driver / FFI Roadmap](rochedb-driver-roadmap.md)
 - [Protocol Compatibility](protocol-compatibility.md)
 - [TLS Transport](tls-transport.md)
+- [Query Safety](query-safety.md)
 - [Payload Codecs](payload-codecs.md)
 - [Vector Backend Selection](vector-backends.md)
 - [FAISS Versioning Policy](faiss-versioning.md)

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -94,6 +94,7 @@ For application-facing tuning, prefer `SearchProfile` over raw numeric knobs:
 | `getEncoded(id)` | Fetch payload bytes together with their `PayloadCodec`. |
 | `query(id, selection)` | Fetch a JSON projection using GraphQL-style selection syntax. |
 | `prepareSelection(selection)` / `query(id, prepared)` | Validate and compile a reusable projection before execution. |
+| `rocheFilter().eq(key, value)` / `rocheFilter().id(id)` | Build JSON read filters without string-concatenated query text. |
 | `exists(id)` / `contains(id)` | Check whether an ID exists. |
 | `update(id, payload)` / `update(id, doc)` | Replace an existing document. |
 | `patch(id, patchDoc)` | Apply a JSON merge patch. |
@@ -115,6 +116,8 @@ The C ABI exposes matching additive functions: `roche_put_codec`,
 | `listByRing(ring, limit = 100, cursor = "")` | List records in one ring with cursor pagination. |
 | `readRing(ring, options = defaultReadOptions())` | Read one ring with filter, selection, cursor/page limit, and page-local sort. |
 | `readStellar(root, options = defaultStellarOptions())` | Read the root ring and nearby coordinate rings. Parent, child, and sibling rings can be in the same field of view; distant rings are not forced into the read path. |
+| `defaultReadOptions().withFilter(rocheFilter().eq(...))` | Apply a typed filter builder to ring reads. |
+| `defaultStellarOptions().withFilter(rocheFilter().eq(...))` | Apply a typed filter builder to stellar reads. |
 | `nearRing(baseRing, ring)` | Resolve a write-time nearby coordinate, for example `nearRing("users/123", "orders") == "users/123/orders"`. |
 | `countByRing(ring)` | Count records in one ring. |
 | `retrieve(queryVec, ring = "", budget = 8, ...)` | Vector/RAG-style retrieval with ring-aware planning. |

--- a/docs/query-safety.md
+++ b/docs/query-safety.md
@@ -1,0 +1,97 @@
+# Query Safety
+
+RocheDB does not execute SQL, so its query-safety surface is different from a
+SQL database.
+
+The two important pieces are:
+
+- prepared selections for projection;
+- typed filter builders for read filters.
+
+Both are designed to avoid string-concatenated query text while keeping
+RocheDB's read path centered on a `ring` or `stellar` coordinate.
+
+## Prepared Selections
+
+Selections are GraphQL-style projections over JSON payloads:
+
+```nim
+let fields = prepareSelection("{ title author { name } }")
+let first = db.query(firstId, fields)
+let second = db.query(secondId, fields)
+```
+
+`prepareSelection` validates and parses the selection once. Embedded reads reuse
+the parsed tree directly. Cluster nodes also keep a bounded cache of validated
+selection trees.
+
+The selection grammar contains field names only. Payload values are not
+interpolated into it.
+
+## Typed Filter Builders
+
+Filters are still represented as JSON objects internally and on the wire. That
+keeps the CLI, C ABI, and existing drivers compatible.
+
+For application code, RocheDB also provides a builder so callers do not need to
+construct filter JSON by string concatenation:
+
+```nim
+let filter = rocheFilter().eq("status", "draft").eq("kind", "order")
+
+let page = db.readRing("docs/japan", defaultReadOptions().withFilter(filter))
+```
+
+The same filter can be used with stellar reads:
+
+```nim
+let page = db.readStellar("commerce/order/A-001",
+  defaultStellarOptions().withFilter(rocheFilter().eq("kind", "shop")))
+```
+
+ID reads can also be built without manually stringifying the ID:
+
+```nim
+let page = db.readRing("users", defaultReadOptions().withFilter(
+  rocheFilter().id(userId)))
+```
+
+Supported builder values:
+
+- strings;
+- integers;
+- floats;
+- booleans;
+- explicit `JsonNode` values;
+- RocheDB IDs through `id(id)`.
+
+## Scope Comes First
+
+The filter builder is not intended to turn RocheDB into an ad-hoc global query
+engine.
+
+RocheDB's read model remains:
+
+1. choose a `ring` or `stellar` coordinate;
+2. optionally narrow with `subring`;
+3. apply typed filters inside that local scope;
+4. project only the requested fields.
+
+This keeps query safety aligned with the main RocheDB idea: avoid unrelated
+working sets before downstream work begins.
+
+## Compatibility
+
+These two forms are equivalent:
+
+```nim
+let a = db.readRing("docs", RocheReadOptions(
+  filter: %*{"status": "draft"},
+  selection: "{ title }"))
+
+let b = db.readRing("docs", defaultReadOptions()
+  .withFilter(rocheFilter().eq("status", "draft")))
+```
+
+The builder-produced filter is a defensive JSON object copy. It can be passed
+through the same API paths that already accept `JsonNode` filters.

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -12,7 +12,7 @@ matrix used before releases.
 | Field / halo movement | `tests/tfield.nim` | Unit-covered: field state and ring movement behavior |
 | Selection parser | `tests/tselect.nim` | Unit-covered: GraphQL-like selection parsing and projection basics |
 | Store / WAL | `tests/tstore.nim` | Unit-covered: codec persistence, torn-tail repair, transaction replay, compact, locality report, backup/restore |
-| Public embedded API | `tests/tapi.nim` | Unit-covered: put/get, codec-aware projection, ring profiles, readRing filtering, pagination, sorting, stellar neighborhood reads from either side, stellar attach/detach persistence, atomic batch rollback, cooperative ring/stellar locks, warp, universe sync |
+| Public embedded API | `tests/tapi.nim` | Unit-covered: put/get, codec-aware projection, ring profiles, readRing filtering, typed filter builders, pagination, sorting, stellar neighborhood reads from either side, stellar attach/detach persistence, atomic batch rollback, cooperative ring/stellar locks, warp, universe sync |
 | CLI embedded usage | `scripts/cli_crud_smoke.sh` | Smoke-covered: help, put/get/query/list/count, readRing options, `--near` placement, `--stellar`, stellar attach/detach, `--subring` neighborhood narrowing, codec display, ring profile auto codec, shell, auth error text |
 | C ABI | `examples/cabi_contract.c`, `scripts/driver_compat.sh` | Contract-covered: ABI version, put/get, codec metadata, read ring page shape, validation errors, atlas |
 | Wire protocol | `tests/twire_driver.nim`, `scripts/cluster_wire_fuzz_smoke.sh` | Smoke-covered: driver-facing PUTR/GETID/QRYID, codec metadata negotiation, malformed frame behavior |

--- a/src/rochedb.nim
+++ b/src/rochedb.nim
@@ -261,6 +261,12 @@ type
     sortField*: string
     sortDirection*: RocheReadSortDirection
 
+  RocheFilterBuilder* = object
+    ## Typed helper for constructing read filters without string-concatenated
+    ## JSON. The stored representation remains a JSON object so existing CLI,
+    ## wire, C ABI, and driver paths stay compatible.
+    node: JsonNode
+
   RocheReadPage* = object
     ring*: string
     count*: int
@@ -1796,6 +1802,68 @@ proc defaultStellarOptions*(): RocheStellarOptions =
     sortField: "time",
     sortDirection: rsDesc)
 
+proc rocheFilter*(): RocheFilterBuilder =
+  ## Start a safe read-filter builder.
+  RocheFilterBuilder(node: newJObject())
+
+proc toJson*(builder: RocheFilterBuilder): JsonNode =
+  ## Return a defensive JSON object copy suitable for RocheReadOptions.filter.
+  if builder.node.isNil:
+    return newJObject()
+  if builder.node.kind != JObject:
+    raise newException(ValueError, "Roche filter builder must contain a JSON object")
+  builder.node.copy()
+
+proc withFilterValue(builder: RocheFilterBuilder; key: string;
+                     value: JsonNode): RocheFilterBuilder =
+  if key.len == 0:
+    raise newException(ValueError, "filter key must not be empty")
+  if value.isNil:
+    raise newException(ValueError, "filter value must not be nil")
+  result.node = builder.toJson()
+  result.node[key] = value.copy()
+
+proc eq*(builder: RocheFilterBuilder; key: string;
+         value: JsonNode): RocheFilterBuilder =
+  ## Add an equality match for a JSON value.
+  builder.withFilterValue(key, value)
+
+proc eq*(builder: RocheFilterBuilder; key, value: string): RocheFilterBuilder =
+  ## Add an equality match for a string value.
+  builder.withFilterValue(key, %value)
+
+proc eq*(builder: RocheFilterBuilder; key: string;
+         value: SomeInteger): RocheFilterBuilder =
+  ## Add an equality match for an integer value.
+  builder.withFilterValue(key, %value)
+
+proc eq*(builder: RocheFilterBuilder; key: string;
+         value: SomeFloat): RocheFilterBuilder =
+  ## Add an equality match for a floating-point value.
+  builder.withFilterValue(key, %value)
+
+proc eq*(builder: RocheFilterBuilder; key: string;
+         value: bool): RocheFilterBuilder =
+  ## Add an equality match for a boolean value.
+  builder.withFilterValue(key, %value)
+
+proc id*(builder: RocheFilterBuilder; rawId: string): RocheFilterBuilder =
+  ## Match a RocheDB raw/string ID using the same `id` filter field accepted by
+  ## readRing and CLI `--filter='{"id":"..."}'`.
+  builder.eq("id", rawId)
+
+proc withFilter*(options: RocheReadOptions;
+                 builder: RocheFilterBuilder): RocheReadOptions =
+  ## Return read options with a builder-produced filter.
+  result = options
+  result.filter = builder.toJson()
+
+proc withFilter*(options: RocheStellarOptions;
+                 builder: RocheFilterBuilder): RocheStellarOptions =
+  ## Return stellar read options with a builder-produced filter.
+  result = options
+  result.filter = builder.toJson()
+
 proc normalizedReadOptions(options: RocheReadOptions): RocheReadOptions =
   result = options
   if result.filter.isNil:
@@ -2508,6 +2576,11 @@ proc ringSummaries*(db: RocheDb, queryVec: seq[float32] = @[]): seq[RocheRingSum
 
 proc `$`*(id: RocheId): string =
   $id.parent & ":" & $id.seq
+
+proc id*(builder: RocheFilterBuilder; rocheId: RocheId): RocheFilterBuilder =
+  ## Match a RocheDB ID without asking callers to manually stringify it.
+  builder.id($rocheId.parent & ":" & $rocheId.epoch & ":" &
+             $rocheId.seq & ":" & $rocheId.tWrite)
 
 proc focusToTopRings*(focus: int): int =
   ## ユーザー向けの探索幅 1..100 を、内部 topRings 2..500 に写像する。

--- a/tests/tapi.nim
+++ b/tests/tapi.nim
@@ -226,6 +226,34 @@ suite "public api":
         selection: "{ title }",
         limit: 1))
 
+    let baseFilter = rocheFilter().eq("name", "a")
+    let extendedFilter = baseFilter.eq("meta", %*{"n": 1})
+    check baseFilter.toJson() == %*{"name": "a"}
+    check extendedFilter.toJson() == %*{"name": "a", "meta": {"n": 1}}
+
+    let builtRead = db.readRing("users", defaultReadOptions().withFilter(
+      rocheFilter().eq("name", "b").eq("meta", %*{"n": 2})))
+    check builtRead.count == 1
+    check parseJson(builtRead.items[0].payload)["name"].getStr() == "b"
+
+    let typedBool = db.put(%*{"name": "flagged", "active": true, "age": 7},
+                           ring = "typed")
+    let typedRead = db.readRing("typed", RocheReadOptions(
+      filter: rocheFilter().eq("active", true).eq("age", 7).toJson(),
+      limit: 10,
+      sortField: "id",
+      sortDirection: rsAsc))
+    check typedRead.count == 1
+    check typedRead.items[0].id == typedBool
+
+    let byBuilderId = db.readRing("users", defaultReadOptions().withFilter(
+      rocheFilter().id(ids[1])))
+    check byBuilderId.count == 1
+    check byBuilderId.items[0].id == ids[1]
+
+    expect ValueError:
+      discard rocheFilter().eq("", "bad")
+
     db.update(ids[0], %*{"name": "a2", "meta": {"n": 10}})
     check db.query(ids[0], "{ name }") == %*{"name": "a2"}
     let patched = db.patch(ids[0], %*{"meta": {"ok": true}, "name": nil})
@@ -330,13 +358,8 @@ suite "public api":
       sortDirection: rsAsc))
     check fromStellar.count == 3
 
-    let fromShop = db.readStellar("shops/1123", RocheStellarOptions(
-      filter: %*{"kind": "user"},
-      limitPerRing: 10,
-      maxDepth: 1,
-      includeRoot: true,
-      sortField: "id",
-      sortDirection: rsAsc))
+    let fromShop = db.readStellar("shops/1123", defaultStellarOptions().withFilter(
+      rocheFilter().eq("kind", "user")))
     check fromShop.count == 1
     check fromShop.rings[0].ring == "users/123"
 


### PR DESCRIPTION
## Summary
- add RocheFilterBuilder with typed eq and id helpers
- allow ring and stellar read options to accept builder-produced filters
- document query safety and update public API/test coverage docs

## Verification
- nim check src/rochedb.nim
- nim c -r --nimcache:/tmp/nimcache_roche_tapi tests/tapi.nim
- scripts/test_core.sh
- git diff --check