### PR TITLE
test: add locality invariant validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Added locality validation workloads for interleaved, random, delete-heavy,
   backfill-heavy, and hot/cold write patterns, including compact-before/after
   read micro-samples.
+- Added locality invariant checks so the same logical ring query must return
+  the same ID/payload set before and after compaction while disk-span metrics
+  are reported.
 - Added topology remapping primitives: explicit arc tables, weighted arcs,
   deterministic virtual arcs, topology validation, and `remapFraction`.
 - Added `docs/topology-remapping.md` to explain the boundary between remapping
@@ -34,6 +37,8 @@
   get workflows.
 - Expanded core tests for explicit arc ownership, weighted arcs, virtual arc
   remap reduction, and malformed topology rejection.
+- Expanded store locality tests to assert logical result preservation across
+  delete/backfill/compact workloads.
 
 ## v0.5.0
 

--- a/docs/data-locality.md
+++ b/docs/data-locality.md
@@ -156,6 +156,16 @@ The demo intentionally writes records in an interleaved pattern, then runs
 compaction. The important result is not the exact byte count; it is that the
 same live records become physically grouped by ring after compaction.
 
+The demo also prints an `invariant` line:
+
+```text
+invariant ring=locality/ring-0 sameSet=true beforeCandidates=22 afterCandidates=22 beforeDiskSpanRuns=88 afterDiskSpanRuns=4 beforeFragmentedRings=4 afterFragmentedRings=0 beforeLatencyUs=30.050 afterLatencyUs=29.894
+```
+
+This is the important safety check. The same logical ring query must return the
+same ID/payload set before and after compaction. Locality improvement is only
+useful if the logical result set is preserved.
+
 The demo can also run less clean write patterns:
 
 ```bash
@@ -179,6 +189,17 @@ The output includes `read_before` and `read_after` lines. These are local
 micro-samples, not universal latency claims. They exist to catch large
 regressions and to make compact-before/compact-after behavior observable next
 to the physical locality metrics.
+
+The output also reports candidate/result counts and physical span indicators in
+the invariant line:
+
+- `beforeCandidates` / `afterCandidates`: records returned by the logical ring
+  query;
+- `beforeDiskSpanRuns` / `afterDiskSpanRuns`: physical live ring runs in the
+  WAL;
+- `beforeFragmentedRings` / `afterFragmentedRings`: rings split across multiple
+  physical runs;
+- `beforeLatencyUs` / `afterLatencyUs`: repeated read micro-samples.
 
 ## Current Scope
 
@@ -210,14 +231,14 @@ implementation keeps compaction simple and local.
 
 The next locality work should add benchmark cases for:
 
-- random writes;
-- delete-heavy workloads;
-- backfill-heavy workloads;
-- hot/cold ring skew;
-- read latency before and after locality-aware compaction;
+- larger adversarial datasets for random writes;
+- larger adversarial datasets for delete-heavy workloads;
+- larger adversarial datasets for backfill-heavy workloads;
+- larger adversarial datasets for hot/cold ring skew;
 - larger datasets where OS page cache and SSD read behavior become visible.
 
 The v0.6 locality-validation branch starts adding these cases to the runnable
-demo and store test matrix. Larger OS page-cache and SSD-sensitive benchmarks
-still need separate benchmark runs because tiny local unit tests cannot prove
-hardware-level locality behavior.
+demo and store test matrix. The current invariant checks verify that compaction
+does not change the logical result set while locality metrics improve. Larger
+OS page-cache and SSD-sensitive benchmarks still need separate benchmark runs
+because tiny local unit tests cannot prove hardware-level locality behavior.

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -11,7 +11,7 @@ matrix used before releases.
 | Orbital placement core | `tests/tcore.nim` | Unit-covered: angle wrapping, ownership, weighted arcs, virtual arc remap reduction, future arrival, conjunctions |
 | Field / halo movement | `tests/tfield.nim` | Unit-covered: field state and ring movement behavior |
 | Selection parser | `tests/tselect.nim` | Unit-covered: GraphQL-like selection parsing and projection basics |
-| Store / WAL | `tests/tstore.nim` | Unit-covered: codec persistence, torn-tail repair, transaction replay, compact, locality report, delete/backfill locality matrix, backup/restore |
+| Store / WAL | `tests/tstore.nim` | Unit-covered: codec persistence, torn-tail repair, transaction replay, compact, locality report, delete/backfill locality matrix, compact-before/after logical query invariants, backup/restore |
 | Public embedded API | `tests/tapi.nim` | Unit-covered: put/get, codec-aware projection, ring profiles, readRing filtering, typed filter builders, pagination, sorting, stellar neighborhood reads from either side, stellar attach/detach persistence, atomic batch rollback, cooperative ring/stellar locks, warp, universe sync |
 | CLI embedded usage | `scripts/cli_crud_smoke.sh` | Smoke-covered: help, put/get/query/list/count, readRing options, `--near` placement, `--stellar`, stellar attach/detach, `--subring` neighborhood narrowing, codec display, ring profile auto codec, shell, auth error text |
 | C ABI | `examples/cabi_contract.c`, `scripts/driver_compat.sh` | Contract-covered: ABI version, put/get, codec metadata, read ring page shape, validation errors, atlas |
@@ -23,7 +23,7 @@ matrix used before releases.
 | Universe sync | `examples/universe_sync_demo.nim`, `scripts/universe_sync_*_smoke.sh` | Smoke-covered: local export/apply, remote apply, idempotency, malformed JSONL handling |
 | Recovery | `scripts/recovery_smoke.sh` | Smoke-covered: backup/restore and recovery status paths |
 | Driver compatibility | `scripts/driver_compat.sh` | Optional smoke: C, C++, and published driver-facing C ABI paths when enabled |
-| Data model demos | `examples/stellar_data_model_demo.sh`, `examples/locality_layout_demo.sh` | Demo-covered: non-copy stellar visibility, narrowed stellar reads, original ring preservation after detach, compaction locality reporting, messy locality workloads, and compact-before/after read micro-samples |
+| Data model demos | `examples/stellar_data_model_demo.sh`, `examples/locality_layout_demo.sh` | Demo-covered: non-copy stellar visibility, narrowed stellar reads, original ring preservation after detach, compaction locality reporting, messy locality workloads, compact-before/after logical result invariants, and read micro-samples |
 
 ## Release Gate
 

--- a/examples/locality_layout_demo.nim
+++ b/examples/locality_layout_demo.nim
@@ -1,6 +1,6 @@
 ## Physical locality demo for RocheDB's WAL layout.
 
-import std/[json, os, strformat, strutils, tempfiles, times]
+import std/[algorithm, json, os, strformat, strutils, tempfiles, times]
 import ../src/rochedb
 
 proc argValue(name, defaultValue: string): string =
@@ -40,6 +40,20 @@ proc measureReadUs(db: RocheDb, ring: string, iters: int): float =
   if consumed < 0:
     echo "" # keep the loop observable to the optimizer
   elapsed * 1_000_000.0 / float(iters)
+
+proc logicalSignature(db: RocheDb, ring: string): seq[string] =
+  ## Stable signature for invariant checks: compaction may rewrite physical
+  ## layout, but the logical ring query must return the same records.
+  let n = max(1, db.countByRing(ring))
+  let page = db.readRing(ring, RocheReadOptions(
+    filter: newJObject(),
+    limit: n,
+    sortField: "id",
+    sortDirection: rsAsc))
+  for item in page.items:
+    let raw = item.id.toRaw()
+    result.add &"{raw.parent}:{raw.epoch}:{raw.seq}:{raw.tWrite:.9f}:{item.codec}:{item.payload}"
+  result.sort()
 
 when isMainModule:
   let rings = max(1, argInt("rings", 8))
@@ -110,14 +124,23 @@ when isMainModule:
       }, ring = ringName(r))
 
     let readRing = ringName(0)
+    let beforeSignature = logicalSignature(db, readRing)
     let beforeReadUs = measureReadUs(db, readRing, readIters)
-    printReport("before_compact", db.localityReport())
+    let beforeReport = db.localityReport()
+    printReport("before_compact", beforeReport)
     echo &"read_before ring={readRing} iters={readIters} usPerRead={beforeReadUs:.3f}"
     let stats = db.compact()
     echo &"compact beforeBytes={stats.beforeBytes} afterBytes={stats.afterBytes} items={stats.items}"
+    let afterSignature = logicalSignature(db, readRing)
     let afterReadUs = measureReadUs(db, readRing, readIters)
-    printReport("after_compact", db.localityReport())
+    let afterReport = db.localityReport()
+    printReport("after_compact", afterReport)
     echo &"read_after ring={readRing} iters={readIters} usPerRead={afterReadUs:.3f}"
+    let sameSet = beforeSignature == afterSignature
+    echo &"invariant ring={readRing} sameSet={sameSet} beforeCandidates={beforeSignature.len} afterCandidates={afterSignature.len} beforeDiskSpanRuns={beforeReport.ringRuns} afterDiskSpanRuns={afterReport.ringRuns} beforeFragmentedRings={beforeReport.fragmentedRings} afterFragmentedRings={afterReport.fragmentedRings} beforeLatencyUs={beforeReadUs:.3f} afterLatencyUs={afterReadUs:.3f}"
+    if not sameSet:
+      raise newException(AssertionDefect,
+        "logical ring query changed across compaction")
   finally:
     db.close()
     if cleanup:

--- a/examples/locality_layout_demo.sh
+++ b/examples/locality_layout_demo.sh
@@ -10,11 +10,18 @@ READ_ITERS="${READ_ITERS:-100}"
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
-mkdir -p bin
-nim c -d:release --nimcache:/tmp/nimcache_roche_locality_layout_demo \
-  -o:bin/locality_layout_demo examples/locality_layout_demo.nim
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/roche-locality-layout-demo.XXXXXX")"
+BIN="$WORK/locality_layout_demo"
+NIMCACHE="$WORK/nimcache"
+cleanup() {
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
 
-bin/locality_layout_demo \
+nim c -d:release --nimcache:"$NIMCACHE" \
+  -o:"$BIN" examples/locality_layout_demo.nim
+
+"$BIN" \
   --workload="$WORKLOAD" \
   --rings="$RINGS" \
   --per-ring="$PER_RING" \

--- a/tests/tstore.nim
+++ b/tests/tstore.nim
@@ -1,7 +1,16 @@
 ## roche/store の永続化テスト
 
-import std/[os, strutils, tables, tempfiles, unittest]
+import std/[algorithm, os, strutils, tables, tempfiles, unittest]
 import ../src/roche/store
+
+proc ringSignature(st: Store, ring: uint64): seq[string] =
+  if ring notin st.itemsByRing:
+    return @[]
+  for k in st.itemsByRing[ring]:
+    if k in st.items:
+      let p = st.items[k]
+      result.add p.payload & "|" & $p.codec & "|" & $p.seq & "|" & $p.tWrite
+  result.sort()
 
 suite "store persistence":
   test "Particle vec は E レコードで復元される":
@@ -398,6 +407,10 @@ suite "store persistence":
                          payload: "b" & $i, codec: pcRaw)
 
     let before = st.localityReport()
+    let ring1Before = st.ringSignature(1'u64)
+    let ring2Before = st.ringSignature(2'u64)
+    let ring3Before = st.ringSignature(3'u64)
+    let ring4Before = st.ringSignature(4'u64)
     check before.totalParticleRecords == 32
     check before.liveParticleRecords == 26
     check before.deadParticleRecords == 6
@@ -407,6 +420,10 @@ suite "store persistence":
 
     discard st.compact()
     let after = st.localityReport()
+    check st.ringSignature(1'u64) == ring1Before
+    check st.ringSignature(2'u64) == ring2Before
+    check st.ringSignature(3'u64) == ring3Before
+    check st.ringSignature(4'u64) == ring4Before
     check after.totalParticleRecords == 26
     check after.liveParticleRecords == 26
     check after.deadParticleRecords == 0


### PR DESCRIPTION
Summary
- add logical ring-query invariant signatures to the locality layout demo
- report candidate count, disk-span runs, fragmented rings, and latency before/after compaction
- assert store-level logical result preservation across delete/backfill/compact workloads
- make the locality demo script safe for parallel workload runs
- update data-locality and test-coverage docs

Validation
- nim check examples/locality_layout_demo.nim
- nim c -r --nimcache:/tmp/nimcache_roche_tstore tests/tstore.nim
- WORKLOAD=random RINGS=4 PER_RING=20 BACKFILL=8 READ_ITERS=20 examples/locality_layout_demo.sh
- WORKLOAD=delete-heavy RINGS=4 PER_RING=20 BACKFILL=8 READ_ITERS=20 examples/locality_layout_demo.sh
- WORKLOAD=backfill-heavy RINGS=4 PER_RING=20 BACKFILL=8 READ_ITERS=20 examples/locality_layout_demo.sh
- WORKLOAD=hot-cold RINGS=4 PER_RING=20 BACKFILL=8 READ_ITERS=20 examples/locality_layout_demo.sh
- scripts/test_core.sh
- git diff --check