### PR TITLE
test: add process crash publication matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,9 @@ jobs:
       - name: Run disk-backed server maintenance and pagination smoke
         run: scripts/auto_pack_server_smoke.sh
 
+      - name: Run process crash publication matrix
+        run: scripts/process_crash_matrix.sh
+
       - name: Run recovery smoke
         run: scripts/recovery_smoke.sh
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -33,6 +33,7 @@ matrix used before releases.
 | Soak testing | `examples/soak_72h.sh`, `examples/soak_runner.nim` | Optional local runner: long-running three-node cluster validation with mixed writes, point reads, query projection, ring reads, retrieval, metrics, snapshot, and offline verify. Not part of CI. |
 | Accelerated churn | `examples/accelerated_churn.sh`, `examples/accelerated_churn.nim` | Manual high-density disk-backed validator: seeded writes, updates, deletes, backfills, bounded maintenance, checkpoint retention, reopen, backup/restore, independent full-state comparisons, bounded latency sampling, RSS/storage/fallback metrics, and final offline verification. A 120,000-operation local run completed with 1,202 exact logical-state comparisons, 60 reopens, 30 backup/restore comparisons, zero duplicate or missing records, and zero WAL fallbacks. It remains outside CI. |
 | Disk-backed crash recovery | `scripts/disk_backed_recovery_smoke.sh`, `examples/disk_backed_recovery_matrix.nim` | Three process-level `SIGKILL` rounds during repeated strong-durability two-ring transactions, each followed by restart, atomic-pair verification, ring pack, compact, backup, restore, and result re-verification. The round count is configurable with `KOUTEN_RECOVERY_ROUNDS`. |
+| Publication crash boundaries | `scripts/process_crash_matrix.sh`, `examples/process_crash_matrix.nim` | CI matrix using actual `SIGKILL` at nine exact boundaries: segment output, data and index publication, manifest activation, inactive-generation cleanup, and checkpoint/backup publication before and after replacement. Restart verification requires old-or-new generation visibility, unrelated-ring isolation, hidden unpublished checkpoints, restorable published state, retry safety, temporary-file cleanup, and zero post-recovery WAL fallback. Test hooks are compile-time-only and absent from release builds. This is process-crash coverage, not a power-loss durability claim. |
 | Driver compatibility | `scripts/driver_compat.sh` | Optional smoke: C, C++, and published driver-facing C ABI paths when enabled |
 | Data model demos | `scripts/demo_smoke.sh`, `examples/stellar_data_model_demo.sh`, `examples/locality_layout_demo.sh`, `examples/payload_codecs_demo.sh`, `examples/effect_validation_demo.sh` | Demo-covered: non-copy stellar visibility, narrowed stellar reads, original ring preservation after detach, payload codec persistence, compaction locality reporting, messy locality workloads, compact-before/after logical result invariants, lightweight effect validation, and read micro-samples. `examples/effect_validation_matrix.sh` and `examples/offline_effect_validation.sh` are manual validation tools, not default CI smoke steps. |
 
@@ -42,6 +43,7 @@ For a normal core release, run:
 
 ```sh
 scripts/test_core.sh
+scripts/process_crash_matrix.sh
 scripts/checkpoint_smoke.sh
 scripts/cli_crud_smoke.sh
 scripts/auto_pack_server_smoke.sh

--- a/docs/v0.12-roadmap.md
+++ b/docs/v0.12-roadmap.md
@@ -203,8 +203,11 @@ replace the process-crash, concurrency, storage-failure, container, or final
 
 ### 3. Process-Crash Matrix
 
-Extend process-level termination tests beyond the writer loop. Send `SIGKILL`
-at pack and checkpoint boundaries, including:
+**Status: implemented for the v0.12 cycle.**
+
+Process-level termination coverage now extends beyond the writer loop. The
+matrix sends an actual `SIGKILL` at pack, checkpoint, and backup boundaries,
+including:
 
 - during segment output;
 - after segment replacement but before index replacement;
@@ -215,6 +218,18 @@ at pack and checkpoint boundaries, including:
 
 After every crash, exactly one complete generation must remain usable and the
 logical result must match WAL recovery.
+
+The matrix covers nine exact publication points: segment output, data-file
+publication, index publication, manifest activation, inactive-generation
+cleanup, checkpoint publication before and after rename, and backup
+publication before and after replacement. It verifies unrelated-ring
+isolation, old-or-new generation visibility, checkpoint listing isolation,
+backup restore contents, retry after restart, temporary-file cleanup, and zero
+segment-to-WAL fallbacks after a recovery pack. The hooks exist only in the
+dedicated `-d:koutenTestCrashPoints` build and are absent from release builds.
+
+This is process-termination evidence. It does not claim power-loss or storage
+device durability; those failure modes remain in the storage-failure matrix.
 
 ### 4. Concurrency And Backpressure
 

--- a/examples/process_crash_matrix.nim
+++ b/examples/process_crash_matrix.nim
@@ -1,0 +1,227 @@
+## Exact process-crash boundary helper used by scripts/process_crash_matrix.sh.
+
+import std/[os, parseopt, sequtils, strformat, strutils]
+import ../src/kouten/store
+
+const
+  MainRing = 701'u64
+  OtherRing = 702'u64
+  RecordCount = 128
+  UpdatedCount = 32
+
+proc require(condition: bool; message: string) =
+  if not condition:
+    raise newException(AssertionDefect, message)
+
+proc seedStore(store: Store) =
+  store.putRingMeta(MainRing, 60.0, 0.1)
+  store.putRingName(MainRing, "crash/main")
+  store.putRingMeta(OtherRing, 120.0, 0.2)
+  store.putRingName(OtherRing, "crash/other")
+  for i in 0'u32 ..< RecordCount.uint32:
+    store.upsert Particle(parent: MainRing, seq: i, period: 60.0,
+                          head: 0.1, tWrite: float(i + 1),
+                          payload: "base-" & $i)
+  for i in 0'u32 ..< 8'u32:
+    store.upsert Particle(parent: OtherRing, seq: i, period: 120.0,
+                          head: 0.2, tWrite: float(i + 1),
+                          payload: "other-" & $i)
+
+proc applyCandidateUpdate(store: Store) =
+  for i in 0'u32 ..< UpdatedCount.uint32:
+    store.upsert Particle(parent: MainRing, seq: i, period: 60.0,
+                          head: 0.1, tWrite: float(1000 + i.int),
+                          payload: "updated-" & $i)
+
+proc assertSourceState(store: Store; candidate = true) =
+  require(store.ringLiveCount(MainRing) == RecordCount,
+          "main ring live count changed")
+  require(store.ringLiveCount(OtherRing) == 8,
+          "unrelated ring live count changed")
+  for i in 0'u32 ..< RecordCount.uint32:
+    let expected =
+      if candidate and i < UpdatedCount.uint32: "updated-" & $i
+      else: "base-" & $i
+    require(store.getParticle(MainRing, i).payload == expected,
+            "main ring payload mismatch at " & $i)
+  for i in 0'u32 ..< 8'u32:
+    require(store.getParticle(OtherRing, i).payload == "other-" & $i,
+            "unrelated ring payload mismatch at " & $i)
+
+proc generationFor(store: Store; ring: uint64): uint64 =
+  for item in store.segmentReport().rings:
+    if item.ring == ring:
+      return item.generation
+  raise newException(AssertionDefect, "ring generation is missing: " & $ring)
+
+proc armCrashPoint(point, readyPath: string) =
+  putEnv("KOUTEN_TEST_CRASH_POINT", point)
+  putEnv("KOUTEN_TEST_CRASH_READY", readyPath)
+
+proc runWorker(root, point, readyPath: string) =
+  let dataDir = root / "data"
+  let checkpointRoot = root / "checkpoints"
+  let backupDir = root / "backup"
+  var store = openStore(dataDir, durability = durStrong, diskBacked = true)
+  store.seedStore()
+
+  if point.startsWith("segment-"):
+    discard store.packRingSegment(MainRing)
+    discard store.packRingSegment(OtherRing)
+    store.applyCandidateUpdate()
+    armCrashPoint(point, readyPath)
+    discard store.packRingSegment(MainRing)
+  elif point.startsWith("checkpoint-"):
+    discard store.createCheckpoint(checkpointRoot, "stable")
+    store.applyCandidateUpdate()
+    armCrashPoint(point, readyPath)
+    discard store.createCheckpoint(checkpointRoot, "candidate")
+  elif point.startsWith("backup-"):
+    discard store.backup(backupDir)
+    store.applyCandidateUpdate()
+    armCrashPoint(point, readyPath)
+    discard store.backup(backupDir)
+  else:
+    raise newException(ValueError, "unknown crash point: " & point)
+
+  store.close()
+  raise newException(AssertionDefect,
+    "worker returned without reaching crash point " & point)
+
+proc assertNoSegmentTemps(dataDir: string) =
+  let segmentDir = dataDir / "segments"
+  if not dirExists(segmentDir):
+    return
+  for path in walkFiles(segmentDir / "*.tmp"):
+    raise newException(AssertionDefect,
+      "segment temporary file survived recovery: " & path)
+
+proc verifySegmentCase(root, point: string) =
+  let dataDir = root / "data"
+  let expectedGeneration =
+    if point in ["segment-after-manifest", "segment-cleanup"]: 2'u64
+    else: 1'u64
+  var store = openStore(dataDir, durability = durStrong, diskBacked = true)
+  store.assertSourceState()
+  require(store.generationFor(MainRing) == expectedGeneration,
+          &"unexpected active generation after {point}")
+  require(store.generationFor(OtherRing) == 1'u64,
+          "unrelated ring generation changed")
+  let packed = store.packRingSegment(MainRing)
+  require(packed.records == RecordCount,
+          "recovery pack did not rewrite the complete main ring")
+  store.close()
+
+  var reopened = openStore(dataDir, durability = durStrong, diskBacked = true)
+  reopened.assertSourceState()
+  require(reopened.generationFor(MainRing) == expectedGeneration + 1,
+          "post-recovery generation did not advance exactly once")
+  require(reopened.segmentReport().walFallbacks == 0,
+          "post-recovery reads fell back to the WAL")
+  reopened.close()
+  assertNoSegmentTemps(dataDir)
+
+proc verifyCheckpointCase(root, point: string) =
+  let dataDir = root / "data"
+  let checkpointRoot = root / "checkpoints"
+  let candidateDir = checkpointRoot / "candidate"
+  let stagedDir = checkpointRoot / ".tmp-candidate"
+
+  var source = openStore(dataDir, durability = durStrong, diskBacked = true)
+  source.assertSourceState()
+  let listed = listCheckpoints(checkpointRoot)
+  if point == "checkpoint-before-publish":
+    require(not dirExists(candidateDir),
+            "unpublished checkpoint became visible")
+    require(dirExists(stagedDir), "checkpoint staging directory is missing")
+    require(checkpointStatus(stagedDir).verified,
+            "completed checkpoint staging generation is not verifiable")
+    require(listed.len == 1 and listed[0].id == "stable" and listed[0].verified,
+            "checkpoint listing exposed an unpublished generation")
+  else:
+    require(dirExists(candidateDir), "published checkpoint is missing")
+    require(not dirExists(stagedDir),
+            "published checkpoint left a staging directory")
+    require(listed.anyIt(it.id == "candidate" and it.verified),
+            "published checkpoint is not listed as verified")
+
+  let selected =
+    if point == "checkpoint-before-publish": checkpointRoot / "stable"
+    else: candidateDir
+  let restoredDir = root / "restored-selected"
+  discard restoreCheckpoint(selected, restoredDir)
+  var restored = openStore(restoredDir, durability = durStrong,
+                           diskBacked = true)
+  restored.assertSourceState(candidate = point != "checkpoint-before-publish")
+  restored.close()
+
+  let retry = source.createCheckpoint(checkpointRoot, "post-crash")
+  require(retry.verified, "checkpoint creation did not recover after SIGKILL")
+  let cleanup = cleanupCheckpoints(checkpointRoot, keep = 1)
+  require(cleanup.kept == 1, "checkpoint cleanup did not retain one generation")
+  source.close()
+
+proc verifyBackupCase(root, point: string) =
+  let dataDir = root / "data"
+  let backupDir = root / "backup"
+  let restoredDir = root / "restored-backup"
+  let expectCandidate = point == "backup-after-publish"
+  let status = verifyBackup(backupDir)
+  require(status.items == RecordCount + 8,
+          "backup item count changed across publication crash")
+  discard restoreBackup(backupDir, restoredDir, durability = durStrong)
+  var restored = openStore(restoredDir, durability = durStrong,
+                           diskBacked = true)
+  restored.assertSourceState(candidate = expectCandidate)
+  restored.close()
+
+  var source = openStore(dataDir, durability = durStrong, diskBacked = true)
+  source.assertSourceState()
+  discard source.backup(backupDir)
+  source.close()
+  require(not fileExists(backupDir / "kouten.log.tmp"),
+          "backup temporary file survived the recovery retry")
+
+proc runVerify(root, point: string) =
+  if point.startsWith("segment-"):
+    verifySegmentCase(root, point)
+  elif point.startsWith("checkpoint-"):
+    verifyCheckpointCase(root, point)
+  elif point.startsWith("backup-"):
+    verifyBackupCase(root, point)
+  else:
+    raise newException(ValueError, "unknown crash point: " & point)
+  echo &"process-crash-matrix OK point={point}"
+
+proc usage() =
+  quit("usage: process_crash_matrix --mode=worker|verify --root=DIR " &
+       "--point=NAME [--ready=FILE]", 2)
+
+proc main() =
+  var mode = ""
+  var root = ""
+  var point = ""
+  var readyPath = ""
+  for kind, key, value in getopt():
+    if kind != cmdLongOption:
+      continue
+    case key
+    of "mode": mode = value
+    of "root": root = value
+    of "point": point = value
+    of "ready": readyPath = value
+    else: usage()
+  if root.len == 0 or point.len == 0:
+    usage()
+  case mode
+  of "worker":
+    if readyPath.len == 0:
+      usage()
+    runWorker(root, point, readyPath)
+  of "verify":
+    runVerify(root, point)
+  else:
+    usage()
+
+when isMainModule:
+  main()

--- a/scripts/process_crash_matrix.sh
+++ b/scripts/process_crash_matrix.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/kouten-process-crash.XXXXXX")"
+BIN="$WORK_DIR/process-crash-matrix"
+PID=""
+
+cleanup() {
+  if [[ -n "$PID" ]] && kill -0 "$PID" 2>/dev/null; then
+    kill -KILL "$PID" 2>/dev/null || true
+    wait "$PID" 2>/dev/null || true
+  fi
+  rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+cd "$ROOT_DIR"
+nim c -d:release -d:koutenTestCrashPoints \
+  --nimcache:/tmp/nimcache_kouten_process_crash_matrix \
+  -o:"$BIN" examples/process_crash_matrix.nim >/dev/null
+
+points=(
+  segment-output
+  segment-after-data-publish
+  segment-before-manifest
+  segment-after-manifest
+  segment-cleanup
+  checkpoint-before-publish
+  checkpoint-after-publish
+  backup-before-publish
+  backup-after-publish
+)
+
+for point in "${points[@]}"; do
+  case_root="$WORK_DIR/case-$point"
+  ready="$WORK_DIR/ready-$point"
+  log="$WORK_DIR/worker-$point.log"
+  mkdir -p "$case_root"
+
+  "$BIN" --mode=worker --root="$case_root" --point="$point" \
+    --ready="$ready" >"$log" 2>&1 &
+  PID=$!
+
+  reached=0
+  for _ in $(seq 1 1000); do
+    if [[ -f "$ready" ]]; then
+      reached=1
+      break
+    fi
+    if ! kill -0 "$PID" 2>/dev/null; then
+      echo "[process-crash-matrix] worker exited before $point" >&2
+      cat "$log" >&2
+      exit 1
+    fi
+    sleep 0.01
+  done
+
+  if [[ "$reached" -ne 1 ]]; then
+    echo "[process-crash-matrix] timed out waiting for $point" >&2
+    cat "$log" >&2
+    exit 1
+  fi
+  if [[ "$(tr -d '\r\n' < "$ready")" != "$point" ]]; then
+    echo "[process-crash-matrix] readiness marker mismatch for $point" >&2
+    exit 1
+  fi
+
+  kill -KILL "$PID"
+  wait "$PID" 2>/dev/null || true
+  PID=""
+
+  "$BIN" --mode=verify --root="$case_root" --point="$point"
+done
+
+echo "[process-crash-matrix] all publication boundaries passed"

--- a/scripts/test_all_smoke.sh
+++ b/scripts/test_all_smoke.sh
@@ -6,6 +6,7 @@ cd "$ROOT"
 
 scripts/test_core.sh
 scripts/disk_backed_recovery_smoke.sh
+scripts/process_crash_matrix.sh
 scripts/auto_pack_server_smoke.sh
 scripts/checkpoint_smoke.sh
 scripts/cli_crud_smoke.sh

--- a/src/kouten/store.nim
+++ b/src/kouten/store.nim
@@ -376,6 +376,21 @@ when defined(koutenTestFailpoints):
   proc failCheckpointRestoreAfterPublishForTest*(enabled: bool) =
     checkpointRestoreFailAfterPublish = enabled
 
+when defined(koutenTestCrashPoints):
+  proc processCrashPoint(name: string) =
+    ## Test-only process boundary. The smoke runner waits for the marker and
+    ## sends SIGKILL, so recovery observes real process termination rather
+    ## than an exception unwinding open files and cleanup handlers.
+    if getEnv("KOUTEN_TEST_CRASH_POINT") != name:
+      return
+    let readyPath = getEnv("KOUTEN_TEST_CRASH_READY")
+    if readyPath.len == 0:
+      raise newException(IOError,
+        "KOUTEN_TEST_CRASH_READY is required for crash-point tests")
+    writeFile(readyPath, name & "\n")
+    while true:
+      sleep(1000)
+
 var dataDirRegistryLock: Lock
 var openDataDirs = initHashSet[string]()
 initLock(dataDirRegistryLock)
@@ -1469,6 +1484,8 @@ proc packRingSegment*(s: Store, ring: uint64; maxBytes = 0'i64;
       let segmentOffset = segment.getFilePos()
       segment.write(framed)
       index.write(indexLine)
+      when defined(koutenTestCrashPoints):
+        processCrashPoint("segment-output")
       offsets[k] = segmentOffset
       inc result.records
       result.bytes += framed.len.int64
@@ -1487,11 +1504,15 @@ proc packRingSegment*(s: Store, ring: uint64; maxBytes = 0'i64;
   index.close()
   if wal != nil: wal.close()
   replaceFileAtomic(tmpSegment, newSegment)
+  when defined(koutenTestCrashPoints):
+    processCrashPoint("segment-after-data-publish")
   when defined(koutenTestFailpoints):
     if s.segmentPackFailAfterSegmentReplace:
       raise newException(IOError,
         "test segment pack failure after segment replacement")
   replaceFileAtomic(tmpIndex, newIndex)
+  when defined(koutenTestCrashPoints):
+    processCrashPoint("segment-before-manifest")
   when defined(koutenTestFailpoints):
     if s.segmentPackFailBeforeManifest:
       raise newException(IOError, "test segment pack failure before manifest")
@@ -1499,6 +1520,8 @@ proc packRingSegment*(s: Store, ring: uint64; maxBytes = 0'i64;
   s.segmentGenerations[ring] = newGeneration
   try:
     s.writeSegmentManifest()
+    when defined(koutenTestCrashPoints):
+      processCrashPoint("segment-after-manifest")
   except CatchableError:
     s.segmentGenerations[ring] = oldGeneration
     raise
@@ -1517,6 +1540,8 @@ proc packRingSegment*(s: Store, ring: uint64; maxBytes = 0'i64;
          path.endsWith(".tmp")):
       removeFile(path)
       inc result.removedFiles
+      when defined(koutenTestCrashPoints):
+        processCrashPoint("segment-cleanup")
   syncDir(s.segmentDir)
 
 when defined(koutenTestFailpoints):
@@ -3094,7 +3119,11 @@ proc createCheckpoint*(s: Store; root = ""; id = ""):
       checkpointChecksum(stageDir / CheckpointManifestName) & "\n")
     discard validateCheckpointContents(stageDir)
     syncDir(stageDir)
+    when defined(koutenTestCrashPoints):
+      processCrashPoint("checkpoint-before-publish")
     moveDirAtomic(stageDir, finalDir)
+    when defined(koutenTestCrashPoints):
+      processCrashPoint("checkpoint-after-publish")
     syncDir(checkpointRoot)
     result = verifyCheckpoint(finalDir)
   except CatchableError:
@@ -3436,7 +3465,11 @@ proc backup*(s: Store, dstDir: string): StoreBackupStats =
   if s.persistent:
     s.flushMaybe(force = true)
   s.writeSnapshotFile(tmp)
+  when defined(koutenTestCrashPoints):
+    processCrashPoint("backup-before-publish")
   replaceFileAtomic(tmp, dst)
+  when defined(koutenTestCrashPoints):
+    processCrashPoint("backup-after-publish")
   syncDir(dstDir)
   result = s.snapshotStats(dst, s.logPath)
 


### PR DESCRIPTION
## Summary
- add compile-time-only process crash points for segment, checkpoint, and backup publication
- exercise nine exact boundaries with real SIGKILL and restart verification
- add the matrix to CI and document its guarantees and limits

## Verification
- scripts/process_crash_matrix.sh
- scripts/disk_backed_recovery_smoke.sh
- scripts/test_core.sh
- nimble check
- normal release compile contains no crash-point symbols or environment markers