### PR TITLE
Fix disk-backed locality verification

### DIFF
--- a/src/kouten/store.nim
+++ b/src/kouten/store.nim
@@ -1768,13 +1768,26 @@ proc snapshotStatsFromFile(path, source: string): StoreBackupStats =
   s.replay(path, repair = false)
   result = s.snapshotStats(path, source)
 
-proc isLiveParticle(s: Store, p: Particle): bool =
+proc sameParticleRevision(current, candidate: Particle): bool =
+  current.parent == candidate.parent and
+    current.seq == candidate.seq and
+    current.version == candidate.version and
+    abs(current.tWrite - candidate.tWrite) < 1e-9
+
+proc isLiveParticle(s: Store, p: Particle, walOffset: int64): bool =
   let k = key(p.parent, p.seq)
+  if s.diskBacked:
+    if k in s.itemOffsets:
+      # The offset is the exact current WAL record identity. Checking its HLC
+      # version also catches divergence without reopening every live payload.
+      return s.itemOffsets[k] == walOffset and
+        k in s.itemVersions and s.itemVersions[k] == p.version
+    if k notin s.itemSegmentOffsets:
+      return false
+    return s.getParticle(p.parent, p.seq).sameParticleRevision(p)
   if k notin s.items:
     return false
-  let live = s.items[k]
-  live.parent == p.parent and live.seq == p.seq and
-    abs(live.tWrite - p.tWrite) < 1e-9
+  s.items[k].sameParticleRevision(p)
 
 proc localityReport*(s: Store): StoreLocalityReport =
   ## Inspect the physical WAL particle order and report ring locality.
@@ -1805,7 +1818,10 @@ proc localityReport*(s: Store): StoreLocalityReport =
   var runCounts = initTable[uint64, int]()
   var rings = initTable[uint64, bool]()
 
-  while fs.readLine(line):
+  while true:
+    let recordStart = fs.getPosition()
+    if not fs.readLine(line):
+      break
     if line.len == 0:
       continue
     if line == WalMagicLine:
@@ -1825,7 +1841,7 @@ proc localityReport*(s: Store): StoreLocalityReport =
       of "P":
         inc result.totalParticleRecords
         let p = recordStream.readParticleRecord(parts, 1)
-        if s.isLiveParticle(p):
+        if s.isLiveParticle(p, recordStart):
           inc result.liveParticleRecords
           rings[p.parent] = true
           if not haveLast or p.parent != lastRing:
@@ -1843,7 +1859,7 @@ proc localityReport*(s: Store): StoreLocalityReport =
       of "XP":
         inc result.totalParticleRecords
         let p = recordStream.readParticleRecord(parts, 2)
-        if s.isLiveParticle(p):
+        if s.isLiveParticle(p, recordStart):
           inc result.liveParticleRecords
           rings[p.parent] = true
           if not haveLast or p.parent != lastRing:
@@ -1861,7 +1877,8 @@ proc localityReport*(s: Store): StoreLocalityReport =
       else:
         discard
     except CatchableError:
-      break
+      raise newException(IOError, "cannot inspect WAL locality near byte " &
+        $recordStart & ": " & getCurrentExceptionMsg())
   if haveLast and currentRun > 0:
     result.maxRunRecords = max(result.maxRunRecords, currentRun)
 
@@ -1872,8 +1889,9 @@ proc localityReport*(s: Store): StoreLocalityReport =
   result.avgRunRecords = if result.ringRuns == 0: 0.0
                          else: float(result.liveParticleRecords) / float(result.ringRuns)
   result.localityScore =
-    if result.ringRuns == 0: 1.0
-    else: float(max(1, result.ringCount)) / float(result.ringRuns)
+    if result.totalParticleRecords == 0: 1.0
+    elif result.liveParticleRecords == 0 or result.ringRuns == 0: 0.0
+    else: float(result.ringCount) / float(result.ringRuns)
 
 proc compact*(s: Store): StoreCompactStats =
   ## 生存レコードだけで WAL を再構築する。

--- a/tests/tapi.nim
+++ b/tests/tapi.nim
@@ -1621,6 +1621,12 @@ suite "永続化":
       check report.items == 18
       check report.rings >= 2
       check report.locality.persistent
+      check report.locality.totalParticleRecords == 18
+      check report.locality.liveParticleRecords == 18
+      check report.locality.deadParticleRecords == 0
+      check report.locality.ringCount == 3
+      check report.locality.ringRuns == 3
+      check report.locality.localityScore == 1.0
       check report.segmentDirExists
       check report.checks.len >= 4
       check report.checks.anyIt(it.name == "open-replay-lock" and it.ok)
@@ -1642,6 +1648,21 @@ suite "永続化":
                                              maxSegmentFiles = 0)
       check not cappedSegments.ok
       check cappedSegments.checks.anyIt(it.name == "segment-files-limit" and not it.ok)
+    finally:
+      removeDir(root)
+
+  test "operationalVerify rejects a corrupted versioned WAL":
+    let root = createTempDir("koutendb", "operational-verify-corrupt")
+    let dir = root / "db"
+    try:
+      var db = open(dataDir = dir, diskBacked = true)
+      discard db.put("checksum", ring = "ops/corrupt")
+      db.close()
+
+      let walPath = dir / "kouten.log"
+      writeFile(walPath, readFile(walPath).replace("checksum", "checksux"))
+      expect IOError:
+        discard operationalVerify(dir, diskBacked = true)
     finally:
       removeDir(root)
 

--- a/tests/tstore.nim
+++ b/tests/tstore.nim
@@ -1037,6 +1037,86 @@ suite "store persistence":
     st.close()
     removeDir(dir)
 
+  test "disk-backed locality report classifies current update delete and transaction records":
+    let dir = createTempDir("kouten-store", "disk-locality")
+    var st = openStore(dir, diskBacked = true)
+    st.upsert Particle(parent: 7'u64, seq: 0'u32, period: 60.0,
+                       head: 0.0, tWrite: 1.0, payload: "old")
+    st.upsert Particle(parent: 7'u64, seq: 0'u32, period: 60.0,
+                       head: 0.0, tWrite: 2.0, payload: "current")
+    st.upsert Particle(parent: 8'u64, seq: 0'u32, period: 60.0,
+                       head: 0.0, tWrite: 3.0, payload: "deleted")
+    st.remove(8'u64, 0'u32)
+
+    let tx = st.beginTxn()
+    tx.upsert Particle(parent: 9'u64, seq: 0'u32, period: 60.0,
+                       head: 0.0, tWrite: 4.0, payload: "transaction")
+    tx.commit()
+    for i in 0'u32 ..< 16'u32:
+      st.upsert Particle(parent: 10'u64, seq: i, period: 60.0,
+                         head: 0.0, tWrite: 10.0 + float(i),
+                         payload: "packed-" & $i)
+
+    check st.items.len == 0
+    check st.itemOffsets.len == 18
+    let before = st.localityReport()
+    check before.totalParticleRecords == 20
+    check before.liveParticleRecords == 18
+    check before.deadParticleRecords == 2
+    check before.ringCount == 3
+    check before.ringRuns == 3
+    check before.fragmentedRings == 0
+    check before.localityScore == 1.0
+    st.close()
+
+    var reopened = openStore(dir, diskBacked = true)
+    check reopened.items.len == 0
+    check reopened.itemOffsets.len == 18
+    check reopened.itemSegmentOffsets.len == 16
+    check reopened.getParticle(7'u64, 0'u32).payload == "current"
+    check reopened.getParticle(9'u64, 0'u32).payload == "transaction"
+    let after = reopened.localityReport()
+    check after.totalParticleRecords == 20
+    check after.liveParticleRecords == 18
+    check after.deadParticleRecords == 2
+    check after.ringCount == 3
+    check after.ringRuns == 3
+    check after.fragmentedRings == 0
+    check after.localityScore == 1.0
+    reopened.close()
+    removeDir(dir)
+
+  test "locality report does not claim perfect locality when every record is dead":
+    let dir = createTempDir("kouten-store", "disk-locality-no-live")
+    var st = openStore(dir, diskBacked = true)
+    st.upsert Particle(parent: 11'u64, seq: 0'u32, period: 60.0,
+                       head: 0.0, tWrite: 1.0, payload: "deleted")
+    st.remove(11'u64, 0'u32)
+
+    let report = st.localityReport()
+    check report.totalParticleRecords == 1
+    check report.liveParticleRecords == 0
+    check report.deadParticleRecords == 1
+    check report.ringCount == 0
+    check report.ringRuns == 0
+    check report.localityScore == 0.0
+    st.close()
+    removeDir(dir)
+
+  test "locality report fails visibly when the open WAL becomes corrupted":
+    let dir = createTempDir("kouten-store", "locality-corrupt")
+    var st = openStore(dir, diskBacked = true)
+    st.upsert Particle(parent: 12'u64, seq: 0'u32, period: 60.0,
+                       head: 0.0, tWrite: 1.0, payload: "checksum")
+    st.sync()
+
+    let walPath = dir / "kouten.log"
+    writeFile(walPath, readFile(walPath).replace("checksum", "checksux"))
+    expect IOError:
+      discard st.localityReport()
+    st.close()
+    removeDir(dir)
+
   test "strong durability の compact 後も WAL は復元できる":
     let dir = createTempDir("kouten-store", "strong-compact")
     var st = openStore(dir, durability = durStrong)


### PR DESCRIPTION
## Summary

- classify disk-backed WAL particles using the current WAL offset and HLC mutation version
- report zero locality instead of a perfect score when all particle records are dead
- fail visibly when WAL corruption is encountered during locality inspection
- cover updates, deletes, transactions, segment rebuilds, zero-live state, and malformed WAL

## Validation

- `scripts/test_core.sh`
- `scripts/test_all_smoke.sh`
- `nimble check`
- `nim check --hints:off src/koutendb.nim`
- `git diff --check`

Resolves #68 after merge.