### PR TITLE
Release KoutenDB v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## Unreleased
 
+## v0.12.0 - 2026-08-13
+
 ### Added
 
+- Added opt-in bounded automatic ring packing with ring, byte, elapsed-time,
+  maintenance-window, and stale-data limits plus shared plan/run/status APIs.
 - Added immutable generation checkpoints that seal a compact WAL and complete
   ring-local segment/index generations behind a checksummed manifest and
   completion marker.
@@ -12,6 +16,16 @@
   functions.
 - Added corruption, symlink, overlap, retention, empty-store, CLI, and C ABI
   checkpoint coverage.
+- Added Prometheus and OpenMetrics output for requests, persistence, segment
+  layout, maintenance, capacity guardrails, checkpoints, and fallback reasons.
+- Added stable maintenance and fallback reason codes without unbounded
+  ring-name or error-text metric labels.
+- Added accelerated churn, process-crash, concurrency/backpressure,
+  storage-failure, upgrade-fixture, container-security, and external-driver
+  validation matrices.
+- Added a final 72-hour three-node, disk-backed, strong-durability gate that
+  completed 4,213,187 mixed operations with zero client errors and exact
+  source-to-restored checkpoint equality.
 
 ### Fixed / Hardened
 
@@ -28,6 +42,15 @@
   reservations with cross-process file locks. Checkpoint restore holds a
   stable sibling guard across verification, directory publication, and
   rollback, so an active or concurrently opened target cannot be replaced.
+- WAL write and flush failures poison the affected Store handle, reject later
+  mutations, and cannot publish a failed record into in-memory state.
+- Torn final WAL records recover to the last checksummed boundary, while
+  derived segment, index, and manifest damage rebuilds from authoritative WAL.
+- Accepted sockets use bounded receive/send deadlines, connection admission is
+  observable, and oversized ring-list pages fail within a fixed limit.
+- Cluster Nim API writes persist ring names correctly across reopen.
+- Upgrade validation covers immutable v0.10.1 and v0.11.0 stores, legacy
+  segment layouts, current packing, checkpoints, restore, and JSONL migration.
 
 ## v0.11.0 - 2026-08-04
 

--- a/README.md
+++ b/README.md
@@ -53,17 +53,17 @@ through six indexed PostgreSQL queries and `236 us` through a PostgreSQL JSON
 aggregate query. The detailed workload, data shape, and reproduction helper are
 documented in [Benchmark Comparison](docs/benchmark-comparison.md).
 
-## Verified Persistent Cluster Operation
+## Verified 72-Hour Strong-Durability Cluster Operation
 
-KoutenDB v0.10.0 completed a **72-hour local three-node persistent cluster
-run** with **4,022,516 mixed client operations**, **zero client errors**, and
-successful offline verification of all three data directories after shutdown.
+KoutenDB v0.12.0 completed a **72-hour local three-node, disk-backed,
+strong-durability run** with **4,213,187 mixed operations** and **zero client
+errors**. After shutdown, all source stores and generation checkpoints passed
+verification, restored stores matched the source data exactly, and every
+cluster queue converged to zero.
 
-The run completed 969,281 each of PUTs, returned-ID GETs, projection queries,
-and bounded ring reads, plus 96,928 ring-scoped retrievals. Handoff, migration,
-and universe-sync error/queue counters remained zero, and retrieval did not fall
-back to a global cluster scan. See [72-Hour Soak Testing](docs/soak-testing.md)
-for the exact configuration and final counters.
+See [72-Hour Soak Testing](docs/soak-testing.md) for the full workload,
+operation counts, latency telemetry, recovery checks, and scope, or read the
+[v0.12.0 Release Notes](docs/github-release-v0.12.0.md) for the release summary.
 
 ## How Locality-First Retrieval Works
 
@@ -96,9 +96,10 @@ Typical NoSQL](docs/nosql-positioning.md) for the full model.
 - Concept: [docs/koutendb-concept.md](docs/koutendb-concept.md)
 - Detailed design: [docs/koutendb-design.md](docs/koutendb-design.md)
 - Feature status / roadmap: [docs/koutendb-status.md](docs/koutendb-status.md)
-- v0.12 implementation and validation roadmap: [docs/v0.12-roadmap.md](docs/v0.12-roadmap.md)
+- v0.12 implementation and validation record: [docs/v0.12-roadmap.md](docs/v0.12-roadmap.md)
 - Release checklist: [docs/release-checklist.md](docs/release-checklist.md)
-- GitHub release notes: [docs/github-release-v0.11.0.md](docs/github-release-v0.11.0.md)
+- v0.12.0 release notes: [docs/github-release-v0.12.0.md](docs/github-release-v0.12.0.md)
+- 72-hour strong-durability result: [docs/soak-testing.md](docs/soak-testing.md)
 - Driver / FFI roadmap: [docs/koutendb-driver-roadmap.md](docs/koutendb-driver-roadmap.md)
 - Driver installation guide: [docs/driver-installation.md](docs/driver-installation.md)
 - Exact vector retrieval: [docs/vector-backends.md](docs/vector-backends.md)
@@ -700,15 +701,16 @@ tests/                 unit and smoke tests
 
 ## Operational Scope
 
-KoutenDB v0.11.0 is a public pre-v1 release with persistent storage, recovery,
-transactions, topology controls, TLS-capable transport, a C ABI, published
-drivers, ring-local physical segments, operational verification, and documented
-local endurance and forced-crash recovery evidence.
+KoutenDB v0.12.0 is a public pre-v1 release with persistent storage, strong
+durability, recovery, transactions, topology controls, TLS-capable transport, a
+C ABI, published drivers, ring-local physical segments, bounded automatic
+maintenance, generation checkpoints, operational metrics, and documented
+crash, corruption, container, driver, and 72-hour endurance validation.
 
 It is designed for teams that can express a meaningful locality boundary and
 want to evaluate a smaller-working-set retrieval architecture. Multi-machine
-and multi-region endurance testing, strong-durability endurance testing, and
-broader external production reports remain active validation tracks. See
+and multi-region endurance testing and broader external production reports
+remain active validation tracks. See
 [Operational Trials](docs/operational-trials.md),
 [Soak Testing](docs/soak-testing.md), and
 [Feature Status](docs/koutendb-status.md) for the current evidence and roadmap.

--- a/docs/external-driver-validation.md
+++ b/docs/external-driver-validation.md
@@ -41,21 +41,19 @@ The PHP path uses a uniquely named temporary Docker image because the host does
 not need to enable PHP FFI globally. The cleanup trap removes that image and all
 matrix-owned temporary data. The matrix is intentionally outside normal CI.
 
-## Current Development Result
+## v0.12 Release Result
 
-The first v0.12 development run established that the core-side harness works
-and identified external-driver release blockers rather than hiding them:
+The clean v0.12 compatibility run on 2026-08-13 completed every driver-owned
+suite and every shared security/restart row:
 
 | Driver | Driver suite | Shared TLS/auth/restart matrix |
 |---|---|---|
-| Rust 0.1.5 | 5 of 6 tests passed. One stale test still expects a failed TLS connection to be deferred until the first operation; the current core fails during `connect`. | Passed every row. |
-| JavaScript/TypeScript 0.1.4 | Passed. | Passed every row, including CA verification and restart. |
-| PHP | Passed in the isolated PHP 8.3 FFI image. | Passed every row, including CA verification and restart. |
-| C++ 0.1.2 | Passed from a clean CMake build directory. | Passed every row, including CA verification and restart. |
-| Python 0.2.0 | 10 of 12 tests passed. The driver has not yet adopted the extended `FWD` response and current routed `BGET` behavior. | Rejection rows passed. Valid shared-secret requests returned `bad-request` before and after restart. |
+| Rust 0.1.6 | Passed 7 tests, including v0.12 persistence/maintenance/checkpoint coverage and eager-connect failure semantics. | Passed every row. |
+| JavaScript/TypeScript 0.1.5 | Passed 3 Node.js tests, including the v0.12 C ABI additions. | Passed every row, including CA verification and restart. |
+| PHP 0.1.3 source | Passed in the isolated PHP 8.3 FFI image, including the v0.12 C ABI additions. | Passed every row, including CA verification and restart. |
+| C++ 0.1.3 | Passed from a clean CMake build directory, including the v0.12 C ABI additions. | Passed every row, including CA verification and restart. |
+| Python 0.2.1 | Passed 12 tests after adopting owner-bearing `FWD` and routed multi-node `BGET`. | Passed every row, including shared-secret CRUD and restart. |
 
-These failures are not accepted as a completed release gate. The core keeps its
-current early connection failure, forwarding metadata, and routing behavior;
-the separately maintained Rust and Python drivers must update their contracts.
-The matrix should be rerun and this result replaced before the final v0.12
-endurance gate.
+Offline segment verification and persistent authentication-failure audit
+evidence also passed. This closes the external-driver compatibility gate for
+the v0.12 release.

--- a/docs/github-release-v0.12.0.md
+++ b/docs/github-release-v0.12.0.md
@@ -1,0 +1,88 @@
+# KoutenDB v0.12.0
+
+KoutenDB v0.12.0 strengthens persistent operation with bounded automatic
+maintenance, verified generation checkpoints, production-facing metrics, and a
+completed 72-hour strong-durability cluster run.
+
+## 72-Hour Release Gate Passed
+
+The v0.12 release candidate completed a local three-node, disk-backed,
+strong-durability run with:
+
+- **72 hours of continuous mixed operation**
+- **4,213,187 completed operations**
+- **zero client errors**
+- **164,053 committed and applied cluster transactions**
+- **zero pending transactions and zero queued handoff work at shutdown**
+- **zero global retrieval requests and zero segment-to-WAL fallbacks**
+- **successful offline verification of every source and restored store**
+- **exact source-to-restored JSONL equality on all three nodes**
+
+The workload covered writes, updates, deletes, historical backfills, point
+reads, projections, bounded ring reads, stellar reads, ring-scoped vector
+retrieval, metrics, automatic packing, checkpoint creation, restore, and queue
+convergence. See [Soak Testing](soak-testing.md) for the complete workload,
+counters, latency telemetry, and recovery evidence.
+
+## Bounded Automatic Maintenance
+
+v0.12 adds opt-in automatic ring packing with explicit limits for selected
+rings, rewritten bytes, elapsed time, maintenance windows, and stale-data
+thresholds. Operators can inspect the same decision model through plan, run,
+status, dry-run, CLI, Nim API, and C ABI paths.
+
+Maintenance remains bounded and observable. Stable reason codes explain why a
+ring was selected, skipped, interrupted, or served through WAL fallback.
+
+## Verified Generation Checkpoints
+
+Generation checkpoints now seal a compact WAL and complete ring-local
+segment/index generations behind checksums and a completion marker. KoutenDB
+can create, inspect, verify, retain, clean up, and restore selected generations
+through Nim, CLI, and additive C ABI v2 functions.
+
+Restore verifies a staged generation before publication and protects an
+existing target with atomic replacement and rollback behavior. Invalid
+generations are preserved for diagnosis, and retention never removes the final
+verified generation.
+
+## Operational Metrics
+
+Prometheus and OpenMetrics output now covers request/error counters, WAL and
+segment layout, automatic maintenance, capacity guardrails, checkpoint health,
+and bounded fallback reasons. Metric labels avoid ring names, checkpoint IDs,
+and arbitrary error text to prevent unbounded cardinality.
+
+## Reliability Validation
+
+The v0.12 cycle added or completed:
+
+- a 120,000-operation accelerated churn matrix;
+- nine process-level `SIGKILL` publication failpoints;
+- concurrent readers, writers, metrics, maintenance, and backpressure tests;
+- deterministic WAL, disk-full, permission, segment, manifest, and index
+  failure injection;
+- immutable v0.10.1 and v0.11.0 upgrade fixtures plus JSONL migration checks;
+- Docker persistence, network interruption, TLS, authentication,
+  authorization, credential rotation, and audit validation;
+- a clean Rust, JavaScript/TypeScript, PHP, C++, and Python driver matrix;
+- the final 72-hour strong-durability endurance and exact restore gate.
+
+## Compatibility
+
+The WAL remains authoritative. Existing stores continue through the tested
+upgrade path, including legacy generation-zero segments. JSONL dump/import
+remains the stable pre-v1 logical migration boundary when a portable rebuild is
+preferred.
+
+## Verification
+
+The release is backed by the core and smoke suites plus the manual validation
+matrices documented in the [v0.12 roadmap](v0.12-roadmap.md). The 72-hour run is
+kept outside CI so normal pull-request checks remain deterministic.
+
+## Scope Note
+
+The endurance result covers the documented local Ubuntu environment. It does
+not claim multi-machine, multi-region, or workload-independent SLA
+certification.

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,9 +22,9 @@ downstream AI/RAG or application logic.
 - [Use Case Recipes](use-case-recipes.md)
 - [Technical FAQ](technical-faq.md)
 - [Feature Status / Roadmap](koutendb-status.md)
-- [v0.12 Implementation And Validation Roadmap](v0.12-roadmap.md)
+- [v0.12 Implementation And Validation Record](v0.12-roadmap.md)
 - [Operational Trials](operational-trials.md)
-- [Soak Testing](soak-testing.md)
+- [72-Hour Strong-Durability Soak Result](soak-testing.md)
 - [Accelerated Churn Testing](accelerated-churn-testing.md)
 - [Benchmark Notes](koutendb-bench.md)
 - [Benchmark Comparison Tables](benchmark-comparison.md)
@@ -62,5 +62,6 @@ downstream AI/RAG or application logic.
 ## Release
 
 - [Release Checklist](release-checklist.md)
+- [v0.12.0 Release Notes](github-release-v0.12.0.md)
 - [v0.11.0 Release Notes](github-release-v0.11.0.md)
 - [Historical v0.10 Roadmap](v0.10-roadmap.md)

--- a/docs/koutendb-status.md
+++ b/docs/koutendb-status.md
@@ -5,9 +5,9 @@ references and may lag behind this file.
 
 Release checklist: [release-checklist.md](./release-checklist.md)
 
-Current release evidence: [v0.11.0 release notes](./github-release-v0.11.0.md)
+Current release evidence: [v0.12.0 release notes](./github-release-v0.12.0.md)
 
-Current next-release planning: [v0.12 roadmap](./v0.12-roadmap.md)
+Current persistence-cycle record: [v0.12 implementation and validation](./v0.12-roadmap.md)
 
 Historical planning reference: [v0.10 roadmap](./v0.10-roadmap.md)
 

--- a/docs/soak-testing.md
+++ b/docs/soak-testing.md
@@ -103,6 +103,80 @@ progress file supplies the corresponding RSS and physical data-size samples.
 The work directory must be empty. This prevents an earlier run from changing
 the storage state or final verification result.
 
+## v0.12.0 Strong-Durability Endurance Result
+
+The v0.12.0 release candidate completed a 72-hour local three-node,
+disk-backed, strong-durability run from 2026-08-10 through 2026-08-13. The
+runner used isolated binaries built from commit
+`e88930994d58ac73562604b042225a628c03e882` for the entire run.
+
+The workload kept bounded automatic packing enabled while continuously mixing
+ordinary writes, historical backfills, updates, deletes, point reads,
+projections, bounded ring reads, stellar reads, ring-scoped vector retrieval,
+metrics collection, and cluster transactions.
+
+### Final Counters
+
+| Operation | Completed |
+|---|---:|
+| PUT | 925,088 |
+| historical backfill | 25,002 |
+| update | 132,155 |
+| delete | 31,899 |
+| returned-ID GET | 925,088 |
+| projection query | 925,088 |
+| bounded ring read | 925,088 |
+| stellar read | 185,017 |
+| ring-scoped retrieve | 92,508 |
+| metrics read | 46,254 |
+| **total mixed operations** | **4,213,187** |
+| **client errors** | **0** |
+
+The cluster also committed and applied 164,053 transactions with zero pending
+transactions at shutdown. Retrieval remained ring-scoped: every node reported
+zero global retrieval requests and zero segment-to-WAL fallbacks.
+
+### Recovery And Convergence
+
+The three nodes recorded 258,791 handoff attempts. Eight transient handoff
+attempts failed during the 72 hours, but they left no pending work: handoff
+pending, queue depth, work depth, stale acknowledgements, and queue-full events
+were all zero at the convergence barrier. The barrier completed immediately
+after the workload (`quiescedAfterSec=0`).
+
+After shutdown:
+
+- all three source stores passed segment-aware offline verification;
+- all three generation checkpoints passed checksum and completeness
+  verification;
+- every checkpoint restored into a fresh data directory;
+- all three restored stores passed offline verification;
+- exact sorted JSONL comparisons between source and restored stores passed;
+- source and restored line counts matched at 341,465, 130,272, and 446,497;
+- the restored compact layouts reported no fragmented rings and a locality
+  score of `1.0` on every node.
+
+The verified live dataset contained 918,199 records across the three nodes.
+
+### Final Rolling Latency Window
+
+The final p50/p95/p99 values below are milliseconds over the latest 4,096
+samples for each operation:
+
+| Operation | p50 | p95 | p99 |
+|---|---:|---:|---:|
+| PUT | 2.650 | 34.720 | 45.650 |
+| returned-ID GET | 0.160 | 36.145 | 69.311 |
+| projection query | 0.125 | 0.176 | 3.240 |
+| bounded ring read | 3.113 | 39.214 | 49.338 |
+| stellar read | 11.000 | 48.289 | 104.076 |
+| ring-scoped retrieve | 293.023 | 350.789 | 471.368 |
+
+This result demonstrates sustained operation, strong-durability persistence,
+bounded maintenance, queue convergence, and exact checkpoint recovery on the
+tested Ubuntu host. It is not a multi-machine, multi-region, or SLA
+certification; those remain separate deployment validation tracks.
+
 ## v0.12 Final Gate Preflight
 
 The release-candidate harness completed a 45-second local preflight on

--- a/docs/v0.12-roadmap.md
+++ b/docs/v0.12-roadmap.md
@@ -1,8 +1,8 @@
-# KoutenDB v0.12 Roadmap
+# KoutenDB v0.12 Implementation And Validation Record
 
-This document records the current implementation and validation candidates for
-the next KoutenDB development cycle. It is a planning document, not a promise
-that every candidate will ship in v0.12.
+This document records the implementation and validation completed for the
+KoutenDB v0.12 development cycle, followed by explicitly separate follow-on
+candidates.
 
 ## Theme
 
@@ -16,7 +16,7 @@ The primary direction is:
 > validate the complete path once instead of repeating long endurance runs
 > after every intermediate change.
 
-## Primary v0.12 Candidates
+## Delivered In v0.12
 
 ### 1. Bounded Automatic Ring Packing (Implemented)
 
@@ -322,8 +322,7 @@ matrix and local result.
 
 ### 8. External Driver Compatibility
 
-**Status: core-side matrix implemented; external fixes and a clean rerun are
-still required.**
+**Status: implemented and clean across all five external drivers.**
 
 `scripts/external_driver_matrix.sh` runs the separately maintained Rust,
 JavaScript/TypeScript, PHP, C++, and Python driver suites and applies the same
@@ -331,25 +330,19 @@ strong disk-backed TLS, authentication, restart, and failure matrix to all five.
 Driver release work remains in each external repository, while the core
 provides the compatibility target.
 
-The first run passed the JavaScript/TypeScript, PHP, and C++ suites and their
-shared security rows. Rust passed the shared rows but has one stale lazy-connect
-test expectation. Python needs the extended forwarding/routing contract and
-shared-secret request path updated. See
-[`external-driver-validation.md`](./external-driver-validation.md). The final
-driver gate remains open until those external changes land and the whole matrix
-passes.
+The 2026-08-13 clean run passed the Rust, JavaScript/TypeScript, PHP, C++, and
+Python suites plus verified TLS/auth CRUD, rejection cases, persistent restart,
+offline segment verification, and audit-evidence checks. Rust follows eager
+connection failure semantics, and Python follows owner-bearing `FWD` responses
+and routed multi-node `BGET`. See
+[`external-driver-validation.md`](./external-driver-validation.md).
 
 ### 9. Final 72-Hour Endurance Gate
 
-**Status: release-candidate harness implemented and short preflight passed;
-final 72-hour run pending.**
+**Status: completed successfully for the v0.12 release.**
 
-The next 72-hour run should start only after the v0.12 storage and maintenance
-behavior is feature-frozen. It should include the bounded maintenance scheduler
-and checkpoint path so one run validates the complete release candidate.
-
-The final report should compare the start, 24-hour, 48-hour, and 72-hour points
-for:
+The final 72-hour run exercised the feature-frozen v0.12 storage and
+maintenance path. The report captured:
 
 - p50/p95/p99 point, ring, stellar, and retrieval latency;
 - memory and disk growth;
@@ -358,16 +351,20 @@ for:
 - cluster queues and errors;
 - final offline verification and restore equivalence.
 
-The 72-hour test remains a manual release gate and must not run in normal CI.
-
-The final harness now runs three strong-durability disk-backed nodes, bounded
+The harness ran three strong-durability disk-backed nodes, bounded
 automatic packing, update/delete/backfill churn, point/ring/stellar/retrieval
 reads, rolling latency percentiles, RSS/data-size sampling, and a queue
 convergence barrier. After shutdown it performs segment-aware verification,
 creates and verifies one generation checkpoint per node, restores each into a
 fresh directory, verifies the restored stores, and compares exact sorted JSONL
-dumps. A 45-second accelerated preflight completed this whole path on
-2026-08-09 with zero workload errors and zero segment-to-WAL fallbacks.
+dumps.
+
+The 2026-08-10 through 2026-08-13 run completed 4,213,187 mixed operations
+with zero client errors. All queues converged to zero, all source and restored
+stores passed offline verification, and every restored sorted JSONL dump was
+byte-for-byte equal to its source. Full counters and conditions are recorded in
+[`soak-testing.md`](./soak-testing.md). The 72-hour test remains a manual
+release gate and does not run in normal CI.
 
 ## Recommended Order
 
@@ -381,7 +378,7 @@ dumps. A 45-second accelerated preflight completed this whole path on
 
 ## Exit Criteria
 
-v0.12 should be considered ready when:
+The v0.12 release met these exit criteria:
 
 - maintenance work is opt-in, bounded, observable, and restart-safe;
 - pack/checkpoint interruption cannot replace a complete generation with an

--- a/koutendb.nimble
+++ b/koutendb.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version     = "0.11.0"
+version     = "0.12.0"
 author      = "puffball1567"
 description = "KoutenDB: ring-oriented NoSQL document/vector store for smaller working sets"
 license     = "Apache-2.0"


### PR DESCRIPTION
## Summary
- prepare KoutenDB v0.12.0 release metadata and documentation
- publish the 72-hour three-node strong-durability validation result: 4,213,187 mixed operations, zero client errors, and exact restored JSONL equality
- document bounded automatic maintenance, generation checkpoints, Prometheus/OpenMetrics, reliability matrices, and current external-driver validation
- keep README claims concise while linking detailed evidence separately

## Verification
- nimble check
- scripts/test_all_smoke.sh component suites
- scripts/cluster_tls_smoke.sh
- scripts/recovery_smoke.sh
- scripts/universe_sync_failure_smoke.sh
- scripts/universe_sync_remote_smoke.sh
- scripts/demo_smoke.sh
- scripts/compose_config_smoke.sh
- 72-hour local three-node strong-durability soak and exact restore comparison