### PR TITLE
release: prepare KoutenDB v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## v0.8.0 - 2026-07-20
+
+### Changed
+
+- Renamed the project to KoutenDB.
+- Renamed the public Nim package to `koutendb`.
+- Renamed the command-line entry point to `kouten` and the daemon to `koutend`.
+- Renamed the C ABI surface to `libkoutendb.so`, `include/koutendb.h`, and
+  `kouten_*` / `KOUTEN_*` symbols.
+- Renamed source modules, documentation, examples, scripts, driver stubs, and
+  environment variables to the KoutenDB naming scheme.
+- Updated package, driver, installation, benchmark, topology, codec, and
+  release documentation to use the new repository and package names.
+
+### Naming
+
+- `Kouten` comes from the Japanese word "kouten" (公転), meaning orbital
+  revolution: one body moving around another. The name is intended to match
+  KoutenDB's model: rings, orbit-inspired placement, locality-aware retrieval,
+  and smaller working sets.
+- The technical direction is unchanged. KoutenDB remains the same
+  ring-oriented NoSQL document/vector store, now under a clearer name.
+
+### Migration Notes
+
+- New users should use `nimble install koutendb` and the `kouten` CLI.
+- Driver projects should target the new KoutenDB package names and C ABI names.
+- Older names may remain visible in historical posts, package registries, or
+  archived release notes, but the active project name is KoutenDB.
+
 ## v0.7.0 - 2026-07-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 # KoutenDB
 
-**v0.7.0 Technical Preview / research OSS.** KoutenDB is not yet presented as a
+**v0.8.0 Technical Preview / research OSS.** KoutenDB is not yet presented as a
 production replacement for Redis, PostgreSQL, MongoDB, Apache Arrow, or a
 dedicated vector database. The current release target is a measurable prototype
 of ring/galaxy-oriented storage, retrieval, persistence, drivers, and cluster
 smoke behavior.
+
+The name `Kouten` comes from the Japanese word "kouten" (公転), meaning orbital
+revolution: one body moving around another. That is a good fit for this database
+because KoutenDB treats placement, rings, orbits, and locality as part of the
+retrieval model instead of only as storage internals. The project was previously
+published under older names; the active name, package name, CLI name, and
+repository name are now KoutenDB / `koutendb` / `kouten`.
 
 KoutenDB's practical goal is simple: reduce the amount of data a system has to
 read, transfer, hold in memory, and pass to downstream AI/RAG or application
@@ -58,7 +65,7 @@ corpus size toward semantic working-set size.
 - Detailed design: [docs/koutendb-design.md](docs/koutendb-design.md)
 - Feature status / roadmap: [docs/koutendb-status.md](docs/koutendb-status.md)
 - Release checklist: [docs/release-checklist.md](docs/release-checklist.md)
-- GitHub release draft: [docs/github-release-v0.7.0.md](docs/github-release-v0.7.0.md)
+- GitHub release draft: [docs/github-release-v0.8.0.md](docs/github-release-v0.8.0.md)
 - Driver / FFI roadmap: [docs/koutendb-driver-roadmap.md](docs/koutendb-driver-roadmap.md)
 - Driver installation guide: [docs/driver-installation.md](docs/driver-installation.md)
 - FAISS versioning policy: [docs/faiss-versioning.md](docs/faiss-versioning.md)

--- a/docs/github-release-v0.8.0.md
+++ b/docs/github-release-v0.8.0.md
@@ -1,0 +1,112 @@
+# KoutenDB v0.8.0
+
+KoutenDB v0.8.0 is a naming and migration release.
+
+Release:
+
+https://github.com/puffball1567/koutendb/releases/tag/v0.8.0
+
+The project was previously published under older names. The active project name
+is now KoutenDB. The package name, CLI name, daemon name, C ABI names, repository
+links, documentation, examples, and driver-facing references have been moved to
+the KoutenDB naming scheme.
+
+## Why KoutenDB
+
+`Kouten` comes from the Japanese word "kouten" (公転), meaning orbital
+revolution: one body moving around another.
+
+That meaning fits the database model. KoutenDB uses ring and orbit-inspired
+placement as part of the retrieval path. A record is not only stored somewhere;
+its placement is meant to help decide what should be read together later. The
+goal is to reduce unrelated reads, transferred bytes, candidate memory, and
+downstream AI/RAG or application work when the application has meaningful
+locality.
+
+The name therefore describes the technical direction more directly:
+
+- rings and orbit-inspired coordinates are part of the data model
+- locality is exposed to the database instead of reconstructed after each query
+- retrieval starts from meaningful placement rather than from a global scan
+- the project remains focused on smaller working sets, not on scanning the
+  entire corpus faster
+
+## What Changed
+
+- Public project name: KoutenDB
+- Nim package: `koutendb`
+- CLI: `kouten`
+- Daemon: `koutend`
+- C ABI library: `libkoutendb.so`
+- C header: `include/koutendb.h`
+- C ABI symbol prefix: `kouten_*`
+- C ABI constants and environment variables: `KOUTEN_*` / `KOUTENDB_*`
+- Main repository URL: `https://github.com/puffball1567/koutendb`
+
+The technical direction is unchanged. KoutenDB remains a ring-oriented
+NoSQL/document/vector store for locality-aware retrieval and smaller working
+sets.
+
+## Migration Notes
+
+New installations should use:
+
+```sh
+nimble install koutendb
+kouten --help
+```
+
+From source:
+
+```sh
+git clone https://github.com/puffball1567/koutendb.git
+cd koutendb
+nimble check
+scripts/test_all_smoke.sh
+```
+
+C ABI users should build through the canonical script:
+
+```sh
+scripts/build_capi.sh
+```
+
+and link against:
+
+```text
+include/koutendb.h
+lib/libkoutendb.so
+```
+
+External drivers should move to the KoutenDB package and repository names. Older
+names may still appear in historical posts or archived package entries, but the
+active project name is KoutenDB.
+
+## Verification
+
+The rename branch was verified with:
+
+- `nim check src/koutendb.nim`
+- `nim check src/koutencli.nim`
+- `nim check src/koutend.nim`
+- `nim check src/koutendb_capi.nim`
+- `nimble check`
+- `scripts/build_capi.sh`
+- `scripts/test_core.sh`
+- `scripts/cli_crud_smoke.sh`
+- `scripts/cabi_tls_smoke.sh`
+- `scripts/driver_compat.sh`
+- `scripts/test_all_smoke.sh`
+
+GitHub Actions for the rename PR also passed, including the Linux and macOS C
+ABI checks.
+
+## Known Boundaries
+
+- KoutenDB remains a technical preview / research OSS.
+- This release is primarily a naming and migration release, not a new storage
+  engine feature release.
+- External driver packages may need their own coordinated KoutenDB-name
+  releases.
+- Historical articles, forum posts, and package names may still mention older
+  names during the transition.

--- a/koutendb.nimble
+++ b/koutendb.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version     = "0.7.0"
+version     = "0.8.0"
 author      = "puffball1567"
 description = "KoutenDB: ring-oriented NoSQL document/vector store for smaller working sets"
 license     = "Apache-2.0"


### PR DESCRIPTION
## Summary
- bump package metadata to v0.8.0
- add the KoutenDB naming and migration release notes
- document that Kouten comes from Japanese kouten (公転), meaning orbital revolution
- update README release status and release-draft link

## Verification
- nimble check