### PR TITLE
docs: publish v0.12 roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Typical NoSQL](docs/nosql-positioning.md) for the full model.
 - Concept: [docs/koutendb-concept.md](docs/koutendb-concept.md)
 - Detailed design: [docs/koutendb-design.md](docs/koutendb-design.md)
 - Feature status / roadmap: [docs/koutendb-status.md](docs/koutendb-status.md)
+- v0.12 implementation and validation roadmap: [docs/v0.12-roadmap.md](docs/v0.12-roadmap.md)
 - Release checklist: [docs/release-checklist.md](docs/release-checklist.md)
 - GitHub release notes: [docs/github-release-v0.11.0.md](docs/github-release-v0.11.0.md)
 - Driver / FFI roadmap: [docs/koutendb-driver-roadmap.md](docs/koutendb-driver-roadmap.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ downstream AI/RAG or application logic.
 - [Use Case Recipes](use-case-recipes.md)
 - [Technical FAQ](technical-faq.md)
 - [Feature Status / Roadmap](koutendb-status.md)
-- [v0.10 Roadmap](v0.10-roadmap.md)
+- [v0.12 Implementation And Validation Roadmap](v0.12-roadmap.md)
 - [Operational Trials](operational-trials.md)
 - [Soak Testing](soak-testing.md)
 - [Benchmark Notes](koutendb-bench.md)
@@ -59,3 +59,4 @@ downstream AI/RAG or application logic.
 
 - [Release Checklist](release-checklist.md)
 - [v0.11.0 Release Notes](github-release-v0.11.0.md)
+- [Historical v0.10 Roadmap](v0.10-roadmap.md)

--- a/docs/koutendb-status.md
+++ b/docs/koutendb-status.md
@@ -7,6 +7,8 @@ Release checklist: [release-checklist.md](./release-checklist.md)
 
 Current release evidence: [v0.11.0 release notes](./github-release-v0.11.0.md)
 
+Current next-release planning: [v0.12 roadmap](./v0.12-roadmap.md)
+
 Historical planning reference: [v0.10 roadmap](./v0.10-roadmap.md)
 
 Translations:

--- a/docs/v0.12-roadmap.md
+++ b/docs/v0.12-roadmap.md
@@ -1,0 +1,244 @@
+# KoutenDB v0.12 Roadmap
+
+This document records the current implementation and validation candidates for
+the next KoutenDB development cycle. It is a planning document, not a promise
+that every candidate will ship in v0.12.
+
+## Theme
+
+v0.11 made ring locality part of the persistent disk-read layout. The next
+cycle should make that layout easier to maintain and observe without weakening
+its crash-safety or operator control.
+
+The primary direction is:
+
+> Make disk-backed locality self-maintaining within explicit limits, then
+> validate the complete path once instead of repeating long endurance runs
+> after every intermediate change.
+
+## Primary v0.12 Candidates
+
+### 1. Bounded Automatic Ring Packing
+
+KoutenDB already reports per-ring stale ratios and provides explicit
+`pack-ring` and `pack-recommended` commands. The next step is an opt-in
+maintenance scheduler that uses the same diagnostics.
+
+The scheduler should support:
+
+- stale-ratio and stale-record thresholds;
+- maximum rings, bytes, or elapsed time per maintenance run;
+- an optional maintenance window;
+- dry-run and status output using the same decision logic as execution;
+- durable reporting of success, skip, interruption, and failure reasons;
+- clean restart after process termination;
+- a default-off mode so opening a database never starts unpredictable work.
+
+The scheduler must not turn into an unbounded background compactor. Operators
+must be able to predict and cap its disk I/O and execution time.
+
+### 2. Generation Checkpoints And Snapshots
+
+A checkpoint should identify one consistent storage generation across the WAL,
+ring-segment manifest, metadata, and rebuildable sidecar indexes.
+
+The initial scope should provide:
+
+- an atomic checkpoint identity and WAL high-water mark;
+- verification that every referenced generation is complete and checksummed;
+- restart and restore from a selected complete checkpoint;
+- cleanup rules that never remove the last verified generation;
+- a machine-readable status suitable for backup orchestration.
+
+This complements backup and restore. It does not need to become a full
+point-in-time recovery service in the first implementation.
+
+### 3. Prometheus-Compatible Operational Metrics
+
+Existing machine-readable counters should be available in Prometheus text
+format through a stable operational surface.
+
+Initial metrics should cover:
+
+- segment hits and WAL fallbacks;
+- segment/index bytes and active generation counts;
+- stale records, stale ratios, and recommended rings;
+- pack attempts, outcomes, durations, and bytes rewritten;
+- checkpoint age and verification state;
+- WAL growth, item/ring counts, and capacity-limit failures;
+- request latency and error counters already exposed by cluster metrics.
+
+Metric names and labels must avoid unbounded ring-name cardinality by default.
+
+### 4. Explainable Maintenance Decisions
+
+Operators should be able to answer why a ring was packed, skipped, or read from
+the WAL. Diagnostics should expose stable reason codes rather than requiring
+log parsing.
+
+This includes:
+
+- pack recommendation reasons;
+- WAL fallback reasons;
+- inactive-generation cleanup results;
+- capacity guardrail failures;
+- checkpoint eligibility and rejection reasons.
+
+## Follow-On Candidates
+
+These are important, but they should not make the v0.12 persistence scope
+unbounded.
+
+### Cluster Transaction Coordinator Redundancy
+
+Remove the current node0 landing single point of failure with fenced ownership
+and recoverable handoff. KoutenDB should not add consensus round trips to every
+ordinary write merely to imitate a different database architecture.
+
+### Incremental Import And Change Feeds
+
+Allow an existing PostgreSQL, MySQL, or application event stream to place only
+changed records into KoutenDB. This supports adoption with an existing system
+of record while KoutenDB serves locality-oriented retrieval.
+
+### Multi-Context Locality
+
+Explore a public model for reading the same stored data through multiple
+context axes, such as time, version, source, or application view, without
+duplicating the payload. Detailed graph/lens semantics remain a separate design
+track and are not required for v0.12.
+
+## Validation Roadmap
+
+### 1. Unit And Invariant Matrix
+
+Continue extending deterministic tests around:
+
+- writes, updates, deletes, backfills, pack, and reopen;
+- identical logical result sets before and after maintenance;
+- segment corruption, wrong index offsets, and whole-ring WAL fallback;
+- exact threshold boundaries and invalid maintenance budgets;
+- checkpoint creation, rejection, cleanup, and restore;
+- failure isolation between unrelated rings.
+
+### 2. Accelerated Churn Test
+
+Before another 72-hour run, execute a one-to-three-hour high-density workload
+that maximizes state transitions rather than wall-clock time.
+
+It should repeatedly perform:
+
+- multi-ring writes, updates, deletes, and backfills;
+- manual and scheduled pack cycles;
+- reopen and verification cycles;
+- checkpoint creation and cleanup;
+- backup and restore comparisons.
+
+The test should record p50/p95/p99 latency, RSS, WAL bytes, segment/index bytes,
+stale ratios, generation counts, fallback counts, and logical-result hashes.
+
+### 3. Process-Crash Matrix
+
+Extend process-level termination tests beyond the writer loop. Send `SIGKILL`
+at pack and checkpoint boundaries, including:
+
+- during segment output;
+- after segment replacement but before index replacement;
+- after both generation files are durable but before manifest activation;
+- immediately after manifest activation;
+- during inactive-generation cleanup;
+- during backup/checkpoint publication.
+
+After every crash, exactly one complete generation must remain usable and the
+logical result must match WAL recovery.
+
+### 4. Concurrency And Backpressure
+
+Run multiple readers and writers while maintenance, backup, and metrics reads
+are active. Validate:
+
+- no deadlocks or duplicated committed mutations;
+- bounded queues and explicit overload errors;
+- stable lock/fencing behavior;
+- no partial results during segment fallback;
+- bounded memory growth under slow clients.
+
+### 5. Storage-Failure Injection
+
+Cover disk-full, permission loss, short writes, missing generation files,
+damaged manifests, and index-only corruption. Failures must be explicit and
+must not report an uncommitted or corrupted write as successful.
+
+### 6. Upgrade And Migration Compatibility
+
+Keep representative v0.10 and v0.11 data fixtures and verify:
+
+- open and WAL replay on the new version;
+- legacy generation-zero segment reads;
+- explicit pack into the current format;
+- JSONL dump/import as the stable pre-v1 migration boundary;
+- backup, restore, and offline verification after upgrade.
+
+### 7. Container And Security Validation
+
+Run the persistence path with Docker volumes, container restarts, network
+interruptions, TLS, ID/password authentication, secret keys, and authorization.
+Certificate rejection and expired/invalid credential paths must fail closed.
+
+### 8. External Driver Compatibility
+
+Run published Rust, JavaScript/TypeScript, PHP, C++, and Python drivers against
+the same CRUD, TLS, restart, and error-contract matrix. Driver release work
+remains in each external repository, while the core provides the compatibility
+target.
+
+### 9. Final 72-Hour Endurance Gate
+
+The next 72-hour run should start only after the v0.12 storage and maintenance
+behavior is feature-frozen. It should include the bounded maintenance scheduler
+and checkpoint path so one run validates the complete release candidate.
+
+The final report should compare the start, 24-hour, 48-hour, and 72-hour points
+for:
+
+- p50/p95/p99 point, ring, stellar, and retrieval latency;
+- memory and disk growth;
+- WAL fallback and pack outcome counters;
+- stale ratios and generation counts;
+- cluster queues and errors;
+- final offline verification and restore equivalence.
+
+The 72-hour test remains a manual release gate and must not run in normal CI.
+
+## Recommended Order
+
+1. Implement bounded automatic packing.
+2. Implement generation checkpoints and maintenance diagnostics.
+3. Add Prometheus-compatible metrics.
+4. Run the accelerated churn, crash, concurrency, storage-failure, and upgrade
+   matrices.
+5. Run container, TLS/auth, and external-driver compatibility tests.
+6. Freeze the release candidate and run one final 72-hour endurance test.
+
+## Exit Criteria
+
+v0.12 should be considered ready when:
+
+- maintenance work is opt-in, bounded, observable, and restart-safe;
+- pack/checkpoint interruption cannot replace a complete generation with an
+  incomplete one;
+- logical result hashes remain identical across maintenance and recovery;
+- capacity growth and fallback behavior are explainable through metrics;
+- upgrade fixtures and backup/restore verification pass;
+- the accelerated and final endurance reports show no unbounded growth or
+  unexplained latency degradation.
+
+## Non-Goals
+
+The v0.12 persistence cycle should not require:
+
+- unbounded automatic compaction;
+- consensus on every ordinary write;
+- a general-purpose graph database inside KoutenDB;
+- a 72-hour CI job;
+- claiming multi-region certification from a local endurance run.


### PR DESCRIPTION
## Summary

Publish the KoutenDB v0.12 implementation and validation roadmap from devel.

The roadmap covers bounded automatic packing, generation checkpoints, Prometheus-compatible metrics, explainable maintenance decisions, accelerated failure/concurrency/upgrade validation, and the final 72-hour release gate.

No package behavior or version metadata changes are included.

## Verification
All five CI jobs passed on #81.