### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.6.0 - Unreleased
+## v0.6.0 - 2026-07-16
 
 ### Added
 
@@ -39,6 +39,7 @@
   remap reduction, and malformed topology rejection.
 - Expanded store locality tests to assert logical result preservation across
   delete/backfill/compact workloads.
+- Bumped package metadata to `0.6.0`.
 
 ## v0.5.0
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RocheDB
 
-**v0.5.0 Technical Preview / research OSS.** RocheDB is not yet presented as a
+**v0.6.0 Technical Preview / research OSS.** RocheDB is not yet presented as a
 production replacement for Redis, PostgreSQL, MongoDB, Apache Arrow, or a
 dedicated vector database. The current release target is a measurable prototype
 of ring/galaxy-oriented storage, retrieval, persistence, drivers, and cluster
@@ -58,7 +58,7 @@ corpus size toward semantic working-set size.
 - Detailed design: [docs/rochedb-design.md](docs/rochedb-design.md)
 - Feature status / roadmap: [docs/rochedb-status.md](docs/rochedb-status.md)
 - Release checklist: [docs/release-checklist.md](docs/release-checklist.md)
-- GitHub release draft: [docs/github-release-v0.5.0.md](docs/github-release-v0.5.0.md)
+- GitHub release draft: [docs/github-release-v0.6.0.md](docs/github-release-v0.6.0.md)
 - Driver / FFI roadmap: [docs/rochedb-driver-roadmap.md](docs/rochedb-driver-roadmap.md)
 - Driver installation guide: [docs/driver-installation.md](docs/driver-installation.md)
 - FAISS versioning policy: [docs/faiss-versioning.md](docs/faiss-versioning.md)
@@ -83,7 +83,7 @@ corpus size toward semantic working-set size.
 
 ## Installation
 
-RocheDB v0.5.x is a technical preview. The Nim package is available through
+RocheDB v0.6.x is a technical preview. The Nim package is available through
 Nimble. Rust, JavaScript / TypeScript, PHP, and Python drivers are published as
 language packages, while the remaining non-Nim language drivers are still
 repository-local foundations.

--- a/docs/github-release-v0.6.0.md
+++ b/docs/github-release-v0.6.0.md
@@ -1,0 +1,136 @@
+# RocheDB v0.6.0
+
+RocheDB v0.6.0 is a technical-preview release focused on topology remapping
+foundations, locality validation, and easier operational configuration.
+
+Release:
+
+https://github.com/puffball1567/rochedb/releases/tag/v0.6.0
+
+RocheDB is still not presented as a production replacement for Redis,
+PostgreSQL, MongoDB, Apache Arrow, or a dedicated vector database. The stronger
+claim in this release is narrower: RocheDB now has more measurable support for
+preserving logical query results while exercising locality-oriented layouts,
+and it has a clearer foundation for future topology changes.
+
+## Main Changes
+
+- Added typed `RocheFilterBuilder` helpers for safer read filters without
+  string-concatenated JSON.
+- Added topology remapping primitives:
+  - explicit arc tables
+  - weighted arcs
+  - deterministic virtual arcs
+  - topology validation
+  - `remapFraction`
+- Added `docs/topology-remapping.md` to describe the boundary between remapping
+  primitives and future online rebalance.
+- Added locality validation workloads for random, delete-heavy, backfill-heavy,
+  hot/cold, and interleaved write patterns.
+- Added locality invariant checks: the same logical ring query must return the
+  same ID/payload set before and after compaction while disk-span and candidate
+  metrics are reported.
+- Added CLI connection config loading with `--config=FILE` and `ROCHE_CONFIG`.
+- Added `docs/use-case-recipes.md` with application recipes for list/detail,
+  membership, inventory locks, webhook idempotency, SaaS tenant isolation,
+  stellar neighborhoods, and RAG corpus layout.
+
+## Why This Release Matters
+
+RocheDB's thesis is that meaningful placement should reduce unnecessary reads,
+transfers, memory pressure, and downstream AI/RAG work. v0.6.0 strengthens the
+engineering around that thesis in two ways.
+
+First, locality is now easier to test as an invariant rather than only a
+narrative. The demo workloads mutate, delete, backfill, compact, and re-read
+the same logical rings, then report whether the result set stayed stable and
+how the physical layout metrics changed.
+
+Second, topology remapping now has explicit primitives. RocheDB still does not
+perform online dynamic membership or live rebalance in this release, but the
+core can model ownership with arc tables and compare remapping behavior without
+falling back to naive `mod nNodes` reasoning.
+
+## Example
+
+Connection config:
+
+```json
+{
+  "peers": ["127.0.0.1:17301"],
+  "galaxy": "docs",
+  "user": "alice",
+  "password": "secret",
+  "tls": {
+    "enabled": true,
+    "ca": "certs/ca.pem",
+    "cert": "certs/client.pem",
+    "key": "certs/client-key.pem"
+  }
+}
+```
+
+Use it from the CLI:
+
+```sh
+roche --config=roche.json health
+
+ROCHE_CONFIG=roche.json roche put \
+  --ring=docs/japan \
+  --payload='{"title":"Hello","status":"draft"}' \
+  --codec=json
+
+ROCHE_CONFIG=roche.json roche get \
+  --ring=docs/japan \
+  --filter='{"status":"draft"}' \
+  --selection='{ title status }'
+```
+
+Run locality validation:
+
+```sh
+examples/locality_layout_demo.sh
+```
+
+The demo prints invariant and layout metrics such as:
+
+```text
+invariant ring=docs/topic/7 sameSet=true beforeCandidates=... afterCandidates=...
+```
+
+## Documentation
+
+New and updated documents:
+
+- `docs/topology-remapping.md`
+- `docs/use-case-recipes.md`
+- `docs/data-locality.md`
+- `docs/config-reference.md`
+- `docs/cli-reference.md`
+- `docs/test-coverage.md`
+- `docs/rochedb-status.md`
+
+## Verification
+
+The local verification pass included:
+
+- `nim check examples/locality_layout_demo.nim`
+- `nim c -r --nimcache:/tmp/nimcache_roche_tstore tests/tstore.nim`
+- `scripts/test_core.sh`
+- `scripts/cli_crud_smoke.sh`
+- `scripts/test_all_smoke.sh`
+- `examples/locality_layout_demo.sh` workloads for random, delete-heavy,
+  backfill-heavy, hot/cold, and interleaved cases during the feature branch
+  verification cycle
+- `git diff --check`
+
+## Known Boundaries
+
+- RocheDB remains a technical preview / research OSS.
+- Online dynamic membership and live rebalance are still planned, not complete.
+- Cluster transaction coordinator redundancy is still planned.
+- Universe sync remains a durable eventual-convergence primitive, not a
+  consensus or quorum system.
+- The next hardening track should focus on the audit items around C ABI failure
+  handling, crash-safe compact/backup/restore, WAL integrity, sync ack safety,
+  data-directory locking, and server resource limits.

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,4 +52,4 @@ downstream AI/RAG or application logic.
 ## Release
 
 - [Release Checklist](release-checklist.md)
-- [GitHub Release Draft](github-release-v0.5.0.md)
+- [GitHub Release Draft](github-release-v0.6.0.md)

--- a/rochedb.nimble
+++ b/rochedb.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version     = "0.5.0"
+version     = "0.6.0"
 author      = "puffball1567"
 description = "Ring-oriented NoSQL document/vector store for smaller working sets"
 license     = "Apache-2.0"


### PR DESCRIPTION
## Summary
- bump RocheDB package metadata and README release label to v0.6.0
- add the v0.6.0 GitHub release draft
- update changelog and docs index for the v0.6.0 release

## Verification
- nimble check
- scripts/test_core.sh
- scripts/cli_crud_smoke.sh via scripts/test_all_smoke.sh
- scripts/test_all_smoke.sh

Note: a sandboxed standalone cli_crud run failed at local TCP/process permissions, but the escalated full smoke suite passed.