### PR TITLE
Isolate 72-hour soak artifacts

### DIFF
--- a/docs/soak-testing.md
+++ b/docs/soak-testing.md
@@ -39,6 +39,13 @@ The script prints the work directory and writes:
 - `snapshot-final.txt`
 - `metrics-final.txt`
 - `verify-node0.json`, `verify-node1.json`, `verify-node2.json`
+- `run-config.txt` with the tested commit and workload settings
+- `bin/` with the exact server, CLI, and runner binaries used by the run
+- `completed.ok` after the final snapshot and every offline verify succeed
+
+The run uses only the binaries stored under its work directory. Rebuilding the
+repository during a long soak therefore cannot change the binaries used for
+the final snapshot or offline verification.
 
 ## 72-Hour Run
 

--- a/examples/soak_72h.sh
+++ b/examples/soak_72h.sh
@@ -8,6 +8,10 @@ WORKDIR="${KOUTEN_SOAK_WORKDIR:-${TMPDIR:-/tmp}/koutendb-soak-$(date +%Y%m%d-%H%
 SECONDS_TO_RUN="${KOUTEN_SOAK_SECONDS:-259200}"
 INTERVAL_MS="${KOUTEN_SOAK_INTERVAL_MS:-250}"
 REPORT_EVERY="${KOUTEN_SOAK_REPORT_EVERY_SECONDS:-60}"
+BIN_DIR="$WORKDIR/bin"
+KOUTEND="$BIN_DIR/koutend"
+KOUTENCLI="$BIN_DIR/koutencli"
+SOAK_RUNNER="$BIN_DIR/soak_runner"
 PIDS=()
 RUNNER_PID=""
 
@@ -25,36 +29,45 @@ cleanup() {
 trap cleanup EXIT
 
 cd "$ROOT"
-mkdir -p "$WORKDIR"
+mkdir -p "$WORKDIR" "$BIN_DIR"
 
 echo "[soak] workdir: $WORKDIR"
 echo "[soak] peers: $PEERS"
 echo "[soak] duration seconds: $SECONDS_TO_RUN"
+{
+  echo "commit=$(git rev-parse HEAD)"
+  echo "startedAt=$(date --iso-8601=seconds)"
+  echo "peers=$PEERS"
+  echo "durationSec=$SECONDS_TO_RUN"
+  echo "intervalMs=$INTERVAL_MS"
+  echo "reportEverySec=$REPORT_EVERY"
+} >"$WORKDIR/run-config.txt"
 
 echo "[soak] build koutend"
-nim c -d:release --nimcache:/tmp/nimcache_koutend_soak -o:src/koutend src/koutend.nim
+nim c -d:release --nimcache:/tmp/nimcache_koutend_soak -o:"$KOUTEND" src/koutend.nim
 
 echo "[soak] build koutencli"
-nim c -d:release --nimcache:/tmp/nimcache_koutencli_soak -o:src/koutencli src/koutencli.nim
+nim c -d:release --nimcache:/tmp/nimcache_koutencli_soak -o:"$KOUTENCLI" src/koutencli.nim
 
 echo "[soak] build soak runner"
-nim c -d:release --nimcache:/tmp/nimcache_kouten_soak_runner -o:bin/soak_runner examples/soak_runner.nim
+nim c -d:release --nimcache:/tmp/nimcache_kouten_soak_runner -o:"$SOAK_RUNNER" examples/soak_runner.nim
 
 echo "[soak] start 3 nodes"
 for id in 0 1 2; do
   mkdir -p "$WORKDIR/node$id"
-  src/koutend --id="$id" --peers="$PEERS" --data="$WORKDIR/node$id" --slow-tick=0.05 >"$WORKDIR/node$id.log" 2>&1 &
+  "$KOUTEND" --id="$id" --peers="$PEERS" --data="$WORKDIR/node$id" --slow-tick=0.05 >"$WORKDIR/node$id.log" 2>&1 &
   PIDS+=("$!")
 done
+printf '%s\n' "${PIDS[@]}" >"$WORKDIR/node-pids.txt"
 
 echo "[soak] wait for health"
 for _ in $(seq 1 100); do
-  if src/koutencli health --peers="$PEERS" >"$WORKDIR/health-start.txt" 2>&1; then
+  if "$KOUTENCLI" health --peers="$PEERS" >"$WORKDIR/health-start.txt" 2>&1; then
     break
   fi
   sleep 0.1
 done
-src/koutencli health --peers="$PEERS" | tee "$WORKDIR/health-start.txt"
+"$KOUTENCLI" health --peers="$PEERS" | tee "$WORKDIR/health-start.txt"
 
 echo "[soak] run workload"
 KOUTEN_SOAK_PEERS="$PEERS" \
@@ -62,14 +75,15 @@ KOUTEN_SOAK_SECONDS="$SECONDS_TO_RUN" \
 KOUTEN_SOAK_INTERVAL_MS="$INTERVAL_MS" \
 KOUTEN_SOAK_REPORT_EVERY_SECONDS="$REPORT_EVERY" \
 KOUTEN_SOAK_OUT="$WORKDIR/soak-progress.jsonl" \
-  bin/soak_runner &
+  "$SOAK_RUNNER" &
 RUNNER_PID="$!"
+echo "$RUNNER_PID" >"$WORKDIR/runner.pid"
 wait "$RUNNER_PID"
 RUNNER_PID=""
 
 echo "[soak] snapshot and metrics before shutdown"
-src/koutencli snapshot --peers="$PEERS" | tee "$WORKDIR/snapshot-final.txt"
-src/koutencli metrics --peers="$PEERS" | tee "$WORKDIR/metrics-final.txt"
+"$KOUTENCLI" snapshot --peers="$PEERS" | tee "$WORKDIR/snapshot-final.txt"
+"$KOUTENCLI" metrics --peers="$PEERS" | tee "$WORKDIR/metrics-final.txt"
 
 echo "[soak] stop nodes for offline verify"
 cleanup
@@ -77,9 +91,10 @@ PIDS=()
 
 echo "[soak] verify node data directories"
 for id in 0 1 2; do
-  src/koutencli verify --data="$WORKDIR/node$id" --json >"$WORKDIR/verify-node$id.json"
+  "$KOUTENCLI" verify --data="$WORKDIR/node$id" --json >"$WORKDIR/verify-node$id.json"
 done
 
+touch "$WORKDIR/completed.ok"
 echo "[soak] OK"
 echo "[soak] progress: $WORKDIR/soak-progress.jsonl"
 echo "[soak] logs: $WORKDIR/node*.log"


### PR DESCRIPTION
## Summary

- build the server, CLI, and soak runner into the run work directory
- ensure repository rebuilds cannot change binaries used by a running soak or its final verification
- record the tested commit, workload settings, process IDs, and successful completion marker
- document the isolated run artifacts

## Validation

- `bash -n examples/soak_72h.sh`
- 10-second three-node mixed-workload preflight
- 40 successful PUT/GET/query/ring-read operations
- retrieval and metrics operations completed with `errors: 0`
- final snapshot and all three offline verifies passed
- disk-backed locality live/dead counts were correct

Supports #57.