### PR TITLE
release: prepare v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+## v0.12.1 - 2026-08-15
+
+### Changed
+
+- Updated the documented Rust, JavaScript/TypeScript, Python, PHP, and C++
+  driver versions to match their current public package or GitHub releases.
+- Distinguished published external drivers from the Go, Swift, C#, Kotlin,
+  Node TCP, and Bun foundations that currently exist only in the core
+  repository.
+- Replaced the misleading Go package installation hint with the supported
+  local `go.mod replace` workflow.
+- Synchronized driver release status across the README, installation guide,
+  roadmap, CLI discovery output, canonical status page, and translations.
+
 ## v0.12.0 - 2026-08-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Typical NoSQL](docs/nosql-positioning.md) for the full model.
 - Feature status / roadmap: [docs/koutendb-status.md](docs/koutendb-status.md)
 - v0.12 implementation and validation record: [docs/v0.12-roadmap.md](docs/v0.12-roadmap.md)
 - Release checklist: [docs/release-checklist.md](docs/release-checklist.md)
+- v0.12.1 release notes: [docs/github-release-v0.12.1.md](docs/github-release-v0.12.1.md)
 - v0.12.0 release notes: [docs/github-release-v0.12.0.md](docs/github-release-v0.12.0.md)
 - 72-hour strong-durability result: [docs/soak-testing.md](docs/soak-testing.md)
 - Driver / FFI roadmap: [docs/koutendb-driver-roadmap.md](docs/koutendb-driver-roadmap.md)

--- a/docs/github-release-v0.12.1.md
+++ b/docs/github-release-v0.12.1.md
@@ -1,0 +1,33 @@
+# KoutenDB v0.12.1
+
+KoutenDB v0.12.1 aligns the core documentation and driver discovery output
+with the current external driver releases.
+
+## Published Drivers
+
+- Rust: [`koutendb` 0.1.6 on crates.io](https://crates.io/crates/koutendb)
+- JavaScript / TypeScript: [`koutendb` 0.1.5 on npm](https://www.npmjs.com/package/koutendb)
+- Python: [`koutendb` 0.2.1 on PyPI](https://pypi.org/project/koutendb/)
+- PHP: [`koutendb/koutendb` 0.1.3 on Packagist](https://packagist.org/packages/koutendb/koutendb)
+- C++: [`koutendb-cpp` 0.1.3 on GitHub](https://github.com/puffball1567/koutendb-cpp/releases/tag/v0.1.3)
+
+## Publication Status Clarified
+
+Go, Swift, C#, and Kotlin wrappers remain in-tree foundations. They have not
+been published as Go, SwiftPM, NuGet, or Maven packages. The in-tree Node TCP
+and Bun paths are also distinguished from the published JavaScript Node-API
+driver.
+
+The CLI no longer suggests a remote `go get` command for the unpublished Go
+module. It now points users to the repository-local `go.mod replace` workflow.
+
+## Verification
+
+- current package versions were checked against crates.io, npm, PyPI,
+  Packagist, and GitHub Releases;
+- the release-mode CLI build passed;
+- the Go driver discovery output was checked;
+- the full GitHub CI matrix passed on the documentation update PR, including
+  core, C ABI, TLS, cluster, recovery, Universe, Linux, and macOS checks.
+
+This patch does not change the wire protocol, storage format, or C ABI.

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,6 +62,7 @@ downstream AI/RAG or application logic.
 ## Release
 
 - [Release Checklist](release-checklist.md)
+- [v0.12.1 Release Notes](github-release-v0.12.1.md)
 - [v0.12.0 Release Notes](github-release-v0.12.0.md)
 - [v0.11.0 Release Notes](github-release-v0.11.0.md)
 - [Historical v0.10 Roadmap](v0.10-roadmap.md)

--- a/docs/koutendb-status.md
+++ b/docs/koutendb-status.md
@@ -5,7 +5,7 @@ references and may lag behind this file.
 
 Release checklist: [release-checklist.md](./release-checklist.md)
 
-Current release evidence: [v0.12.0 release notes](./github-release-v0.12.0.md)
+Current release evidence: [v0.12.1 release notes](./github-release-v0.12.1.md)
 
 Current persistence-cycle record: [v0.12 implementation and validation](./v0.12-roadmap.md)
 

--- a/koutendb.nimble
+++ b/koutendb.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version     = "0.12.0"
+version     = "0.12.1"
 author      = "puffball1567"
 description = "KoutenDB: ring-oriented NoSQL document/vector store for smaller working sets"
 license     = "Apache-2.0"


### PR DESCRIPTION
## Summary

- bump the core package version to 0.12.1
- add the v0.12.1 changelog and release notes
- expose the latest release notes from the README and documentation index
- publish the corrected external driver versions and distinguish unpublished in-tree drivers

## Verification

- all five CI jobs passed on PR #102 for the functional documentation and CLI metadata changes
- git diff --check passed
- nimble check reported the package as valid; only the sandboxed user-cache write was unavailable

This patch does not change the wire protocol, storage format, or C ABI.