### PR TITLE
feat: add topology remapping primitives

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,7 @@ downstream AI/RAG or application logic.
 - [Detailed Design](rochedb-design.md)
 - [Topology Configuration](topology-config.md)
 - [Topology Pattern Catalog](topology-examples.md)
+- [Topology Remapping](topology-remapping.md)
 - [Universe Sync](universe-sync.md)
 - [Data Locality](data-locality.md)
 - [Cloud Operations Metrics](cloud-operations.md)

--- a/docs/technical-faq.md
+++ b/docs/technical-faq.md
@@ -94,16 +94,20 @@ coordinate metadata and can compute ownership and future placement locally. The
 model is inspired by orbital mechanics because time, position, proximity, and
 movement are useful concepts for cluster routing, scheduling, and recovery.
 
-Current limitation:
+Current implementation status:
 
-- simple owner segmentation can remap too much data when the number of nodes
-  changes;
-- this must be improved before making stronger distributed-database claims.
+- the original equal-division owner calculation is still supported for simple
+  static clusters;
+- weighted arc tables can give nodes different portions of the angle space;
+- virtual arc tables provide a deterministic topology primitive that reduces
+  unnecessary movement when nodes are added;
+- `remapFraction` measures how much angle space would change owner between two
+  topology epochs.
 
-The planned direction is to keep the deterministic coordinate model, but replace
-the naive node-count mapping with persisted arcs, node weights, virtual arcs, or
-a topology epoch. That would preserve the coordinate idea while reducing
-unnecessary remapping during membership changes.
+This is not yet an automatic online rebalance protocol. It is the core
+topology/remapping foundation: RocheDB can now represent the safer layout, test
+its expected movement, and keep the deterministic coordinate idea without tying
+all placement to `mod nNodes`.
 
 ## Where do the benchmark improvements come from?
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -8,7 +8,7 @@ matrix used before releases.
 
 | Area | Primary checks | Current status |
 | --- | --- | --- |
-| Orbital placement core | `tests/tcore.nim` | Unit-covered: angle wrapping, ownership, future arrival, conjunctions |
+| Orbital placement core | `tests/tcore.nim` | Unit-covered: angle wrapping, ownership, weighted arcs, virtual arc remap reduction, future arrival, conjunctions |
 | Field / halo movement | `tests/tfield.nim` | Unit-covered: field state and ring movement behavior |
 | Selection parser | `tests/tselect.nim` | Unit-covered: GraphQL-like selection parsing and projection basics |
 | Store / WAL | `tests/tstore.nim` | Unit-covered: codec persistence, torn-tail repair, transaction replay, compact, locality report, delete/backfill locality matrix, backup/restore |

--- a/docs/topology-remapping.md
+++ b/docs/topology-remapping.md
@@ -1,0 +1,97 @@
+# Topology Remapping
+
+RocheDB's first owner mapping was intentionally simple: divide the angle space
+equally by `nNodes`, then choose the owner from the current angle.
+
+That is useful for a small static cluster, but it has an important weakness:
+changing `nNodes` can move far more data than necessary. v0.6 adds the core
+primitives needed to model safer topology changes without abandoning RocheDB's
+coordinate-based placement model.
+
+## Arc Tables
+
+`ArcTable` now supports two modes:
+
+| Mode | Meaning |
+| --- | --- |
+| Equal arcs | The legacy-compatible mode. `arcs` is empty, and the angle space is divided evenly by `nNodes`. |
+| Explicit arcs | The angle space is represented by sorted `(start, node)` entries. Each entry owns `[start, nextStart)`. |
+
+Equal arcs keep simple deployments simple. Explicit arcs are the foundation for
+weighted placement, virtual arcs, and future topology epochs.
+
+## Weighted Arcs
+
+Weighted arcs allocate one contiguous arc per node according to a weight list.
+
+Example:
+
+```nim
+let tbl = weightedArcTable(epoch = 1, weights = [1, 3])
+```
+
+This gives node `0` roughly 25% of the angle space and node `1` roughly 75%.
+It is useful when nodes have different capacity, but it is still a coarse
+layout because each node receives one large contiguous region.
+
+## Virtual Arcs
+
+Virtual arcs create many small deterministic arcs per node.
+
+Example:
+
+```nim
+let tbl = virtualArcTable(epoch = 1, nNodes = 8, virtualArcsPerNode = 64)
+```
+
+The important property is stability. Existing node/slot arc positions are
+derived from deterministic hashes. Adding a node introduces that node's virtual
+arcs without recomputing all existing node positions from `mod nNodes`.
+
+This is closer to the operational goal:
+
+- keep coordinate-based ownership;
+- reduce unnecessary remapping during membership changes;
+- allow future topology epochs to be planned and measured before activation.
+
+## Remap Measurement
+
+`remapFraction` estimates how much of the angle space changes owner between two
+topologies.
+
+Example:
+
+```nim
+let before = virtualArcTable(epoch = 1, nNodes = 8, virtualArcsPerNode = 64)
+let after = virtualArcTable(epoch = 2, nNodes = 9, virtualArcsPerNode = 64)
+let moved = remapFraction(before, after, samples = 8192)
+```
+
+This is a planning metric. It does not move records by itself. It gives tests,
+operators, and future automation a concrete way to compare topology choices.
+
+## Current Boundary
+
+This feature is a remapping foundation, not a complete online rebalance system.
+
+Implemented:
+
+- explicit arc-table ownership;
+- weighted arc-table construction;
+- deterministic virtual arc-table construction;
+- topology validation;
+- remap-fraction measurement;
+- unit tests proving virtual arcs reduce movement versus equal `nNodes`
+  remapping for the covered scenario.
+
+Still future work:
+
+- persisted topology-epoch files;
+- online membership change workflow;
+- staged migration / compaction integration;
+- operational CLI for previewing and applying topology changes.
+
+The design goal is to avoid turning RocheDB into a generic distributed hash
+table. The topology layer should support RocheDB's locality model: records
+remain placed by meaningful coordinates, while cluster membership changes avoid
+unnecessary movement.

--- a/src/roche/core.nim
+++ b/src/roche/core.nim
@@ -24,10 +24,18 @@ type
     e*: float        ## 滞在偏り（0=均等, ≤ EMax）
     pomega*: float   ## 近点角 ϖ。滞在が最長になる遠点は ϖ + π
 
+  ArcOwner* = object
+    ## Arc start and owner node. The arc owns `[start, nextStart)`.
+    start*: float
+    node*: NodeId
+
   ArcTable* = object
-    ## epoch ごとのリング弧所有表（§9）。PoC は等分割弧。
+    ## epoch ごとのリング弧所有表（§9）。
+    ## `arcs` が空の場合は従来互換の等分割弧。`arcs` がある場合は
+    ## start angle -> owner node の persisted/virtual arc table として使う。
     epoch*: uint32
     nNodes*: uint16
+    arcs*: seq[ArcOwner]
 
   OrbitalId* = object
     ## 自己記述ID（§2.2）: elements は id から計算する。粒子ごとの所在表は存在しない。
@@ -60,16 +68,119 @@ proc theta*(o: Orbit, t: float): float {.inline.} =
   let m = o.meanLongitude(t)
   wrap(m + 2.0 * o.e * sin(m - o.pomega))
 
-proc arcWidth*(tbl: ArcTable): float {.inline.} = TAU / float(tbl.nNodes)
+proc arcWidth*(tbl: ArcTable): float {.inline.} =
+  ## Average arc width. Equal tables use this as the exact width.
+  if tbl.arcs.len > 0: TAU / float(tbl.arcs.len)
+  else: TAU / float(tbl.nNodes)
 
-proc arcStart*(tbl: ArcTable, n: NodeId): float = float(n) * tbl.arcWidth
+proc arcStart*(tbl: ArcTable, n: NodeId): float =
+  ## Representative boundary for a node. Equal tables return the exact node
+  ## boundary; custom arc tables return the first persisted arc for the node.
+  if tbl.arcs.len == 0:
+    return float(n) * tbl.arcWidth
+  result = Inf
+  for arc in tbl.arcs:
+    if arc.node == n:
+      result = min(result, arc.start)
+  if result == Inf:
+    result = float(n) * TAU / float(max(1'u16, tbl.nNodes))
 
-proc owner*(tbl: ArcTable, th: float): NodeId {.inline.} =
-  NodeId(int(wrap(th) / TAU * float(tbl.nNodes)) mod int(tbl.nNodes))
+proc owner*(tbl: ArcTable, th: float): NodeId =
+  let angle = wrap(th)
+  if tbl.arcs.len == 0:
+    return NodeId(int(angle / TAU * float(tbl.nNodes)) mod int(tbl.nNodes))
+
+  var lo = 0
+  var hi = tbl.arcs.len
+  while lo < hi:
+    let mid = (lo + hi) div 2
+    if tbl.arcs[mid].start <= angle:
+      lo = mid + 1
+    else:
+      hi = mid
+  if lo == 0: tbl.arcs[^1].node else: tbl.arcs[lo - 1].node
 
 proc node*(tbl: ArcTable, o: Orbit, t: float): NodeId {.inline.} =
   ## node(id, t) = arc_owner(θ(t)) — 誰にも問い合わせない所在解決（概念書 2章）
   tbl.owner(o.theta(t))
+
+proc validateArcTable*(tbl: ArcTable) =
+  if tbl.nNodes == 0:
+    raise newException(ValueError, "ArcTable requires at least one node")
+  if tbl.arcs.len == 0:
+    return
+  var prev = -1.0
+  for arc in tbl.arcs:
+    if arc.start < 0.0 or arc.start >= TAU:
+      raise newException(ValueError, "arc start must be in [0, TAU)")
+    if arc.start <= prev:
+      raise newException(ValueError, "arc starts must be strictly increasing")
+    if arc.node >= tbl.nNodes:
+      raise newException(ValueError, "arc owner is outside nNodes")
+    prev = arc.start
+
+proc equalArcTable*(epoch: uint32, nNodes: uint16): ArcTable =
+  result = ArcTable(epoch: epoch, nNodes: nNodes)
+  result.validateArcTable()
+
+proc weightedArcTable*(epoch: uint32; weights: openArray[int]): ArcTable =
+  ## Build a persisted arc table from node weights. Each positive weight
+  ## receives one contiguous arc sized by weight / totalWeight.
+  if weights.len == 0:
+    raise newException(ValueError, "weightedArcTable requires at least one weight")
+  var total = 0
+  for w in weights:
+    if w < 0:
+      raise newException(ValueError, "node weights must be non-negative")
+    total += w
+  if total <= 0:
+    raise newException(ValueError, "at least one node weight must be positive")
+
+  result = ArcTable(epoch: epoch, nNodes: uint16(weights.len))
+  var at = 0.0
+  for node, w in weights:
+    if w <= 0:
+      continue
+    result.arcs.add ArcOwner(start: at, node: NodeId(node))
+    at += TAU * float(w) / float(total)
+  result.validateArcTable()
+
+proc mix64(x: uint64): uint64 =
+  var z = x + 0x9e3779b97f4a7c15'u64
+  z = (z xor (z shr 30)) * 0xbf58476d1ce4e5b9'u64
+  z = (z xor (z shr 27)) * 0x94d049bb133111eb'u64
+  z xor (z shr 31)
+
+proc virtualArcTable*(epoch: uint32, nNodes: uint16,
+                      virtualArcsPerNode = 64): ArcTable =
+  ## Build a deterministic virtual-arc table. Existing node/slot arc positions
+  ## stay stable when a new node is added, so membership changes move only the
+  ## ranges captured by the new node's virtual arcs instead of remapping the
+  ## whole equal-division table.
+  if nNodes == 0:
+    raise newException(ValueError, "virtualArcTable requires at least one node")
+  if virtualArcsPerNode <= 0:
+    raise newException(ValueError, "virtualArcsPerNode must be positive")
+  result = ArcTable(epoch: epoch, nNodes: nNodes)
+  for node in 0 ..< int(nNodes):
+    for slot in 0 ..< virtualArcsPerNode:
+      let h = mix64((uint64(node) shl 32) xor uint64(slot))
+      let unit = float(h shr 11) / float(1'u64 shl 53)
+      result.arcs.add ArcOwner(start: unit * TAU, node: NodeId(node))
+  result.arcs.sort(proc(a, b: ArcOwner): int = cmp(a.start, b.start))
+  result.validateArcTable()
+
+proc remapFraction*(oldTable, newTable: ArcTable; samples = 4096): float =
+  ## Estimate how much of the angle space changes owner between two tables.
+  ## This is a topology-planning metric, not a runtime routing primitive.
+  if samples <= 0:
+    raise newException(ValueError, "samples must be positive")
+  var changed = 0
+  for i in 0 ..< samples:
+    let th = (float(i) + 0.5) * TAU / float(samples)
+    if oldTable.owner(th) != newTable.owner(th):
+      inc changed
+  float(changed) / float(samples)
 
 # ---------------------------------------------------------------- slow パス（予測・逆算）
 

--- a/tests/tcore.nim
+++ b/tests/tcore.nim
@@ -21,6 +21,60 @@ suite "theta / owner (fast 層)":
     check tbl.owner(TAU - 1e-9) == 7
     check tbl.owner(PI) == 4
     check tbl.owner(PI - 1e-9) == 3
+  test "明示 ArcTable でも弧境界と wrap が安定する":
+    let tbl = ArcTable(
+      epoch: 1,
+      nNodes: 2,
+      arcs: @[ArcOwner(start: 0.0, node: 0'u16),
+              ArcOwner(start: PI, node: 1'u16)])
+    tbl.validateArcTable()
+    check tbl.owner(0.0) == 0
+    check tbl.owner(PI - 1e-9) == 0
+    check tbl.owner(PI) == 1
+    check tbl.owner(TAU - 1e-9) == 1
+    check tbl.owner(-0.1) == 1
+  test "weightedArcTable は重みに応じた連続弧を作る":
+    let tbl = weightedArcTable(1, [1, 3])
+    check tbl.nNodes == 2
+    check tbl.arcs.len == 2
+    check abs(tbl.arcs[0].start - 0.0) < 1e-12
+    check abs(tbl.arcs[1].start - TAU * 0.25) < 1e-12
+    check tbl.owner(TAU * 0.24) == 0
+    check tbl.owner(TAU * 0.26) == 1
+    expect ValueError:
+      discard weightedArcTable(1, [0, 0])
+    expect ValueError:
+      discard weightedArcTable(1, [1, -1])
+  test "virtualArcTable はノード追加時の再配置率を等分割より下げる":
+    let equal8 = equalArcTable(1, 8)
+    let equal9 = equalArcTable(2, 9)
+    let virt8 = virtualArcTable(1, 8, 64)
+    let virt9 = virtualArcTable(2, 9, 64)
+    check virt8.arcs.len == 8 * 64
+    check virt9.arcs.len == 9 * 64
+    virt8.validateArcTable()
+    virt9.validateArcTable()
+    let equalMoved = remapFraction(equal8, equal9, samples = 8192)
+    let virtualMoved = remapFraction(virt8, virt9, samples = 8192)
+    check equalMoved > 0.4
+    check virtualMoved < 0.25
+    check virtualMoved < equalMoved
+  test "ArcTable validators reject malformed topology":
+    expect ValueError:
+      discard equalArcTable(1, 0)
+    expect ValueError:
+      discard virtualArcTable(1, 0)
+    expect ValueError:
+      discard virtualArcTable(1, 2, 0)
+    expect ValueError:
+      ArcTable(epoch: 1, nNodes: 2,
+               arcs: @[ArcOwner(start: 0.2, node: 0'u16),
+                       ArcOwner(start: 0.1, node: 1'u16)]).validateArcTable()
+    expect ValueError:
+      ArcTable(epoch: 1, nNodes: 2,
+               arcs: @[ArcOwner(start: 0.0, node: 2'u16)]).validateArcTable()
+    expect ValueError:
+      discard remapFraction(equalArcTable(1, 1), equalArcTable(2, 1), samples = 0)
   test "e>0 でも単調（EMax の根拠）":
     let o = Orbit(a: 1.0, phi: 0.0, period: 10.0, e: EMax, pomega: 1.0)
     var prev = -1.0


### PR DESCRIPTION
Summary
- add explicit ArcTable ownership with equal, weighted, and virtual arc modes
- add remapFraction as a topology planning metric
- document the current remapping boundary and test coverage

Validation
- nim check src/roche/core.nim
- nim c -r --nimcache:/tmp/nimcache_roche_tcore tests/tcore.nim
- scripts/test_core.sh
- git diff --check