### PR TITLE
docs: define v1.0 stabilization and service trial gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ Typical NoSQL](docs/nosql-positioning.md) for the full model.
 
 - Documentation site entry point: [docs/index.md](docs/index.md)
 - Installation: [docs/installation.md](docs/installation.md)
+- Hands-on evaluation: [docs/hands-on-evaluation.md](docs/hands-on-evaluation.md)
+- Service operation trial: [docs/service-trial.md](docs/service-trial.md)
+- v1.0 stabilization plan: [docs/v1-stabilization.md](docs/v1-stabilization.md)
 - Public API reference: [docs/public-api.md](docs/public-api.md)
 - Configuration reference: [docs/config-reference.md](docs/config-reference.md)
 - CLI reference: [docs/cli-reference.md](docs/cli-reference.md)
@@ -715,6 +718,9 @@ It is designed for teams that can express a meaningful locality boundary and
 want to evaluate a smaller-working-set retrieval architecture. Multi-machine
 and multi-region endurance testing and broader external production reports
 remain active validation tracks. See
+[Hands-on Evaluation](docs/hands-on-evaluation.md),
+[Service Trial](docs/service-trial.md),
+[v1.0 Stabilization](docs/v1-stabilization.md),
 [Operational Trials](docs/operational-trials.md),
 [Soak Testing](docs/soak-testing.md), and
 [Feature Status](docs/koutendb-status.md) for the current evidence and roadmap.

--- a/docs/hands-on-evaluation.md
+++ b/docs/hands-on-evaluation.md
@@ -1,0 +1,186 @@
+---
+layout: page
+title: Hands-on Evaluation
+---
+
+# Hands-on Evaluation
+
+This guide is the shortest human path from a clean installation to a verified
+KoutenDB restore. It is for evaluation and maintainer dogfooding, not only for
+CI. Follow it before relying on less familiar cluster or Universe features.
+
+## What You Will Prove
+
+By the end, you will have:
+
+- stored and queried related JSON documents through ring coordinates;
+- reopened a persistent database;
+- inspected its atlas and physical health;
+- exported a portable JSONL copy;
+- created and verified an operational backup;
+- restored into an independent directory and read the same logical data.
+
+Use disposable directories and non-sensitive data for the first run.
+
+## 1. Install And Identify The Build
+
+Install the released package:
+
+```sh
+nimble install koutendb
+kouten --help
+```
+
+If the command is missing, add `~/.nimble/bin` to `PATH` as described in
+[Installation](installation.md). Record the exact KoutenDB release, Nim version,
+operating system, and installation method in your evaluation notes.
+
+## 2. Create A Persistent Local Store
+
+Use an isolated working directory:
+
+```sh
+export KOUTEN_TRIAL="$PWD/koutendb-human-trial"
+mkdir -p "$KOUTEN_TRIAL"
+export KOUTEN_DATA="$KOUTEN_TRIAL/data"
+```
+
+Write a user and nearby application data:
+
+```sh
+kouten put --ring=users/123 \
+  --payload='{"kind":"user","name":"Ada"}' --codec=json
+kouten put --near=users/123 --ring=profile \
+  --payload='{"kind":"profile","plan":"pro"}' --codec=json
+kouten put --near=users/123 --ring=orders \
+  --payload='{"kind":"order","number":"A-001","total":120}' --codec=json
+```
+
+Read the neighborhood and then narrow it:
+
+```sh
+kouten get --ring=users/123 --subring=profile,orders
+kouten get --ring=users/123 --subring=orders \
+  --selection='{ kind number total }'
+kouten atlas
+```
+
+Expected result: the broad user coordinate can see the nearby profile and
+order, while `--subring=orders` excludes the profile. This is the core locality
+behavior, not a global field scan.
+
+## 3. Use The Interactive Shell
+
+The shell is useful for manual inspection:
+
+```sh
+kouten shell --data="$KOUTEN_DATA"
+```
+
+Try:
+
+```text
+list users/123 20
+count users/123
+atlas
+help
+exit
+```
+
+The shell uses KoutenDB commands rather than SQL. Use single-shot commands for
+scripts because their arguments and exit status are easier to reproduce.
+
+## 4. Reopen And Verify
+
+Each single-shot command closes its embedded handle before returning. Running a
+new command therefore exercises persistent reopen:
+
+```sh
+kouten get --ring=users/123 --subring=profile,orders
+kouten verify --data="$KOUTEN_DATA" --segments --json
+kouten doctor --data="$KOUTEN_DATA" --json
+```
+
+Both maintenance commands must exit successfully. Save their JSON output in
+your evaluation record.
+
+Do not run direct data-directory maintenance while `koutend` has the same
+directory open. The single-writer lock should reject that mistake, but the
+correct operational procedure is to stop or drain the server first.
+
+## 5. Test Portable Migration
+
+Dump the logical data and import it into a clean store:
+
+```sh
+kouten dump --data="$KOUTEN_DATA" --out="$KOUTEN_TRIAL/export.jsonl"
+kouten import-jsonl --data="$KOUTEN_TRIAL/imported" \
+  --in="$KOUTEN_TRIAL/export.jsonl" --batch-size=1000
+kouten get --data="$KOUTEN_TRIAL/imported" \
+  --ring=users/123 --subring=profile,orders
+kouten verify --data="$KOUTEN_TRIAL/imported" --json
+```
+
+JSONL is the portable cross-version boundary. Imported records receive target
+store IDs; compare logical ring, payload, codec, and vector data rather than
+internal IDs.
+
+## 6. Test Backup And Restore
+
+Create, verify, and restore an operational backup:
+
+```sh
+kouten backup --data="$KOUTEN_DATA" --backup="$KOUTEN_TRIAL/backup"
+kouten verify --backup="$KOUTEN_TRIAL/backup" --json
+kouten restore --backup="$KOUTEN_TRIAL/backup" \
+  --data="$KOUTEN_TRIAL/restored"
+kouten verify --data="$KOUTEN_TRIAL/restored" --segments --json
+kouten get --data="$KOUTEN_TRIAL/restored" \
+  --ring=users/123 --subring=profile,orders
+```
+
+A backup is not proven by successful creation. The independent restore and read
+are part of the test.
+
+## 7. Continue With A Server Trial
+
+Run the authenticated persistent Compose trial in
+[Operational Trials](operational-trials.md), then use the longer
+[Service Trial](service-trial.md) when an application is ready to consume the
+database.
+
+## Dogfooding Journal
+
+Keep one append-only Markdown or JSONL journal per trial. A minimal entry is:
+
+```text
+timestamp:
+koutendbVersion:
+applicationVersion:
+environment:
+operationOrIncident:
+expected:
+observed:
+dataAtRisk:
+recoveryAction:
+result:
+linkedIssue:
+```
+
+Record successful upgrade, backup, and restore drills too. The absence of an
+incident is meaningful only beside operation counts, uptime, and the workload
+that actually ran.
+
+## Evaluation Pass Criteria
+
+The human evaluation passes when:
+
+- every command can be understood without reading source code;
+- persistent reopen returns the expected logical records;
+- JSONL migration produces the expected logical dataset;
+- backup verification and independent restore both succeed;
+- errors identify a corrective action rather than exposing an internal stack;
+- every deviation from this guide is fixed or tracked publicly.
+
+Passing this guide does not by itself prove production readiness. It proves
+that the documented operational foundation is usable by a human.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,9 @@ downstream AI/RAG or application logic.
 
 - [Concept](koutendb-concept.md)
 - [Installation](installation.md)
+- [Hands-on Evaluation](hands-on-evaluation.md)
+- [Service Trial](service-trial.md)
+- [v1.0 Stabilization Plan](v1-stabilization.md)
 - [Public API](public-api.md)
 - [Configuration Reference](config-reference.md)
 - [CLI Reference](cli-reference.md)

--- a/docs/koutendb-status.md
+++ b/docs/koutendb-status.md
@@ -7,6 +7,11 @@ Release checklist: [release-checklist.md](./release-checklist.md)
 
 Current release evidence: [v0.13.0 release notes](./github-release-v0.13.0.md)
 
+Current v1.0 preparation: [v1.0 stabilization plan](./v1-stabilization.md)
+
+Human evaluation path: [hands-on evaluation](./hands-on-evaluation.md) and
+[service trial](./service-trial.md)
+
 Current persistence-cycle record: [v0.12 implementation and validation](./v0.12-roadmap.md)
 
 Current coordinator-redundancy record: [v0.13 coordinator redundancy](./v0.13-roadmap.md)

--- a/docs/operational-trials.md
+++ b/docs/operational-trials.md
@@ -1,7 +1,10 @@
 # Operational Trials
 
-KoutenDB v0.10 adds an operational evaluation path for users who want to try a
-persistent deployment shape before putting important data behind it.
+KoutenDB provides this short operational evaluation path for users who want to
+try a persistent deployment shape before putting important data behind it.
+Start with the [Hands-on Evaluation](hands-on-evaluation.md). Use this Compose
+trial as the next rehearsal, then follow the longer
+[Service Trial](service-trial.md) before the v1.0 RC gate.
 
 The goal is not to pretend that a Compose file is a managed service. The goal is
 to make a small trial repeatable:
@@ -124,5 +127,5 @@ It does not prove:
 - multi-region disaster recovery;
 - enterprise audit policy completeness.
 
-Those are larger deployment topics. The v0.10 trial is deliberately smaller:
+Those are larger deployment topics. This Compose trial is deliberately smaller:
 it should be easy to run, inspect, and challenge.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -4,6 +4,24 @@ This is the canonical release checklist for the public KoutenDB repository.
 The current automated test coverage matrix is tracked in
 [Test Coverage](test-coverage.md).
 
+## Required Before v1.0 RC
+
+The detailed gates and evidence rules are defined in
+[v1.0 Stabilization](v1-stabilization.md).
+
+| Area | Required Item | Status |
+|---|---|---|
+| Human evaluation | Complete the public install, CRUD, reopen, migration, backup, and restore path from a clean environment | Documentation ready; independent run pending |
+| Maintainer dogfooding | Use KoutenDB through a maintained application and keep an operation/incident journal | Pending |
+| Service trial | Run a useful persistent service with real application traffic, monitoring, verified backups, and recovery drills | Pending |
+| Stable surface | Name the v1.x API, CLI, configuration, storage, migration, wire, and C ABI contracts | Pending final freeze |
+| Experimental surface | Label features outside the v1.x compatibility promise consistently | Pending review |
+| Upgrade matrix | Exercise maintained historical fixtures, JSONL migration, supported drivers, wire negotiation, and fail-closed boundaries | Partial; historical storage fixtures exist |
+| Recovery matrix | Re-run crash, corruption, storage-failure, checkpoint, coordinator, TLS/auth, and restore tests on the RC commit | Existing coverage; final RC run pending |
+| Operations | Publish redacted service evidence with metrics, incidents, restore results, and exclusions | Pending |
+| Documentation | A new operator can install, evaluate, operate, troubleshoot, and recover without implementation knowledge | In progress |
+| Release blockers | No open issue violates the declared stable v1.0 contract | Pending RC review |
+
 ## v0.2.0 Positioning
 
 Release v0.2.0 as a technical preview / research OSS release with stronger

--- a/docs/service-trial.md
+++ b/docs/service-trial.md
@@ -1,0 +1,158 @@
+---
+layout: page
+title: Service Trial
+---
+
+# Service Trial
+
+The v1.0 service trial moves KoutenDB beyond scripted validation. It runs a
+useful application against a persistent deployment and records whether normal
+operation, maintenance, recovery, and upgrade work as documented.
+
+Start with non-critical or reconstructible data. Good first workloads include
+documentation retrieval, a searchable content catalog, application activity
+context, generated metadata, or a secondary read model populated from another
+source of truth. The service must still be useful; a health-check-only process
+does not count.
+
+Real application traffic does not require public adoption or high request
+volume. Maintainer usage counts when requests come from a real workflow and the
+application would notice missing, stale, or incorrect data. Synthetic load can
+supplement that evidence, but cannot replace it.
+
+## Choose The Data Contract
+
+Before deployment, write down:
+
+1. why related records belong in the selected rings;
+2. which reads should remain ring-local;
+3. which system is authoritative for each data class;
+4. whether records can be reconstructed;
+5. the maximum acceptable data loss and recovery time;
+6. which operations require a transaction or cooperative lock;
+7. which features are stable and which are experimental.
+
+This prevents the trial from changing its success criteria after an incident.
+
+## Minimum Deployment
+
+The first service trial may use one persistent node. Use a three-node cluster
+only when the application needs to exercise placement, handoff, or coordinator
+recovery. A small honest topology is more useful than a large topology that no
+one monitors.
+
+For server operation, require:
+
+- strong durability;
+- disk-backed ring-local reads;
+- TLS with certificate verification;
+- username/password plus secret-key authentication;
+- least-privilege role and ring-prefix authorization;
+- secrets supplied by files or the deployment secret manager;
+- persistent data and checkpoint volumes;
+- a bounded automatic-maintenance policy or an explicit maintenance schedule;
+- health, metrics, audit, and disk-capacity collection.
+
+The existing Compose operational trial is a local rehearsal. A service trial
+must also document the actual host, container, VM, or orchestration boundary.
+
+## Observe The Right Signals
+
+Collect at least:
+
+- process uptime and restart count;
+- requests, errors, auth failures, and authorization denials;
+- active and rejected connections;
+- item, ring, WAL, segment, and stale-record growth;
+- ring-local segment hits and WAL fallback reasons;
+- maintenance attempts, failures, rewritten bytes, and elapsed time;
+- transaction, handoff, migration, and Universe queues when enabled;
+- checkpoint verification status and age;
+- application latency and error rate at the call site.
+
+Use bounded labels. Do not put ring names, record IDs, or user-controlled values
+into Prometheus labels.
+
+## Required Operating Loop
+
+Run this loop throughout the trial.
+
+### Daily
+
+- inspect health, application errors, queue depth, storage growth, and the last
+  successful checkpoint;
+- verify that backup/checkpoint creation completed;
+- review auth failures and unexpected broad-scan diagnostics.
+
+### Weekly
+
+- run offline `verify` during a documented maintenance window or verify an
+  immutable checkpoint independently;
+- restore a selected backup or checkpoint into an isolated target;
+- run representative application reads against the restored target;
+- review maintenance recommendations and execute only bounded work.
+
+### Once Per Release Candidate
+
+- terminate the process during representative write traffic and verify reopen;
+- rehearse the documented upgrade path;
+- rehearse rollback or restore to the previous known-good state;
+- rotate a test credential and certificate;
+- confirm an unauthorized role cannot read or write outside its prefixes;
+- exercise overload and malformed-request handling without losing health.
+
+Never run a destructive drill against the only copy of the data.
+
+## Incident Handling
+
+For each incident, record:
+
+- first observable symptom and detection source;
+- affected version, topology, configuration, and workload;
+- whether an acknowledged write was at risk;
+- exact recovery commands and elapsed recovery time;
+- final verification result;
+- root cause and regression-test location;
+- whether the outcome is a defect, documented boundary, or operator error.
+
+Open a focused issue for reproducible defects. Close it after the fix is merged
+and the regression test passes; the trial journal should link both the issue
+and the validating release.
+
+## Acceptance Criteria
+
+The recommended v1.0 gate is at least 30 consecutive calendar days with real
+application traffic. It passes only when all of the following are true:
+
+- no acknowledged write is missing without a documented external failure
+  outside the declared durability boundary;
+- no corruption, authorization bypass, or incompatible state is accepted
+  silently;
+- monitoring covers the process, application, storage, and recovery artifacts;
+- scheduled backups/checkpoints are verified;
+- at least two independent restores return the expected logical data;
+- controlled termination and restart preserve the documented guarantees;
+- upgrade and rollback/recovery rehearsals complete from public instructions;
+- unresolved incidents are classified and none violates the proposed stable
+  v1.0 contract;
+- the operator can explain the remaining experimental boundaries.
+
+Do not invent an availability SLA from a lightly used trial. Publish the actual
+duration, operation counts, workload, failures, and recovery results.
+
+## Evidence To Publish
+
+Commit a redacted summary under `docs/validation-evidence/` containing:
+
+- release and environment information;
+- topology and non-secret configuration;
+- start/end timestamps and operation counts;
+- final metrics and storage diagnostics;
+- checkpoint/backup verification and restore results;
+- incident timeline and linked fixes;
+- commands required to reproduce the drills;
+- explicit exclusions.
+
+Do not commit live databases, credentials, private payloads, or huge raw logs.
+The evidence should let a reviewer distinguish a continuously used service
+from a process that was merely left running.

--- a/docs/v1-stabilization.md
+++ b/docs/v1-stabilization.md
@@ -1,0 +1,177 @@
+---
+layout: page
+title: KoutenDB v1.0 Stabilization
+---
+
+# KoutenDB v1.0 Stabilization
+
+KoutenDB has reached the point where adding more features is not the shortest
+path to v1.0. The remaining work is to make the existing database predictable
+for a person who did not implement it, use it continuously in a maintained
+application, operate it as a small service, and freeze the contracts that v1.x
+must preserve.
+
+This document is the canonical v1.0 stabilization plan. It does not assign an
+RC date. KoutenDB enters RC only after the evidence gates below are complete.
+
+## Release Sequence
+
+1. **Human evaluation:** a new user can install KoutenDB, perform normal reads
+   and writes, restart it, inspect it, back it up, and restore it by following
+   one guide.
+2. **Author dogfooding:** the maintainer uses KoutenDB through an application,
+   not only through test scripts, and records friction and incidents.
+3. **Service trial:** at least one useful, non-critical service runs against a
+   persistent KoutenDB deployment with monitoring and verified recovery.
+4. **Compatibility freeze:** stable storage, migration, wire, C ABI, CLI, and
+   configuration contracts are named and exercised across supported releases.
+5. **v1.0 RC:** only bug fixes, compatibility corrections, documentation fixes,
+   and release-blocking operational work enter the RC line.
+
+The RC is not blocked on broad market adoption. It is blocked on evidence that
+the documented product can be used and recovered without private knowledge.
+
+## Candidate Stable Surface
+
+The following areas are candidates for the v1.x compatibility promise:
+
+| Area | Candidate contract |
+|---|---|
+| Data model | galaxy, ring hierarchy, in-store record identity, JSON/raw payloads, stellar visibility |
+| Embedded API | open, CRUD, ring reads, projections, transactions, locks, backup, restore |
+| Persistence | acknowledged strong-durability writes survive supported restart and recovery paths |
+| Portable migration | versioned JSONL dump/import remains readable across supported releases |
+| Server | authenticated/TLS TCP operation, bounded requests, health, metrics, drain and snapshot |
+| Cluster | static topology, deterministic placement epochs, explicit migration and coordinator promotion |
+| C ABI | ABI version discovery, documented ownership, length, error, and byte-order rules |
+| Operations | verify, doctor, checkpoint, backup, restore, maintenance status, and audit output |
+
+The exact list must be frozen before RC. A feature is not automatically stable
+because it exists in v0.x.
+
+## Experimental Surface
+
+Features may remain available in v1.0 without joining the full compatibility
+promise. Current candidates include the heuristic retrieval planner, time
+orbit administration, Universe convergence policy, browser/WASM work, and
+automatic deployment orchestration.
+
+Experimental features must:
+
+- be identified in the status and API documentation;
+- fail clearly when a required capability is unavailable;
+- not weaken the stable persistence or recovery path;
+- have an explicit migration or removal policy.
+
+Dynamic membership, automatic coordinator failover, global serializable
+transactions, and managed-service orchestration are not required for v1.0 if
+their unsupported boundaries remain explicit and fail closed.
+
+## Gate 1: Human Evaluation
+
+The [Hands-on Evaluation Guide](hands-on-evaluation.md) must be completed from
+a clean environment by following the public documentation only.
+
+Evidence must record:
+
+- operating system, KoutenDB version, compiler/runtime version, and install
+  method;
+- every command that differed from the guide;
+- unclear output, missing prerequisites, and manual recovery steps;
+- successful persistent reopen, dump/import, backup verification, and restore;
+- the final `verify` or `doctor` result.
+
+Documentation defects found here are release defects. They should not be
+worked around only in a private script.
+
+## Gate 2: Maintainer Dogfooding
+
+At least one maintained application must use KoutenDB for useful state. A
+benchmark generator or a process that only calls `health` does not count.
+
+The application should exercise representative operations such as:
+
+- repeated writes, updates, deletes, ring reads, and restart;
+- the locality shape that motivated choosing KoutenDB;
+- one published driver or the public Nim API;
+- real error handling rather than unconditional retries;
+- backup and restore from the same data shape used by the application.
+
+Use the journal in the hands-on guide. Record normal operation as well as
+failures; an empty incident log is useful only when the observation period and
+operation counts are also present.
+
+## Gate 3: Service Operation
+
+The [Service Trial Guide](service-trial.md) defines the deployment and evidence
+requirements. The recommended minimum observation window is 30 consecutive
+calendar days. Duration alone is not a pass: the service must receive real
+application traffic and complete the recovery drills.
+
+Required outcomes:
+
+- no unexplained loss of an acknowledged write;
+- no silent corruption or silent authorization bypass;
+- health and bounded-cardinality metrics collected continuously;
+- backups or checkpoints created on schedule and verified;
+- at least two restores performed into independent directories or instances;
+- one controlled process termination and restart;
+- one upgrade rehearsal and one rollback or restore rehearsal;
+- every incident assigned a result: fixed, documented limitation, or explicit
+  v1.0 blocker.
+
+The first service should use non-critical or reconstructible data. That reduces
+adoption risk without turning the trial into a synthetic demo.
+
+## Gate 4: Compatibility And Recovery
+
+Before RC, automated validation must cover:
+
+1. open and migrate the maintained historical release fixtures;
+2. export old stores and import them into the RC using the portable JSONL
+   boundary;
+3. verify same-version checkpoint and backup restore;
+4. exercise supported driver versions against the RC server;
+5. verify wire-version negotiation and fail-closed mixed-version boundaries;
+6. test configuration parsing, deprecated fields, unknown fields, and invalid
+   combinations;
+7. document whether direct WAL opening from each supported v0.x release is
+   supported, migrated, or rejected with recovery instructions;
+8. run the crash, corruption, coordinator, TLS/auth, and storage-failure
+   matrices on the RC commit.
+
+KoutenDB must not imply that JSONL migration preserves internal record IDs when
+the documented dump format reissues them. Stable claims must match executable
+tests exactly.
+
+## Gate 5: RC Review
+
+The RC branch is ready when:
+
+- every stable API and operational command is documented;
+- stable and experimental features are labeled consistently in README, status,
+  API, CLI, and configuration documents;
+- all release checks pass from a clean checkout;
+- service-trial evidence is linked from the repository;
+- known limitations describe observable behavior and recovery, not only future
+  plans;
+- no open release-blocking issue remains.
+
+After RC begins, new product features move to the post-v1 branch. The RC line
+accepts only work needed to make the declared v1.0 contract true.
+
+## Evidence Location
+
+Commit compact, reviewable evidence under `docs/validation-evidence/`. Do not
+commit live databases, secrets, raw customer content, huge logs, or generated
+build trees. Prefer:
+
+- environment and configuration summaries with secrets removed;
+- compressed progress summaries;
+- final health, metrics, verify, and checkpoint reports;
+- hashes for deliberately deleted large artifacts;
+- incident and recovery timelines;
+- exact reproduction commands.
+
+Operational evidence supports a release claim only when another person can
+understand what ran, what passed, and what was not tested.


### PR DESCRIPTION
## Summary

- define the canonical stabilization sequence before KoutenDB v1.0 RC
- add a human-facing install-to-restore evaluation guide
- add a real service-operation trial with monitoring, recovery, upgrade, and incident gates
- link the new path from README, GitHub Pages, status, operational trials, and the release checklist

## Verification

- built the current CLI from this branch
- executed the documented ring/nearby read workflow
- executed the interactive shell commands
- verified persistent reopen with `verify` and `doctor`
- completed JSONL dump/import into a clean store
- completed backup verification and restore into an independent store
- checked all new relative Markdown links
- `git diff --check`
- `nimble check`

Related to #108. The issue remains open until maintainer dogfooding and real service evidence satisfy the documented gates.