### PR TITLE
KoutenDB v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+## v0.12.1 - 2026-08-15
+
+### Changed
+
+- Updated the documented Rust, JavaScript/TypeScript, Python, PHP, and C++
+  driver versions to match their current public package or GitHub releases.
+- Distinguished published external drivers from the Go, Swift, C#, Kotlin,
+  Node TCP, and Bun foundations that currently exist only in the core
+  repository.
+- Replaced the misleading Go package installation hint with the supported
+  local `go.mod replace` workflow.
+- Synchronized driver release status across the README, installation guide,
+  roadmap, CLI discovery output, canonical status page, and translations.
+
 ## v0.12.0 - 2026-08-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Typical NoSQL](docs/nosql-positioning.md) for the full model.
 - Feature status / roadmap: [docs/koutendb-status.md](docs/koutendb-status.md)
 - v0.12 implementation and validation record: [docs/v0.12-roadmap.md](docs/v0.12-roadmap.md)
 - Release checklist: [docs/release-checklist.md](docs/release-checklist.md)
+- v0.12.1 release notes: [docs/github-release-v0.12.1.md](docs/github-release-v0.12.1.md)
 - v0.12.0 release notes: [docs/github-release-v0.12.0.md](docs/github-release-v0.12.0.md)
 - 72-hour strong-durability result: [docs/soak-testing.md](docs/soak-testing.md)
 - Driver / FFI roadmap: [docs/koutendb-driver-roadmap.md](docs/koutendb-driver-roadmap.md)

--- a/README.md
+++ b/README.md
@@ -279,26 +279,26 @@ Published external drivers:
 
 | Language / runtime | Package | Version | Repository | Mode |
 |---|---|---:|---|---|
-| Rust | [`koutendb`](https://crates.io/crates/koutendb) | `0.1.5` | [`puffball1567/koutendb-rust`](https://github.com/puffball1567/koutendb-rust) | C ABI wrapper |
-| JavaScript / TypeScript | [`koutendb`](https://www.npmjs.com/package/koutendb) | `0.1.3` | [`puffball1567/koutendb-js`](https://github.com/puffball1567/koutendb-js) | Node-API C ABI wrapper |
-| PHP | [`koutendb/koutendb`](https://packagist.org/packages/koutendb/koutendb) | `0.1.2` | [`puffball1567/koutendb-php`](https://github.com/puffball1567/koutendb-php) | FFI / C ABI wrapper |
-| C++ | GitHub / CMake source package | `0.1.1` | [`puffball1567/koutendb-cpp`](https://github.com/puffball1567/koutendb-cpp) | C++17 C ABI wrapper |
-| Python | [`koutendb`](https://pypi.org/project/koutendb/) | `0.1.3` | [`puffball1567/koutendb-python`](https://github.com/puffball1567/koutendb-python) | Native TCP wire driver |
+| Rust | [`koutendb`](https://crates.io/crates/koutendb) | `0.1.6` | [`puffball1567/koutendb-rust`](https://github.com/puffball1567/koutendb-rust) | C ABI wrapper |
+| JavaScript / TypeScript | [`koutendb`](https://www.npmjs.com/package/koutendb) | `0.1.5` | [`puffball1567/koutendb-js`](https://github.com/puffball1567/koutendb-js) | Node-API C ABI wrapper |
+| PHP | [`koutendb/koutendb`](https://packagist.org/packages/koutendb/koutendb) | `0.1.3` | [`puffball1567/koutendb-php`](https://github.com/puffball1567/koutendb-php) | FFI / C ABI wrapper |
+| C++ | GitHub / CMake source package | `0.1.3` | [`puffball1567/koutendb-cpp`](https://github.com/puffball1567/koutendb-cpp) | C++17 C ABI wrapper |
+| Python | [`koutendb`](https://pypi.org/project/koutendb/) | `0.2.1` | [`puffball1567/koutendb-python`](https://github.com/puffball1567/koutendb-python) | Native TCP wire driver |
 
 The table below lists current core-repository driver foundations. Publication
 priority for remaining language packages is tracked in
 [docs/koutendb-driver-roadmap.md](docs/koutendb-driver-roadmap.md).
 
-| Language / runtime | Driver path | Current mode | Smoke status |
-|---|---|---|---|
-| Nim | `src/koutendb.nim` | Native embedded and cluster API | core tests |
-| C ABI | `include/koutendb.h` | Embedded / cluster foundation for bindings | contract smoke |
-| Node.js / TypeScript | `drivers/node` | Native TCP wire driver, ESM | `node --test` |
-| Bun | `drivers/node` | Node-compatible TCP wire driver | `bun test` |
-| Go | `drivers/go` | C ABI wrapper | `go test` |
-| Swift | `drivers/swift` | SwiftPM C ABI wrapper | Linux Docker smoke |
-| C# | `drivers/csharp` | Generic .NET C ABI wrapper | contract smoke |
-| Kotlin/JVM | `drivers/kotlin` | JNI / C ABI wrapper | Docker smoke |
+| Language / runtime | Driver path | Current mode | Distribution | Verification |
+|---|---|---|---|---|
+| Nim | `src/koutendb.nim` | Native embedded and cluster API | Published with the core Nimble package | core tests |
+| C ABI | `include/koutendb.h` | Embedded / cluster foundation for bindings | Shipped with the core source release | contract smoke |
+| Node.js / TypeScript | `drivers/node` | Native TCP wire driver, ESM | In-tree test foundation; the published Node-API driver is listed above | `node --test` |
+| Bun | `drivers/node` | Node-compatible TCP wire driver | In-tree experimental path; no separate Bun package | `bun test` |
+| Go | `drivers/go` | C ABI wrapper | **In-tree only; no Go module has been published** | `go test` |
+| Swift | `drivers/swift` | SwiftPM C ABI wrapper | **In-tree only; no SwiftPM package has been published** | Linux Docker smoke |
+| C# | `drivers/csharp` | Generic .NET C ABI wrapper | **In-tree only; no NuGet package has been published** | contract smoke |
+| Kotlin/JVM | `drivers/kotlin` | JNI / C ABI wrapper | **In-tree only; no Maven package has been published** | Docker smoke |
 
 Detailed setup notes are in
 [docs/driver-installation.md](docs/driver-installation.md). Nimble package

--- a/docs/driver-installation.md
+++ b/docs/driver-installation.md
@@ -118,9 +118,9 @@ working while newer wrappers may bind the additional symbols explicitly.
 
 The Python driver is released as a separate native TCP wire driver:
 
-- repository: [`puffball1567/koutendb-python` v0.1.3](https://github.com/puffball1567/koutendb-python)
+- repository: [`puffball1567/koutendb-python` v0.2.1](https://github.com/puffball1567/koutendb-python)
 - mode: pure Python TCP driver for `koutend`
-- PyPI: [`koutendb` v0.1.3](https://pypi.org/project/koutendb/)
+- PyPI: [`koutendb` v0.2.1](https://pypi.org/project/koutendb/)
 
 ```sh
 python3 -m pip install koutendb
@@ -143,7 +143,7 @@ db.close()
 The published JavaScript / TypeScript driver is a Node-API wrapper over the
 KoutenDB C ABI:
 
-- npm: [`koutendb` v0.1.3](https://www.npmjs.com/package/koutendb)
+- npm: [`koutendb` v0.1.5](https://www.npmjs.com/package/koutendb)
 - repository: [`puffball1567/koutendb-js`](https://github.com/puffball1567/koutendb-js)
 
 Install it in an application:
@@ -179,7 +179,7 @@ await db.close();
 
 The Rust driver is published as a C ABI wrapper:
 
-- crates.io: [`koutendb` v0.1.5](https://crates.io/crates/koutendb)
+- crates.io: [`koutendb` v0.1.6](https://crates.io/crates/koutendb)
 - repository: [`puffball1567/koutendb-rust`](https://github.com/puffball1567/koutendb-rust)
 
 Install it in a Rust project:
@@ -200,7 +200,8 @@ repository README for the full setup flow.
 
 ## Go
 
-The Go driver is a C ABI wrapper.
+The Go driver is a repository-local C ABI wrapper. It has not been published as
+a Go module or separate driver repository.
 
 ```sh
 scripts/build_capi.sh
@@ -219,7 +220,7 @@ replace github.com/koutendb/koutendb-go => ../drivers/go
 The PHP driver uses FFI over the C ABI. Local PHP must have `ext-ffi` enabled.
 It is published on Packagist:
 
-- Packagist: [`koutendb/koutendb` v0.1.2](https://packagist.org/packages/koutendb/koutendb)
+- Packagist: [`koutendb/koutendb` v0.1.3](https://packagist.org/packages/koutendb/koutendb)
 - repository: [`puffball1567/koutendb-php`](https://github.com/puffball1567/koutendb-php)
 - package name: `koutendb/koutendb`
 
@@ -297,7 +298,7 @@ separate from this generic OSS driver.
 
 The C++ driver is released as a separate C++17 wrapper over the C ABI:
 
-- repository: [`puffball1567/koutendb-cpp` v0.1.1](https://github.com/puffball1567/koutendb-cpp)
+- repository: [`puffball1567/koutendb-cpp` v0.1.3](https://github.com/puffball1567/koutendb-cpp)
 - mode: C++17 RAII wrapper over `libkoutendb.so`
 
 ```sh

--- a/docs/github-release-v0.12.1.md
+++ b/docs/github-release-v0.12.1.md
@@ -1,0 +1,33 @@
+# KoutenDB v0.12.1
+
+KoutenDB v0.12.1 aligns the core documentation and driver discovery output
+with the current external driver releases.
+
+## Published Drivers
+
+- Rust: [`koutendb` 0.1.6 on crates.io](https://crates.io/crates/koutendb)
+- JavaScript / TypeScript: [`koutendb` 0.1.5 on npm](https://www.npmjs.com/package/koutendb)
+- Python: [`koutendb` 0.2.1 on PyPI](https://pypi.org/project/koutendb/)
+- PHP: [`koutendb/koutendb` 0.1.3 on Packagist](https://packagist.org/packages/koutendb/koutendb)
+- C++: [`koutendb-cpp` 0.1.3 on GitHub](https://github.com/puffball1567/koutendb-cpp/releases/tag/v0.1.3)
+
+## Publication Status Clarified
+
+Go, Swift, C#, and Kotlin wrappers remain in-tree foundations. They have not
+been published as Go, SwiftPM, NuGet, or Maven packages. The in-tree Node TCP
+and Bun paths are also distinguished from the published JavaScript Node-API
+driver.
+
+The CLI no longer suggests a remote `go get` command for the unpublished Go
+module. It now points users to the repository-local `go.mod replace` workflow.
+
+## Verification
+
+- current package versions were checked against crates.io, npm, PyPI,
+  Packagist, and GitHub Releases;
+- the release-mode CLI build passed;
+- the Go driver discovery output was checked;
+- the full GitHub CI matrix passed on the documentation update PR, including
+  core, C ABI, TLS, cluster, recovery, Universe, Linux, and macOS checks.
+
+This patch does not change the wire protocol, storage format, or C ABI.

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,6 +62,7 @@ downstream AI/RAG or application logic.
 ## Release
 
 - [Release Checklist](release-checklist.md)
+- [v0.12.1 Release Notes](github-release-v0.12.1.md)
 - [v0.12.0 Release Notes](github-release-v0.12.0.md)
 - [v0.11.0 Release Notes](github-release-v0.11.0.md)
 - [Historical v0.10 Roadmap](v0.10-roadmap.md)

--- a/docs/koutendb-driver-roadmap.md
+++ b/docs/koutendb-driver-roadmap.md
@@ -39,15 +39,15 @@ and atlas access.
 
 | Priority | Target | Reason | Status |
 |---:|---|---|---|
-| 1 | Rust driver | High-performance infrastructure, gateway, and systems integration path | Published: crates.io [`koutendb` v0.1.5](https://crates.io/crates/koutendb), repository [`puffball1567/koutendb-rust`](https://github.com/puffball1567/koutendb-rust) |
-| 2 | JavaScript / TypeScript driver | Web API, SaaS, Studio, GUI, and local AI client entry point | Published: npm [`koutendb` v0.1.3](https://www.npmjs.com/package/koutendb), repository [`puffball1567/koutendb-js`](https://github.com/puffball1567/koutendb-js). Bun remains experimental on the same Node-API path |
-| 3 | PHP driver | Laravel and existing business web systems | Published: Packagist [`koutendb/koutendb` v0.1.2](https://packagist.org/packages/koutendb/koutendb), repository [`puffball1567/koutendb-php`](https://github.com/puffball1567/koutendb-php) |
-| 4 | C++ driver | Generic native and engine integration base. Unreal plugin stays separate | Repository released: [`puffball1567/koutendb-cpp` v0.1.1](https://github.com/puffball1567/koutendb-cpp); CMake smoke passes in CI |
-| 5 | Python native wire driver | AI/RAG and broad scripting entry point without making big-data positioning the first message | Published: PyPI [`koutendb` v0.1.3](https://pypi.org/project/koutendb/), repository [`puffball1567/koutendb-python`](https://github.com/puffball1567/koutendb-python) |
-| 6 | Swift driver | Apple local AI client, browser companion, and app state path | Minimal C ABI wrapper done. Docker smoke added |
-| 7 | Kotlin-first JVM driver | JVM backend and Android path, Java-compatible | Minimal JNI / C ABI wrapper done |
-| 8 | Go driver | Cloud backend and ops tooling; lower initial priority than Rust/Node/PHP for KoutenDB positioning | Minimal C ABI wrapper done. Native wire comes later |
-| 9 | C# driver | Generic .NET backend entry point. Unity official asset stays separate | Minimal C ABI wrapper done |
+| 1 | Rust driver | High-performance infrastructure, gateway, and systems integration path | Published: crates.io [`koutendb` v0.1.6](https://crates.io/crates/koutendb), repository [`puffball1567/koutendb-rust`](https://github.com/puffball1567/koutendb-rust) |
+| 2 | JavaScript / TypeScript driver | Web API, SaaS, Studio, GUI, and local AI client entry point | Published: npm [`koutendb` v0.1.5](https://www.npmjs.com/package/koutendb), repository [`puffball1567/koutendb-js`](https://github.com/puffball1567/koutendb-js). Bun remains experimental on the same Node-API path |
+| 3 | PHP driver | Laravel and existing business web systems | Published: Packagist [`koutendb/koutendb` v0.1.3](https://packagist.org/packages/koutendb/koutendb), repository [`puffball1567/koutendb-php`](https://github.com/puffball1567/koutendb-php) |
+| 4 | C++ driver | Generic native and engine integration base. Unreal plugin stays separate | Repository released: [`puffball1567/koutendb-cpp` v0.1.3](https://github.com/puffball1567/koutendb-cpp); CMake smoke passes in CI |
+| 5 | Python native wire driver | AI/RAG and broad scripting entry point without making big-data positioning the first message | Published: PyPI [`koutendb` v0.2.1](https://pypi.org/project/koutendb/), repository [`puffball1567/koutendb-python`](https://github.com/puffball1567/koutendb-python) |
+| 6 | Swift driver | Apple local AI client, browser companion, and app state path | In-tree C ABI wrapper only; not published to SwiftPM. Docker smoke added |
+| 7 | Kotlin-first JVM driver | JVM backend and Android path, Java-compatible | In-tree JNI / C ABI wrapper only; not published to Maven |
+| 8 | Go driver | Cloud backend and ops tooling; lower initial priority than Rust/Node/PHP for KoutenDB positioning | In-tree C ABI wrapper only; no Go module or external repository published. Native wire comes later |
+| 9 | C# driver | Generic .NET backend entry point. Unity official asset stays separate | In-tree C ABI wrapper only; not published to NuGet |
 | 10 | DB trust work | Crash recovery, compatibility suite, failure benchmarks, operational docs | Ongoing core work |
 
 ## Browser / Wasm Track

--- a/docs/koutendb-status.de.md
+++ b/docs/koutendb-status.de.md
@@ -58,12 +58,14 @@ Release checklist: [release-checklist.md](./release-checklist.md)
 |---|---|---|
 | Nim API | Done | Native public API |
 | C ABI | Done | ABI version / last error / put/get/retrieve/batch/atlas |
-| Python | Done | Native wire minimal |
-| Node.js / TypeScript / Bun | Partially published | npm `koutendb` v0.1.3. Bun remains experimental |
-| Rust | Published | crates.io `koutendb` v0.1.5; see the English canonical document for links |
-| Go | Done | C ABI wrapper minimal |
-| PHP / Swift / Kotlin | Done | Docker smoke available |
-| C# / C++ | Done | OSS generic wrappers; Unity / Unreal official assets are separate candidates |
+| Python | Published | PyPI `koutendb` v0.2.1; native TCP wire driver |
+| Node.js / TypeScript / Bun | Published | npm `koutendb` v0.1.5. Bun remains experimental |
+| Rust | Published | crates.io `koutendb` v0.1.6; see the English canonical document for links |
+| Go | In-tree only | Minimal C ABI wrapper; no Go module or external driver repository has been published |
+| PHP | Published | Packagist `koutendb/koutendb` v0.1.3; Docker smoke available |
+| Swift / Kotlin | In-tree only | Wrappers and Docker smoke exist; no SwiftPM or Maven package has been published |
+| C# | In-tree only | Generic wrapper exists; no NuGet package has been published. Unity official asset is separate |
+| C++ | GitHub Release | `koutendb-cpp` v0.1.3. Unreal official asset is separate |
 | React Native / WASM | Post-v0.1 candidate | Browser / local state boundary |
 | Driver discovery CLI | Done | `kouten driver list/info/install` prints official driver metadata and setup commands without executing remote scripts |
 | Package publishing | Partial | `nimble install koutendb`, `cargo add koutendb`, `npm install koutendb`, `composer require koutendb/koutendb`, and `python3 -m pip install koutendb` are available. Other registries remain future work |

--- a/docs/koutendb-status.fr.md
+++ b/docs/koutendb-status.fr.md
@@ -58,12 +58,14 @@ Release checklist: [release-checklist.md](./release-checklist.md)
 |---|---|---|
 | Nim API | Done | Native public API |
 | C ABI | Done | ABI version / last error / put/get/retrieve/batch/atlas |
-| Python | Done | Native wire minimal |
-| Node.js / TypeScript / Bun | Partially published | npm `koutendb` v0.1.3. Bun remains experimental |
-| Rust | Published | crates.io `koutendb` v0.1.5; see the English canonical document for links |
-| Go | Done | C ABI wrapper minimal |
-| PHP / Swift / Kotlin | Done | Docker smoke available |
-| C# / C++ | Done | OSS generic wrappers; Unity / Unreal official assets are separate candidates |
+| Python | Published | PyPI `koutendb` v0.2.1; native TCP wire driver |
+| Node.js / TypeScript / Bun | Published | npm `koutendb` v0.1.5. Bun remains experimental |
+| Rust | Published | crates.io `koutendb` v0.1.6; see the English canonical document for links |
+| Go | In-tree only | Minimal C ABI wrapper; no Go module or external driver repository has been published |
+| PHP | Published | Packagist `koutendb/koutendb` v0.1.3; Docker smoke available |
+| Swift / Kotlin | In-tree only | Wrappers and Docker smoke exist; no SwiftPM or Maven package has been published |
+| C# | In-tree only | Generic wrapper exists; no NuGet package has been published. Unity official asset is separate |
+| C++ | GitHub Release | `koutendb-cpp` v0.1.3. Unreal official asset is separate |
 | React Native / WASM | Post-v0.1 candidate | Browser / local state boundary |
 | Driver discovery CLI | Done | `kouten driver list/info/install` prints official driver metadata and setup commands without executing remote scripts |
 | Package publishing | Partial | `nimble install koutendb`, `cargo add koutendb`, `npm install koutendb`, `composer require koutendb/koutendb`, and `python3 -m pip install koutendb` are available. Other registries remain future work |

--- a/docs/koutendb-status.ja.md
+++ b/docs/koutendb-status.ja.md
@@ -57,12 +57,14 @@
 |---|---|---|
 | Nim API | 完了 | Native public API |
 | C ABI | 完了 | ABI version / last error / put/get/retrieve/batch/atlas |
-| Python | 完了 | Native wire minimal |
-| Node.js / TypeScript / Bun | 一部公開済み | npm `koutendb` v0.1.3。Bun は実験的 |
-| Rust | 公開済み | crates.io `koutendb` v0.1.5。詳細は英語正本を参照 |
-| Go | 完了 | C ABI wrapper minimal |
-| PHP / Swift / Kotlin | 完了 | Docker smoke あり |
-| C# / C++ | 完了 | OSS generic wrappers。Unity / Unreal 公式 asset は別候補 |
+| Python | 公開済み | PyPI `koutendb` v0.2.1。Native TCP wire driver |
+| Node.js / TypeScript / Bun | 公開済み | npm `koutendb` v0.1.5。Bun は実験的 |
+| Rust | 公開済み | crates.io `koutendb` v0.1.6。詳細は英語正本を参照 |
+| Go | リポジトリ内のみ | C ABI wrapper minimal。Go module と外部 driver repository は未公開 |
+| PHP | 公開済み | Packagist `koutendb/koutendb` v0.1.3。Docker smoke あり |
+| Swift / Kotlin | リポジトリ内のみ | wrapper と Docker smoke は実装済み。SwiftPM / Maven package は未公開 |
+| C# | リポジトリ内のみ | generic wrapper は実装済み。NuGet package は未公開。Unity 公式 asset は別候補 |
+| C++ | GitHub Release 公開済み | `koutendb-cpp` v0.1.3。Unreal 公式 asset は別候補 |
 | React Native / WASM | v0.1 後の候補 | Browser / local state boundary |
 | Driver discovery CLI | 完了 | `kouten driver list/info/install` が公式 driver metadata と setup command を表示。remote script は実行しない |
 | Package publishing | 一部完了 | `nimble install koutendb`, `cargo add koutendb`, `npm install koutendb`, `composer require koutendb/koutendb`, `python3 -m pip install koutendb` が利用可能。その他のレジストリは今後 |

--- a/docs/koutendb-status.ko.md
+++ b/docs/koutendb-status.ko.md
@@ -57,12 +57,14 @@ Release checklist: [release-checklist.md](./release-checklist.md)
 |---|---|---|
 | Nim API | Done | Native public API |
 | C ABI | Done | ABI version / last error / put/get/retrieve/batch/atlas |
-| Python | Done | Native wire minimal |
-| Node.js / TypeScript / Bun | Partially published | npm `koutendb` v0.1.3. Bun remains experimental |
-| Rust | Published | crates.io `koutendb` v0.1.5; see the English canonical document for links |
-| Go | Done | C ABI wrapper minimal |
-| PHP / Swift / Kotlin | Done | Docker smoke available |
-| C# / C++ | Done | OSS generic wrappers; Unity / Unreal official assets are separate candidates |
+| Python | Published | PyPI `koutendb` v0.2.1; native TCP wire driver |
+| Node.js / TypeScript / Bun | Published | npm `koutendb` v0.1.5. Bun remains experimental |
+| Rust | Published | crates.io `koutendb` v0.1.6; see the English canonical document for links |
+| Go | In-tree only | Minimal C ABI wrapper; no Go module or external driver repository has been published |
+| PHP | Published | Packagist `koutendb/koutendb` v0.1.3; Docker smoke available |
+| Swift / Kotlin | In-tree only | Wrappers and Docker smoke exist; no SwiftPM or Maven package has been published |
+| C# | In-tree only | Generic wrapper exists; no NuGet package has been published. Unity official asset is separate |
+| C++ | GitHub Release | `koutendb-cpp` v0.1.3. Unreal official asset is separate |
 | React Native / WASM | Post-v0.1 candidate | Browser / local state boundary |
 | Driver discovery CLI | Done | `kouten driver list/info/install` prints official driver metadata and setup commands without executing remote scripts |
 | Package publishing | Partial | `nimble install koutendb`, `cargo add koutendb`, `npm install koutendb`, `composer require koutendb/koutendb`, and `python3 -m pip install koutendb` are available. Other registries remain future work |

--- a/docs/koutendb-status.md
+++ b/docs/koutendb-status.md
@@ -91,16 +91,16 @@ Translations:
 |---|---|---|
 | Nim API | Done | Native public API |
 | C ABI | Done | ABI version / last error / put/get/retrieve/batch/atlas plus additive codec-aware put/get calls; C ABI vectors are host-native float arrays, while TCP wire vectors are canonical little-endian float32 |
-| JavaScript / TypeScript | Published | npm [`koutendb` v0.1.3](https://www.npmjs.com/package/koutendb); repository [`puffball1567/koutendb-js`](https://github.com/puffball1567/koutendb-js); Node-API C ABI wrapper with TypeScript API |
+| JavaScript / TypeScript | Published | npm [`koutendb` v0.1.5](https://www.npmjs.com/package/koutendb); repository [`puffball1567/koutendb-js`](https://github.com/puffball1567/koutendb-js); Node-API C ABI wrapper with TypeScript API |
 | Bun | Partial | The npm package uses Node-API and includes Bun compatibility verification, but Bun support remains experimental |
-| Rust | Published | crates.io [`koutendb` v0.1.5](https://crates.io/crates/koutendb); repository [`puffball1567/koutendb-rust`](https://github.com/puffball1567/koutendb-rust); C ABI wrapper |
-| Python | Published | PyPI [`koutendb` v0.1.3](https://pypi.org/project/koutendb/); repository [`puffball1567/koutendb-python`](https://github.com/puffball1567/koutendb-python); native TCP wire driver |
-| Go | Done | C ABI wrapper minimal |
-| PHP | Published | Packagist [`koutendb/koutendb` v0.1.2](https://packagist.org/packages/koutendb/koutendb); repository [`puffball1567/koutendb-php`](https://github.com/puffball1567/koutendb-php); FFI / C ABI wrapper with Docker smoke |
-| Swift | Done | SwiftPM C ABI wrapper with Linux Docker smoke |
-| C# minimal | Done | OSS generic C# wrapper. Unity official asset is separate |
-| C++ | Released | Repository [`puffball1567/koutendb-cpp` v0.1.1](https://github.com/puffball1567/koutendb-cpp); C++17 C ABI wrapper with CMake smoke; Unreal official plugin is separate |
-| Kotlin-first JVM | Done | JNI / C ABI wrapper with Docker smoke |
+| Rust | Published | crates.io [`koutendb` v0.1.6](https://crates.io/crates/koutendb); repository [`puffball1567/koutendb-rust`](https://github.com/puffball1567/koutendb-rust); C ABI wrapper |
+| Python | Published | PyPI [`koutendb` v0.2.1](https://pypi.org/project/koutendb/); repository [`puffball1567/koutendb-python`](https://github.com/puffball1567/koutendb-python); native TCP wire driver |
+| Go | In-tree only | Minimal C ABI wrapper; no Go module or external driver repository has been published |
+| PHP | Published | Packagist [`koutendb/koutendb` v0.1.3](https://packagist.org/packages/koutendb/koutendb); repository [`puffball1567/koutendb-php`](https://github.com/puffball1567/koutendb-php); FFI / C ABI wrapper with Docker smoke |
+| Swift | In-tree only | SwiftPM-compatible C ABI wrapper with Linux Docker smoke; no SwiftPM package has been published |
+| C# minimal | In-tree only | Generic C# wrapper; no NuGet package has been published. Unity official asset is separate |
+| C++ | Released | Repository [`puffball1567/koutendb-cpp` v0.1.3](https://github.com/puffball1567/koutendb-cpp); C++17 C ABI wrapper with CMake smoke; Unreal official plugin is separate |
+| Kotlin-first JVM | In-tree only | JNI / C ABI wrapper with Docker smoke; no Maven package has been published |
 | React Native / WASM local state | Post-v0.1 candidate | Browser / React Native state boundary; handled with the WASM line, not before Kotlin |
 | Driver discovery CLI | Done | `kouten driver list/info/install` prints official driver metadata and setup commands without executing remote scripts |
 | Driver compatibility test suite | Partial | `scripts/driver_compat.sh`; Docker-backed PHP / Swift / Kotlin are opt-in and verified |

--- a/docs/koutendb-status.md
+++ b/docs/koutendb-status.md
@@ -5,7 +5,7 @@ references and may lag behind this file.
 
 Release checklist: [release-checklist.md](./release-checklist.md)
 
-Current release evidence: [v0.12.0 release notes](./github-release-v0.12.0.md)
+Current release evidence: [v0.12.1 release notes](./github-release-v0.12.1.md)
 
 Current persistence-cycle record: [v0.12 implementation and validation](./v0.12-roadmap.md)
 

--- a/docs/koutendb-status.zh.md
+++ b/docs/koutendb-status.zh.md
@@ -57,12 +57,14 @@ Release checklist: [release-checklist.md](./release-checklist.md)
 |---|---|---|
 | Nim API | Done | Native public API |
 | C ABI | Done | ABI version / last error / put/get/retrieve/batch/atlas |
-| Python | Done | Native wire minimal |
-| Node.js / TypeScript / Bun | Partially published | npm `koutendb` v0.1.3. Bun remains experimental |
-| Rust | Published | crates.io `koutendb` v0.1.5; see the English canonical document for links |
-| Go | Done | C ABI wrapper minimal |
-| PHP / Swift / Kotlin | Done | Docker smoke available |
-| C# / C++ | Done | OSS generic wrappers; Unity / Unreal official assets are separate candidates |
+| Python | Published | PyPI `koutendb` v0.2.1; native TCP wire driver |
+| Node.js / TypeScript / Bun | Published | npm `koutendb` v0.1.5. Bun remains experimental |
+| Rust | Published | crates.io `koutendb` v0.1.6; see the English canonical document for links |
+| Go | In-tree only | Minimal C ABI wrapper; no Go module or external driver repository has been published |
+| PHP | Published | Packagist `koutendb/koutendb` v0.1.3; Docker smoke available |
+| Swift / Kotlin | In-tree only | Wrappers and Docker smoke exist; no SwiftPM or Maven package has been published |
+| C# | In-tree only | Generic wrapper exists; no NuGet package has been published. Unity official asset is separate |
+| C++ | GitHub Release | `koutendb-cpp` v0.1.3. Unreal official asset is separate |
 | React Native / WASM | Post-v0.1 candidate | Browser / local state boundary |
 | Driver discovery CLI | Done | `kouten driver list/info/install` prints official driver metadata and setup commands without executing remote scripts |
 | Package publishing | Partial | `nimble install koutendb`, `cargo add koutendb`, `npm install koutendb`, `composer require koutendb/koutendb`, and `python3 -m pip install koutendb` are available. Other registries remain future work |

--- a/koutendb.nimble
+++ b/koutendb.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version     = "0.12.0"
+version     = "0.12.1"
 author      = "puffball1567"
 description = "KoutenDB: ring-oriented NoSQL document/vector store for smaller working sets"
 license     = "Apache-2.0"

--- a/src/koutencli.nim
+++ b/src/koutencli.nim
@@ -40,7 +40,7 @@ proc driverRegistry(): seq[DriverInfo] =
       repository: "https://github.com/puffball1567/koutendb-rust",
       packageName: "koutendb",
       installHint: "cargo add koutendb",
-      notes: "Published on crates.io as koutendb v0.1.5. Wraps the KoutenDB C ABI."
+      notes: "Published on crates.io as koutendb v0.1.6. Wraps the KoutenDB C ABI."
     ),
     DriverInfo(
       name: "node",
@@ -49,7 +49,7 @@ proc driverRegistry(): seq[DriverInfo] =
       repository: "https://github.com/puffball1567/koutendb-js",
       packageName: "koutendb",
       installHint: "npm install koutendb",
-      notes: "Published on npm as koutendb v0.1.3. Bun compatibility is tested on the Node-API path, but remains experimental."
+      notes: "Published on npm as koutendb v0.1.5. Bun compatibility is tested on the Node-API path, but remains experimental."
     ),
     DriverInfo(
       name: "php",
@@ -58,7 +58,7 @@ proc driverRegistry(): seq[DriverInfo] =
       repository: "https://github.com/puffball1567/koutendb-php",
       packageName: "koutendb/koutendb",
       installHint: "composer require koutendb/koutendb",
-      notes: "Published on Packagist as koutendb/koutendb v0.1.2. Wraps the KoutenDB C ABI through PHP FFI."
+      notes: "Published on Packagist as koutendb/koutendb v0.1.3. Wraps the KoutenDB C ABI through PHP FFI."
     ),
     DriverInfo(
       name: "cpp",
@@ -67,7 +67,7 @@ proc driverRegistry(): seq[DriverInfo] =
       repository: "https://github.com/puffball1567/koutendb-cpp",
       packageName: "koutendb-cpp",
       installHint: "git clone https://github.com/puffball1567/koutendb-cpp.git",
-      notes: "Released as koutendb-cpp v0.1.1. CMake smoke passes in CI; Conan/vcpkg publication is future work."
+      notes: "Released as koutendb-cpp v0.1.3. CMake smoke passes in CI; Conan/vcpkg publication is future work."
     ),
     DriverInfo(
       name: "python",
@@ -76,16 +76,16 @@ proc driverRegistry(): seq[DriverInfo] =
       repository: "https://github.com/puffball1567/koutendb-python",
       packageName: "koutendb",
       installHint: "python3 -m pip install koutendb",
-      notes: "Published on PyPI as koutendb v0.1.3. Pure Python TCP driver."
+      notes: "Published on PyPI as koutendb v0.2.1. Pure Python TCP driver."
     ),
     DriverInfo(
       name: "go",
       status: "repository-local",
       mode: "C ABI wrapper",
       repository: "drivers/go",
-      packageName: "github.com/koutendb/koutendb-go",
-      installHint: "go get github.com/koutendb/koutendb-go",
-      notes: "Repository-local foundation. Package publication is future work."
+      packageName: "not published (local module path: github.com/koutendb/koutendb-go)",
+      installHint: "use drivers/go with a local go.mod replace directive",
+      notes: "In-tree foundation only. No Go module or external Go driver repository has been published."
     )
   ]
 


### PR DESCRIPTION
## KoutenDB v0.12.1

This patch aligns KoutenDB documentation and CLI driver discovery with the current external driver releases.

### Published driver versions

- Rust: crates.io 0.1.6
- JavaScript / TypeScript: npm 0.1.5
- Python: PyPI 0.2.1
- PHP: Packagist 0.1.3
- C++: GitHub Release 0.1.3

### Clarifications

- Go, Swift, C#, and Kotlin remain in-tree foundations and are explicitly marked as unpublished.
- The in-tree Node TCP and Bun paths are distinguished from the published JavaScript Node-API driver.
- The misleading remote Go installation command is replaced with the local go.mod replace workflow.

### Verification

- both devel-target PRs passed all five required CI jobs
- package metadata validates as KoutenDB 0.12.1
- no wire protocol, storage format, or C ABI changes