### PR TITLE
release: prepare v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 ## Unreleased
 
+## v0.13.0 - 2026-08-21
+
+### Added
+
+- Added a configurable durable standby for the cluster transaction
+  coordinator. A committed multi-owner transaction is acknowledged only after
+  its complete intent reaches the configured primary and standby durability
+  boundaries.
+- Added persistent coordinator epochs, primary/standby assignments,
+  epoch-encoded transaction IDs, mirror markers, and completion markers that
+  survive WAL replay and compaction.
+- Added explicit majority-gated coordinator promotion through the Nim API and
+  `kouten coordinator-promote`, plus coordinator discovery and status commands.
+- Added coordinator role, assignment, replica-health, mirror success/failure,
+  and pending-intent metrics.
+- Added a three-node strong-durability failure matrix covering process
+  termination, SIGKILL, standby outages, primary loss, replay, promotion,
+  transaction identity collisions, and stale-primary return.
+
+### Changed
+
+- Cluster transaction clients now discover the highest non-conflicting
+  coordinator epoch from reachable peers instead of assuming node zero.
+- Promoted coordinators re-replicate pending intent to the newly assigned
+  standby before resuming owner application.
+- Coordinator changes require an explicit maintenance drain, a reachable
+  majority, and reachable assigned primary and standby. Ordinary ring-local
+  reads and writes do not gain a quorum round trip.
+
+### Fixed / Hardened
+
+- Fenced mirror and apply operations reject stale coordinator epochs and
+  conflicting assignments after failover.
+- Duplicate intent, mirror, completion, and retry operations are idempotent,
+  while transaction-ID reuse with changed content fails closed.
+- Orphan cluster-transaction WAL operation and commit records now fail closed
+  during replay instead of producing an incomplete intent.
+- A failed standby mirror or completion acknowledgement leaves the primary
+  intent pending and recoverable instead of reporting an unsafe success.
+
 ## v0.12.1 - 2026-08-15
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ Typical NoSQL](docs/nosql-positioning.md) for the full model.
 - Detailed design: [docs/koutendb-design.md](docs/koutendb-design.md)
 - Feature status / roadmap: [docs/koutendb-status.md](docs/koutendb-status.md)
 - v0.12 implementation and validation record: [docs/v0.12-roadmap.md](docs/v0.12-roadmap.md)
+- Coordinator failover: [docs/coordinator-failover.md](docs/coordinator-failover.md)
 - Release checklist: [docs/release-checklist.md](docs/release-checklist.md)
+- v0.13.0 release notes: [docs/github-release-v0.13.0.md](docs/github-release-v0.13.0.md)
 - v0.12.1 release notes: [docs/github-release-v0.12.1.md](docs/github-release-v0.12.1.md)
 - v0.12.0 release notes: [docs/github-release-v0.12.0.md](docs/github-release-v0.12.0.md)
 - 72-hour strong-durability result: [docs/soak-testing.md](docs/soak-testing.md)
@@ -702,11 +704,12 @@ tests/                 unit and smoke tests
 
 ## Operational Scope
 
-KoutenDB v0.12.0 is a public pre-v1 release with persistent storage, strong
+KoutenDB v0.13.0 is a public pre-v1 release with persistent storage, strong
 durability, recovery, transactions, topology controls, TLS-capable transport, a
 C ABI, published drivers, ring-local physical segments, bounded automatic
-maintenance, generation checkpoints, operational metrics, and documented
-crash, corruption, container, driver, and 72-hour endurance validation.
+maintenance, generation checkpoints, operational metrics, recoverable cluster
+transaction coordinator failover, and documented crash, corruption, container,
+driver, and 72-hour endurance validation.
 
 It is designed for teams that can express a meaningful locality boundary and
 want to evaluate a smaller-working-set retrieval architecture. Multi-machine

--- a/docs/github-release-v0.13.0.md
+++ b/docs/github-release-v0.13.0.md
@@ -1,0 +1,59 @@
+# KoutenDB v0.13.0
+
+KoutenDB v0.13.0 removes the cluster transaction landing node as a single
+point of failure. Committed multi-owner transaction intent can now be mirrored
+to a durable standby and recovered through an explicit, epoch-fenced
+promotion, without adding consensus traffic to ordinary ring-local reads and
+writes.
+
+## Coordinator Recovery
+
+- persisted coordinator epoch, primary, and standby assignment;
+- epoch-encoded transaction IDs with a persistent local sequence;
+- durable intent mirroring before commit acknowledgement;
+- explicit majority-gated standby promotion through the Nim API and CLI;
+- client discovery of the highest non-conflicting visible coordinator epoch;
+- re-replication of pending intent before a promoted coordinator resumes;
+- fenced mirror and owner-apply operations that reject a stale primary;
+- coordinator role, replica-health, mirror, and pending-intent metrics.
+
+The compatibility setting `coordinatorReplica: -1` retains the legacy
+single-coordinator mode. To enable recoverable coordination, configure the same
+positive `coordinatorEpoch`, `coordinatorNode`, and distinct
+`coordinatorReplica` on every peer. Strong durability is recommended for the
+coordinator pair.
+
+## Failure Validation
+
+The new three-node strong-durability matrix verifies:
+
+- commit refusal while the standby is unavailable, under termination and
+  SIGKILL;
+- exact retry after standby recovery without duplicate visible data;
+- mirror and completion replay idempotency;
+- fail-closed transaction identity collision handling;
+- pending-intent survival across primary and standby WAL restart;
+- promotion refusal without drain, quorum, or the assigned standby;
+- explicit standby promotion after primary loss;
+- pending-intent re-replication and exact final convergence;
+- stale-primary rejection after a newer epoch becomes active;
+- fail-closed replay of orphan cluster-transaction WAL records.
+
+The full local `scripts/test_all_smoke.sh` suite passed before release,
+including storage corruption, process crash, concurrent pressure, TLS, RBAC,
+wire fuzzing, placement migration, Universe sync, and demo coverage.
+`nimble check` also passed. GitHub CI passed its Linux core/integration/TLS/C
+ABI jobs and the macOS TLS-enabled C ABI job.
+
+## Operational Boundary
+
+Promotion is deliberately operator-driven. KoutenDB does not guess a winner
+through a network partition, and this release does not add Raft or a quorum
+round trip to every write. Peer discovery remains static, cross-Universe
+convergence remains separate, and managed-service health policy and automatic
+orchestration remain deployment-layer responsibilities.
+
+Configuration and recovery commands are documented in
+[Coordinator Failover](coordinator-failover.md). The complete invariants and
+test matrix are recorded in the
+[v0.13 implementation record](v0.13-roadmap.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,8 @@ downstream AI/RAG or application logic.
 - [Technical FAQ](technical-faq.md)
 - [Feature Status / Roadmap](koutendb-status.md)
 - [v0.12 Implementation And Validation Record](v0.12-roadmap.md)
+- [v0.13 Coordinator Redundancy Record](v0.13-roadmap.md)
+- [Coordinator Failover](coordinator-failover.md)
 - [Operational Trials](operational-trials.md)
 - [72-Hour Strong-Durability Soak Result](soak-testing.md)
 - [Accelerated Churn Testing](accelerated-churn-testing.md)
@@ -62,6 +64,7 @@ downstream AI/RAG or application logic.
 ## Release
 
 - [Release Checklist](release-checklist.md)
+- [v0.13.0 Release Notes](github-release-v0.13.0.md)
 - [v0.12.1 Release Notes](github-release-v0.12.1.md)
 - [v0.12.0 Release Notes](github-release-v0.12.0.md)
 - [v0.11.0 Release Notes](github-release-v0.11.0.md)

--- a/docs/koutendb-status.md
+++ b/docs/koutendb-status.md
@@ -5,11 +5,11 @@ references and may lag behind this file.
 
 Release checklist: [release-checklist.md](./release-checklist.md)
 
-Current release evidence: [v0.12.1 release notes](./github-release-v0.12.1.md)
+Current release evidence: [v0.13.0 release notes](./github-release-v0.13.0.md)
 
 Current persistence-cycle record: [v0.12 implementation and validation](./v0.12-roadmap.md)
 
-Current development record: [v0.13 coordinator redundancy](./v0.13-roadmap.md)
+Current coordinator-redundancy record: [v0.13 coordinator redundancy](./v0.13-roadmap.md)
 
 Historical planning reference: [v0.10 roadmap](./v0.10-roadmap.md)
 

--- a/koutendb.nimble
+++ b/koutendb.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version     = "0.12.1"
+version     = "0.13.0"
 author      = "puffball1567"
 description = "KoutenDB: ring-oriented NoSQL document/vector store for smaller working sets"
 license     = "Apache-2.0"


### PR DESCRIPTION
## Summary

- set the package version to 0.13.0
- add release notes and changelog for recoverable coordinator failover
- link the coordinator operations and v0.13 implementation records from the README and documentation index
- update the canonical status and operational scope

## Verification

- full `scripts/test_all_smoke.sh` passed on the release implementation
- `nimble check` passed after the version update
- `git diff --check` passed
- PR #105 GitHub CI passed on Linux and macOS