### PR TITLE
docs: refresh v0.6 status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## v0.6.0 - Unreleased
+
+### Added
+
+- Added typed `RocheFilterBuilder` helpers for safer read filters without
+  string-concatenated JSON.
+- Added locality validation workloads for interleaved, random, delete-heavy,
+  backfill-heavy, and hot/cold write patterns, including compact-before/after
+  read micro-samples.
+- Added topology remapping primitives: explicit arc tables, weighted arcs,
+  deterministic virtual arcs, topology validation, and `remapFraction`.
+- Added `docs/topology-remapping.md` to explain the boundary between remapping
+  primitives and future online rebalance.
+- Added `docs/use-case-recipes.md` with application recipes for list/detail,
+  membership, inventory locks, webhook idempotency, SaaS tenant isolation,
+  stellar neighborhoods, and RAG corpus layout.
+- Added CLI connection config loading with `--config=FILE` and `ROCHE_CONFIG`.
+  Config can provide peers, auth, galaxy, and TLS defaults while command-line
+  flags remain the override.
+
+### Changed
+
+- Updated technical FAQ and status documents to reflect that arc-table based
+  remapping has a foundation, while live dynamic membership remains future
+  work.
+- Expanded CLI and configuration documentation for cluster/TLS connection
+  defaults.
+
+### Fixed / Hardened
+
+- Expanded CLI smoke coverage to verify config-driven cluster health, put, and
+  get workflows.
+- Expanded core tests for explicit arc ownership, weighted arcs, virtual arc
+  remap reduction, and malformed topology rejection.
+
 ## v0.5.0
 
 ### Added

--- a/docs/rochedb-status.md
+++ b/docs/rochedb-status.md
@@ -69,7 +69,7 @@ Translations:
 | TLS | Done | Standard TLS transport for `roched` and CLI/client connections when built with `-d:ssl`; `scripts/cluster_tls_smoke.sh` covers authenticated TLS, secret-key transport, JSON put/get, and plain-client rejection |
 | Authz / RBAC | PoC | `roched --allow-ring=prefix[,prefix...]` and `--role=user:password:reader|writer|admin[:prefixes]`; `scripts/cluster_authz_smoke.sh` and `scripts/cluster_rbac_smoke.sh` cover prefix and role matrix behavior |
 | Wire fuzz smoke | Done | `scripts/cluster_wire_fuzz_smoke.sh` runs deterministic malformed-frame cases, including oversized headers, and verifies the cluster stays healthy |
-| Dynamic membership / epoch migration | Planned | Current peer list is static |
+| Dynamic membership / epoch migration | Foundation | Current peer list is still static at runtime, but v0.6 adds explicit arc tables, weighted arcs, deterministic virtual arcs, topology validation, and `remapFraction` so membership changes can be modeled with less unnecessary remapping than naive `mod nNodes`. Online rebalance workflow is still planned |
 | Cluster transaction coordinator redundancy | Planned | Remove node0 as a single point of failure |
 | Read-your-writes for cluster tx | PoC | `get/query/batchGet` fallback to node0 landing intent before owner apply; cluster smoke covers update/delete |
 | Fault-tolerance improvements | Planned | Post-v0.1 work; universe sync outbox is now the first durable eventual-convergence primitive |

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -76,7 +76,9 @@ drivers.
   minimal for read/write/admin separation.
 - Cluster transaction coordinator redundancy is not implemented; node0 landing
   remains a single point of failure.
-- Dynamic membership and epoch migration are not implemented.
+- Online dynamic membership and epoch migration workflows are not implemented.
+  The core can model explicit / weighted / virtual arc tables, but operators
+  cannot yet apply a live rebalance protocol through the server.
 - General database-wide audit logs are not implemented. Warp jobs persist
   attempts, retry timing, acknowledgement, and dead-letter state, but that is
   job state rather than a complete access/change audit trail.


### PR DESCRIPTION
Summary
- add an unreleased v0.6.0 changelog section
- update dynamic membership status to reflect topology/remapping foundation
- clarify that online dynamic membership remains future work in the threat model

Validation
- git diff --check