### PR TITLE
test: expand locality validation workloads

### DIFF
--- a/docs/data-locality.md
+++ b/docs/data-locality.md
@@ -156,6 +156,30 @@ The demo intentionally writes records in an interleaved pattern, then runs
 compaction. The important result is not the exact byte count; it is that the
 same live records become physically grouped by ring after compaction.
 
+The demo can also run less clean write patterns:
+
+```bash
+WORKLOAD=random examples/locality_layout_demo.sh
+WORKLOAD=delete-heavy examples/locality_layout_demo.sh
+WORKLOAD=backfill-heavy examples/locality_layout_demo.sh
+WORKLOAD=hot-cold examples/locality_layout_demo.sh
+```
+
+Useful knobs:
+
+| Environment variable | Meaning |
+| --- | --- |
+| `RINGS` | Number of rings to write |
+| `PER_RING` | Baseline records per ring |
+| `BACKFILL` | Additional backfill records |
+| `WORKLOAD` | `interleaved`, `random`, `delete-heavy`, `backfill-heavy`, or `hot-cold` |
+| `READ_ITERS` | Number of repeated ring reads used for before/after latency sampling |
+
+The output includes `read_before` and `read_after` lines. These are local
+micro-samples, not universal latency claims. They exist to catch large
+regressions and to make compact-before/compact-after behavior observable next
+to the physical locality metrics.
+
 ## Current Scope
 
 This is not a full LSM-tree, B+ tree, or columnar layout. RocheDB's current
@@ -193,5 +217,7 @@ The next locality work should add benchmark cases for:
 - read latency before and after locality-aware compaction;
 - larger datasets where OS page cache and SSD read behavior become visible.
 
-Those cases are deliberately separate from the first metric surface so the core
-behavior remains easy to audit.
+The v0.6 locality-validation branch starts adding these cases to the runnable
+demo and store test matrix. Larger OS page-cache and SSD-sensitive benchmarks
+still need separate benchmark runs because tiny local unit tests cannot prove
+hardware-level locality behavior.

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -11,7 +11,7 @@ matrix used before releases.
 | Orbital placement core | `tests/tcore.nim` | Unit-covered: angle wrapping, ownership, future arrival, conjunctions |
 | Field / halo movement | `tests/tfield.nim` | Unit-covered: field state and ring movement behavior |
 | Selection parser | `tests/tselect.nim` | Unit-covered: GraphQL-like selection parsing and projection basics |
-| Store / WAL | `tests/tstore.nim` | Unit-covered: codec persistence, torn-tail repair, transaction replay, compact, locality report, backup/restore |
+| Store / WAL | `tests/tstore.nim` | Unit-covered: codec persistence, torn-tail repair, transaction replay, compact, locality report, delete/backfill locality matrix, backup/restore |
 | Public embedded API | `tests/tapi.nim` | Unit-covered: put/get, codec-aware projection, ring profiles, readRing filtering, typed filter builders, pagination, sorting, stellar neighborhood reads from either side, stellar attach/detach persistence, atomic batch rollback, cooperative ring/stellar locks, warp, universe sync |
 | CLI embedded usage | `scripts/cli_crud_smoke.sh` | Smoke-covered: help, put/get/query/list/count, readRing options, `--near` placement, `--stellar`, stellar attach/detach, `--subring` neighborhood narrowing, codec display, ring profile auto codec, shell, auth error text |
 | C ABI | `examples/cabi_contract.c`, `scripts/driver_compat.sh` | Contract-covered: ABI version, put/get, codec metadata, read ring page shape, validation errors, atlas |
@@ -23,7 +23,7 @@ matrix used before releases.
 | Universe sync | `examples/universe_sync_demo.nim`, `scripts/universe_sync_*_smoke.sh` | Smoke-covered: local export/apply, remote apply, idempotency, malformed JSONL handling |
 | Recovery | `scripts/recovery_smoke.sh` | Smoke-covered: backup/restore and recovery status paths |
 | Driver compatibility | `scripts/driver_compat.sh` | Optional smoke: C, C++, and published driver-facing C ABI paths when enabled |
-| Data model demos | `examples/stellar_data_model_demo.sh`, `examples/locality_layout_demo.sh` | Demo-covered: non-copy stellar visibility, narrowed stellar reads, original ring preservation after detach, and compaction locality reporting |
+| Data model demos | `examples/stellar_data_model_demo.sh`, `examples/locality_layout_demo.sh` | Demo-covered: non-copy stellar visibility, narrowed stellar reads, original ring preservation after detach, compaction locality reporting, messy locality workloads, and compact-before/after read micro-samples |
 
 ## Release Gate
 

--- a/examples/locality_layout_demo.nim
+++ b/examples/locality_layout_demo.nim
@@ -1,6 +1,6 @@
 ## Physical locality demo for RocheDB's WAL layout.
 
-import std/[json, os, strformat, strutils, tempfiles]
+import std/[json, os, strformat, strutils, tempfiles, times]
 import ../src/rochedb
 
 proc argValue(name, defaultValue: string): string =
@@ -16,10 +16,37 @@ proc argInt(name: string, defaultValue: int): int =
 proc printReport(label: string, r: LocalityReport) =
   echo &"{label} persistent={r.persistent} walBytes={r.walBytes} totalParticleRecords={r.totalParticleRecords} liveParticleRecords={r.liveParticleRecords} deadParticleRecords={r.deadParticleRecords} ringCount={r.ringCount} ringRuns={r.ringRuns} fragmentedRings={r.fragmentedRings} avgRunRecords={r.avgRunRecords:.3f} maxRunRecords={r.maxRunRecords} localityScore={r.localityScore:.6f}"
 
+proc ringName(r: int): string =
+  "locality/ring-" & $r
+
+proc pickRing(i, rings: int): int =
+  ## Deterministic pseudo-random ring selection for reproducible demos.
+  let x = (int64(i) * 1103515245'i64 + 12345'i64) and 0x7fffffff'i64
+  int(x mod int64(rings))
+
+proc measureReadUs(db: RocheDb, ring: string, iters: int): float =
+  if iters <= 0:
+    return 0.0
+  let start = cpuTime()
+  var consumed = 0
+  for _ in 0 ..< iters:
+    let page = db.readRing(ring, RocheReadOptions(
+      filter: newJObject(),
+      limit: 100,
+      sortField: "id",
+      sortDirection: rsAsc))
+    consumed += page.count
+  let elapsed = cpuTime() - start
+  if consumed < 0:
+    echo "" # keep the loop observable to the optimizer
+  elapsed * 1_000_000.0 / float(iters)
+
 when isMainModule:
   let rings = max(1, argInt("rings", 8))
   let perRing = max(1, argInt("per-ring", 200))
   let backfill = max(0, argInt("backfill", 64))
+  let readIters = max(0, argInt("read-iters", 100))
+  let workload = argValue("workload", "interleaved")
   let explicitDataDir = argValue("data", "")
   let dataDir =
     if explicitDataDir.len > 0: explicitDataDir
@@ -32,27 +59,65 @@ when isMainModule:
 
   var db = open(dataDir = dataDir)
   try:
-    for i in 0 ..< perRing:
-      for r in 0 ..< rings:
-        discard db.put(%*{
-          "phase": "interleaved",
+    var ids: seq[seq[RocheId]] = newSeq[seq[RocheId]](rings)
+    let total = rings * perRing
+
+    case workload
+    of "random":
+      for i in 0 ..< total:
+        let r = pickRing(i, rings)
+        ids[r].add db.put(%*{
+          "phase": "random",
           "ring": r,
           "i": i,
           "body": "record-" & $r & "-" & $i
-        }, ring = "locality/ring-" & $r)
+        }, ring = ringName(r))
+    of "hot-cold":
+      for i in 0 ..< total:
+        let r = if i mod 10 < 7: 0 else: 1 + (i mod max(1, rings - 1))
+        let rr = r mod rings
+        ids[rr].add db.put(%*{
+          "phase": "hot-cold",
+          "ring": rr,
+          "i": i,
+          "body": "record-" & $rr & "-" & $i
+        }, ring = ringName(rr))
+    else:
+      for i in 0 ..< perRing:
+        for r in 0 ..< rings:
+          ids[r].add db.put(%*{
+            "phase": workload,
+            "ring": r,
+            "i": i,
+            "body": "record-" & $r & "-" & $i
+          }, ring = ringName(r))
 
-    for i in 0 ..< backfill:
+    if workload == "delete-heavy":
+      for r in 0 ..< rings:
+        for i, id in ids[r]:
+          if i mod 3 == 0:
+            db.deleteById(id)
+
+    let backfillCount =
+      if workload == "backfill-heavy": max(backfill, perRing * rings div 2)
+      else: backfill
+    for i in 0 ..< backfillCount:
       let r = (i * 7 + 3) mod rings
       discard db.put(%*{
         "phase": "backfill",
         "ring": r,
         "i": i
-      }, ring = "locality/ring-" & $r)
+      }, ring = ringName(r))
 
+    let readRing = ringName(0)
+    let beforeReadUs = measureReadUs(db, readRing, readIters)
     printReport("before_compact", db.localityReport())
+    echo &"read_before ring={readRing} iters={readIters} usPerRead={beforeReadUs:.3f}"
     let stats = db.compact()
     echo &"compact beforeBytes={stats.beforeBytes} afterBytes={stats.afterBytes} items={stats.items}"
+    let afterReadUs = measureReadUs(db, readRing, readIters)
     printReport("after_compact", db.localityReport())
+    echo &"read_after ring={readRing} iters={readIters} usPerRead={afterReadUs:.3f}"
   finally:
     db.close()
     if cleanup:

--- a/examples/locality_layout_demo.sh
+++ b/examples/locality_layout_demo.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 RINGS="${RINGS:-8}"
 PER_RING="${PER_RING:-200}"
 BACKFILL="${BACKFILL:-64}"
+WORKLOAD="${WORKLOAD:-interleaved}"
+READ_ITERS="${READ_ITERS:-100}"
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
@@ -13,6 +15,8 @@ nim c -d:release --nimcache:/tmp/nimcache_roche_locality_layout_demo \
   -o:bin/locality_layout_demo examples/locality_layout_demo.nim
 
 bin/locality_layout_demo \
+  --workload="$WORKLOAD" \
   --rings="$RINGS" \
   --per-ring="$PER_RING" \
-  --backfill="$BACKFILL"
+  --backfill="$BACKFILL" \
+  --read-iters="$READ_ITERS"

--- a/tests/tstore.nim
+++ b/tests/tstore.nim
@@ -378,6 +378,45 @@ suite "store persistence":
     st.close()
     removeDir(dir)
 
+  test "locality report matrix covers delete and backfill fragmentation":
+    let dir = createTempDir("roche-store", "locality-matrix")
+    var st = openStore(dir)
+
+    for i in 0'u32 ..< 24'u32:
+      let ring = uint64((i mod 4) + 1)
+      st.upsert Particle(parent: ring, seq: i div 4, period: 60.0,
+                         head: float(ring), tWrite: float(i),
+                         payload: "p" & $i, codec: pcRaw)
+
+    for i in countup(0'u32, 20'u32, 4):
+      st.remove(1'u64, i div 4)
+
+    for i in 0'u32 ..< 8'u32:
+      let ring = uint64(((i * 3) mod 4) + 1)
+      st.upsert Particle(parent: ring, seq: 100'u32 + i, period: 60.0,
+                         head: float(ring), tWrite: 100.0 + float(i),
+                         payload: "b" & $i, codec: pcRaw)
+
+    let before = st.localityReport()
+    check before.totalParticleRecords == 32
+    check before.liveParticleRecords == 26
+    check before.deadParticleRecords == 6
+    check before.ringCount == 4
+    check before.fragmentedRings > 0
+    check before.localityScore < 1.0
+
+    discard st.compact()
+    let after = st.localityReport()
+    check after.totalParticleRecords == 26
+    check after.liveParticleRecords == 26
+    check after.deadParticleRecords == 0
+    check after.ringCount == 4
+    check after.ringRuns == 4
+    check after.fragmentedRings == 0
+    check after.localityScore == 1.0
+    st.close()
+    removeDir(dir)
+
   test "strong durability の compact 後も WAL は復元できる":
     let dir = createTempDir("roche-store", "strong-compact")
     var st = openStore(dir, durability = durStrong)


### PR DESCRIPTION
## Summary
- expand locality layout demo with interleaved, random, delete-heavy, backfill-heavy, and hot-cold workloads
- add compact-before/after ring-read micro-samples to the locality demo output
- add store-level delete/backfill locality matrix coverage
- document the new workload knobs and validation boundaries

## Verification
- nim check examples/locality_layout_demo.nim
- nim c -r --nimcache:/tmp/nimcache_roche_tstore tests/tstore.nim
- WORKLOAD=interleaved RINGS=4 PER_RING=20 BACKFILL=8 READ_ITERS=20 examples/locality_layout_demo.sh
- WORKLOAD=delete-heavy RINGS=4 PER_RING=20 BACKFILL=8 READ_ITERS=20 examples/locality_layout_demo.sh
- WORKLOAD=hot-cold RINGS=4 PER_RING=20 BACKFILL=8 READ_ITERS=20 examples/locality_layout_demo.sh
- scripts/test_core.sh
- git diff --check