### PR TITLE
feat: add CLI connection config

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -53,6 +53,7 @@ bin/roche --help
 
 | Flag | Meaning |
 |---|---|
+| `--config=FILE` | Load cluster connection defaults from JSON. CLI flags override the file. `ROCHE_CONFIG` can point to the same file. |
 | `--peers=host:port,...` | Target cluster. |
 | `--user=NAME` / `--password=TEXT` | Username/password auth. |
 | `--auth-token=TEXT` | Token-style auth. |
@@ -63,6 +64,24 @@ bin/roche --help
 | `--tls-server-name=NAME` | Optional hostname override for TLS verification and SNI. |
 | `--tls-insecure-skip-verify` | Skip certificate verification for local smoke tests only. |
 | `--metrics` | Emit key/value metrics where supported. |
+
+Example:
+
+```json
+{
+  "peers": ["127.0.0.1:7301"],
+  "user": "alice",
+  "password": "change-me",
+  "secretKey": "change-me-too",
+  "tls": true,
+  "tlsCaFile": "/etc/rochedb/ca.crt"
+}
+```
+
+```sh
+roche health --config=/etc/rochedb/client.json
+roche get --config=/etc/rochedb/client.json --ring=docs/japan
+```
 
 ## Cluster Commands
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -31,6 +31,30 @@ full reference in [Topology Configuration](topology-config.md).
 | `tlsServerName` | string | `""` | Optional hostname override for TLS verification and SNI. |
 | `tlsInsecureSkipVerify` | bool | `false` | Skip certificate verification for local smoke tests only. |
 
+The CLI can load these connection defaults from JSON with `--config=FILE` or
+`ROCHE_CONFIG=FILE`. Command-line flags override the file.
+
+```json
+{
+  "peers": ["127.0.0.1:7301", "127.0.0.1:7302"],
+  "user": "alice",
+  "password": "change-me",
+  "secretKey": "change-me-too",
+  "galaxy": "default",
+  "tls": true,
+  "tlsCaFile": "/etc/rochedb/ca.crt",
+  "tlsServerName": "rochedb.internal",
+  "tlsInsecureSkipVerify": false
+}
+```
+
+`peers` may be either a comma-separated string or an array of `host:port`
+strings. The CLI accepts the documented camelCase fields and their flag-style
+aliases such as `secret-key`, `auth-token`, `tls-ca`, and `tls-server-name`.
+Keep production config files outside the repository, lock down file
+permissions, and prefer external secret injection when the deployment platform
+provides it.
+
 ## `roched` Server Flags
 
 | Flag | Meaning |

--- a/scripts/cli_crud_smoke.sh
+++ b/scripts/cli_crud_smoke.sh
@@ -208,6 +208,27 @@ for _ in $(seq 1 50); do
   fi
   sleep 0.1
 done
+
+echo "[cli-crud] cluster connection config"
+cat >"$WORK/cluster-config.json" <<CONFIG
+{
+  "peers": ["127.0.0.1:${BASE_PORT}"],
+  "user": "app",
+  "password": "right",
+  "secret-key": "secret",
+  "galaxy": "",
+  "tls": false
+}
+CONFIG
+bin/roche health --config="$WORK/cluster-config.json" |
+  grep -q "node=0"
+config_put="$(bin/roche put --config="$WORK/cluster-config.json" \
+  --ring=cluster/config-demo --payload='{"kind":"config"}' --codec=json)"
+config_raw_id="$(sed -n 's/.*rawId=\([^ ]*\).*/\1/p' <<<"$config_put")"
+bin/roche get --config="$WORK/cluster-config.json" \
+  --ring=cluster/config-demo --filter="{\"id\":\"$config_raw_id\"}" |
+  grep -q '"kind": "config"'
+
 auth_out="$(bin/roche health --peers="127.0.0.1:${BASE_PORT}" \
   --user=app --password=wrong --secret-key=secret 2>&1 >/dev/null || true)"
 grep -q '^error: AUTHRESP failed: ERR auth-required$' <<<"$auth_out"

--- a/src/rochecli.nim
+++ b/src/rochecli.nim
@@ -267,6 +267,33 @@ proc resolveDataDir(dataDir, peers: string): string =
   else:
     defaultDataDir()
 
+proc jsonStringOpt(node: JsonNode, key, default: string): string =
+  if node.kind == JObject and node.hasKey(key):
+    node[key].getStr()
+  else:
+    default
+
+proc jsonBoolOpt(node: JsonNode, key: string, default: bool): bool =
+  if node.kind == JObject and node.hasKey(key):
+    node[key].getBool()
+  else:
+    default
+
+proc jsonPeersOpt(node: JsonNode, default: string): string =
+  if node.kind != JObject or not node.hasKey("peers"):
+    return default
+  let peersNode = node["peers"]
+  case peersNode.kind
+  of JString:
+    peersNode.getStr()
+  of JArray:
+    var parts: seq[string] = @[]
+    for item in peersNode:
+      parts.add item.getStr()
+    parts.join(",")
+  else:
+    raise newException(ValueError, "config peers must be a string or array")
+
 proc requireCliTarget(dataDir, peers: string): string =
   resolveDataDir(dataDir, peers)
 
@@ -2240,7 +2267,8 @@ proc printHelp() =
   echo "  parent:epoch:seq:tWrite"
   echo ""
   echo "Local commands use --data=DIR, ROCHE_DATA, or ./data by default."
-  echo "Cluster commands use --peers=host:port,..."
+  echo "Cluster commands use --peers=host:port,... or --config=FILE."
+  echo "ROCHE_CONFIG can point to the same JSON config file."
   echo "Get uses --view=auto by default; payload codec is inferred from stored metadata."
   echo "--where is accepted as an alias for --filter. --id is a low-level shortcut for scripts."
   echo "Cluster get/query requires --ring=RING so the CLI can reconstruct ring placement metadata."
@@ -2297,6 +2325,7 @@ proc main() =
   var failureDomain = ""
   var authRef = ""
   var redisEndpoint = "127.0.0.1:6379"
+  var configPath = getEnv("ROCHE_CONFIG")
   var universeConfig = ""
   var driverManifestPath = ""
   var driverProjectDir = ""
@@ -2318,6 +2347,36 @@ proc main() =
   var depth = 1
   var branchBudget = 0
   var positionals: seq[string] = @[]
+
+  for kind, key, val in getopt():
+    if kind == cmdLongOption and key == "config":
+      configPath = val
+
+  if configPath.len > 0:
+    let cfg = parseFile(configPath)
+    if cfg.kind != JObject:
+      raise newException(ValueError, "config file must contain a JSON object")
+    peers = jsonPeersOpt(cfg, peers)
+    dataDir = jsonStringOpt(cfg, "data", dataDir)
+    dataDir = jsonStringOpt(cfg, "dataDir", dataDir)
+    username = jsonStringOpt(cfg, "user", username)
+    username = jsonStringOpt(cfg, "username", username)
+    password = jsonStringOpt(cfg, "password", password)
+    authToken = jsonStringOpt(cfg, "authToken", authToken)
+    authToken = jsonStringOpt(cfg, "auth-token", authToken)
+    secretKey = jsonStringOpt(cfg, "secretKey", secretKey)
+    secretKey = jsonStringOpt(cfg, "secret-key", secretKey)
+    galaxy = jsonStringOpt(cfg, "galaxy", galaxy)
+    tls = jsonBoolOpt(cfg, "tls", tls)
+    tlsCaFile = jsonStringOpt(cfg, "tlsCaFile", tlsCaFile)
+    tlsCaFile = jsonStringOpt(cfg, "tls-ca", tlsCaFile)
+    tlsServerName = jsonStringOpt(cfg, "tlsServerName", tlsServerName)
+    tlsServerName = jsonStringOpt(cfg, "tls-server-name", tlsServerName)
+    tlsInsecureSkipVerify = jsonBoolOpt(cfg, "tlsInsecureSkipVerify",
+                                        tlsInsecureSkipVerify)
+    tlsInsecureSkipVerify = jsonBoolOpt(cfg, "tls-insecure-skip-verify",
+                                        tlsInsecureSkipVerify)
+
   for kind, key, val in getopt():
     case kind
     of cmdArgument:
@@ -2330,6 +2389,7 @@ proc main() =
     of cmdLongOption:
       case key
       of "help": help = true
+      of "config": configPath = val
       of "peers": peers = val
       of "data": dataDir = val
       of "target-data": targetDataDir = val


### PR DESCRIPTION
Summary
- add CLI JSON connection config via --config or ROCHE_CONFIG
- support peers as a string or array, plus camelCase and flag-style field names
- cover config-driven cluster health/put/get in CLI smoke
- document config and TLS connection defaults

Validation
- nim check src/rochecli.nim
- scripts/cli_crud_smoke.sh
- git diff --check