### PR TITLE
feat: add official container release path

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,99 @@
+name: Container
+
+on:
+  pull_request:
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - koutendb.nimble
+      - config.nims
+      - src/**
+      - scripts/container_image_smoke.sh
+      - .github/workflows/container.yml
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: container-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  smoke:
+    name: Runtime contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build and verify official image
+        run: scripts/container_image_smoke.sh
+
+  build:
+    name: Build OCI image
+    needs: smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        if: github.event_name == 'release'
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha,prefix=sha-
+
+      - name: Build and optionally publish
+        id: image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name == 'release' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VCS_REF=${{ github.sha }}
+            VERSION=${{ github.event.release.tag_name || github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Attest published image
+        if: github.event_name == 'release'
+        uses: actions/attest@v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.image.outputs.digest }}
+          push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+FROM nimlang/nim:2.2.10 AS build
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends gcc libsodium-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp/koutendb-deps
+RUN nimble install -y nimsodium
+
+WORKDIR /build
+COPY koutendb.nimble config.nims ./
+COPY src ./src
+RUN nim c -d:ssl -d:release --nimcache:/tmp/nimcache_koutend \
+      -o:/out/koutend src/koutend.nim \
+ && nim c -d:ssl -d:release --nimcache:/tmp/nimcache_kouten \
+      -o:/out/kouten src/koutencli.nim
+
+FROM debian:trixie-slim AS runtime
+
+ARG VCS_REF="unknown"
+ARG VERSION="dev"
+ENV DEBIAN_FRONTEND=noninteractive
+
+LABEL org.opencontainers.image.title="KoutenDB" \
+      org.opencontainers.image.description="Locality-first document and vector database" \
+      org.opencontainers.image.source="https://github.com/puffball1567/koutendb" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates libsodium23 openssl \
+ && rm -rf /var/lib/apt/lists/* \
+ && groupadd --gid 10001 koutendb \
+ && useradd --uid 10001 --gid 10001 --no-create-home --home-dir /var/lib/koutendb \
+      --shell /usr/sbin/nologin koutendb \
+ && install -d -o koutendb -g koutendb -m 0750 /var/lib/koutendb /etc/koutendb
+
+COPY --from=build /out/koutend /usr/local/bin/koutend
+COPY --from=build /out/kouten /usr/local/bin/kouten
+RUN ln -s /usr/local/bin/kouten /usr/local/bin/koutencli
+
+USER 10001:10001
+WORKDIR /var/lib/koutendb
+VOLUME ["/var/lib/koutendb"]
+EXPOSE 7301
+STOPSIGNAL SIGTERM
+
+ENTRYPOINT ["/usr/local/bin/koutend"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ downstream AI/RAG or application logic.
 - [Hands-on Evaluation](hands-on-evaluation.md)
 - [Service Trial](service-trial.md)
 - [v1.0 Stabilization Plan](v1-stabilization.md)
+- [v0.14 Self-Hosted Operations](v0.14-self-hosted-operations.md)
 - [Public API](public-api.md)
 - [Configuration Reference](config-reference.md)
 - [CLI Reference](cli-reference.md)

--- a/docs/koutendb-status.md
+++ b/docs/koutendb-status.md
@@ -9,6 +9,8 @@ Current release evidence: [v0.13.0 release notes](./github-release-v0.13.0.md)
 
 Current v1.0 preparation: [v1.0 stabilization plan](./v1-stabilization.md)
 
+Current self-host work: [v0.14 self-hosted operations](./v0.14-self-hosted-operations.md)
+
 Human evaluation path: [hands-on evaluation](./hands-on-evaluation.md) and
 [service trial](./service-trial.md)
 

--- a/docs/v0.14-self-hosted-operations.md
+++ b/docs/v0.14-self-hosted-operations.md
@@ -1,0 +1,89 @@
+---
+layout: page
+title: v0.14 Self-Hosted Operations
+---
+
+# KoutenDB v0.14 Self-Hosted Operations
+
+v0.14 reduces the work required to operate KoutenDB without turning the core
+database into a cloud-provisioning platform. KoutenDB owns database safety,
+recovery artifacts, topology validation, and typed execution plans. Cloud,
+virtualization, or bare-metal systems remain responsible for creating actual
+CPU, memory, disks, and hosts.
+
+## Scope
+
+1. official versioned `linux/amd64` and `linux/arm64` images on GHCR;
+2. a single-node self-host bootstrap with persistent storage, TLS/auth, health,
+   and strong-durability defaults;
+3. failure detection and supervised restart integration;
+4. checkpoint creation, strict verification, independent restore verification,
+   retention, and provider-neutral transfer;
+5. staged certificate rotation with preflight and rollback;
+6. safe upgrade through drain, checkpoint, replacement, health verification,
+   resume, and rollback;
+7. capacity history and forecast from bounded operational metrics;
+8. typed scale-plan generation;
+9. immutable plan approval followed by operator-controlled execution.
+
+Instant horizontal autoscaling is not in scope. v0.14 can identify required
+capacity and safely consume a prepared node, but it does not silently create an
+EC2 instance, resize a physical server, or execute an arbitrary provisioning
+shell command.
+
+## Safety Invariants
+
+- topology or binary replacement requires a verified recovery generation;
+- generated plans contain no password, token, secret key, or private key;
+- a plan cannot execute without an exact plan ID and explicit approval;
+- approval does not bypass current drain, epoch, quorum, or fencing checks;
+- failed operations retain a known-good binary/configuration and recovery
+  generation;
+- transferred backups are verified at the destination before success is
+  recorded;
+- health failure and infrastructure shortage are reported separately;
+- process supervision may restart a failed process, but cannot invent physical
+  capacity.
+
+## Delivery Stages
+
+### Stage 1: Reproducible Image
+
+The repository root `Dockerfile` builds TLS-enabled `koutend`, `kouten`, and
+`koutencli` binaries into a non-root runtime image. GitHub Releases publish the
+same version tag to `ghcr.io/puffball1567/koutendb` with build provenance.
+
+### Stage 2: Single-Node Operations
+
+The self-host bundle generates a pinned deployment, secrets outside the
+configuration file, a persistent data volume, health checks, monitoring output,
+and recovery storage. Source compilation is not part of the normal path.
+
+### Stage 3: Recovery And Lifecycle
+
+The operator automates checkpoints, destination verification, restore drills,
+certificate rotation, upgrade, and rollback. Each operation emits a bounded
+JSON record suitable for the v1.0 service-trial evidence.
+
+### Stage 4: Capacity And Scale Plans
+
+Capacity samples produce a provider-neutral plan containing observed growth,
+forecast horizon, required bytes/CPU/memory, topology intent, prerequisites,
+and KoutenDB actions. Terraform, Kubernetes, AWS, GCP, Proxmox, or a human may
+prepare the resources. KoutenDB applies only its typed portion after approval.
+
+## Release Gate
+
+v0.14 is ready when local and container matrices cover:
+
+- image startup as a non-root user on both declared architectures;
+- unhealthy process detection and bounded restart behavior;
+- interrupted checkpoint, transfer, restore, upgrade, and certificate rotation;
+- exact plan-ID approval, stale-plan refusal, and repeat execution;
+- rollback after post-replacement health failure;
+- capacity boundary and forecast calculations;
+- redaction of every credential-bearing input;
+- clean removal of test containers, volumes, and images.
+
+The confidentiality audit remains a separate implementation branch and must be
+reviewed and integrated independently before the v0.14 release branch is cut.

--- a/scripts/container_image_smoke.sh
+++ b/scripts/container_image_smoke.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+IMAGE="${KOUTEN_CONTAINER_IMAGE:-koutendb:container-smoke}"
+BUILD_IMAGE="${KOUTEN_CONTAINER_BUILD_IMAGE:-1}"
+VOLUME="koutendb-container-smoke-$$"
+
+cleanup() {
+  docker volume rm "$VOLUME" >/dev/null 2>&1 || true
+  if [[ "$BUILD_IMAGE" == "1" && "${KOUTEN_CONTAINER_KEEP_IMAGE:-0}" != "1" ]]; then
+    docker image rm "$IMAGE" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "[container-image] docker command is required" >&2
+  exit 1
+fi
+if ! docker info >/dev/null 2>&1; then
+  echo "[container-image] docker daemon is unavailable" >&2
+  exit 1
+fi
+
+if [[ "$BUILD_IMAGE" == "1" ]]; then
+  echo "[container-image] build official image"
+  docker build --build-arg VCS_REF=container-smoke \
+    --build-arg VERSION=container-smoke -t "$IMAGE" .
+fi
+
+echo "[container-image] verify runtime identity and CLI"
+docker run --rm --entrypoint id "$IMAGE" | grep -q 'uid=10001(koutendb)'
+docker run --rm --entrypoint kouten "$IMAGE" --help | grep -q 'KoutenDB command-line client'
+
+echo "[container-image] verify named-volume persistence across containers"
+docker volume create "$VOLUME" >/dev/null
+docker run --rm -v "$VOLUME:/var/lib/koutendb" --entrypoint kouten "$IMAGE" \
+  put --data=/var/lib/koutendb/data --ring=ops/container \
+  --payload='{"status":"persisted"}' --codec=json >/dev/null
+docker run --rm -v "$VOLUME:/var/lib/koutendb" --entrypoint kouten "$IMAGE" \
+  get --data=/var/lib/koutendb/data --ring=ops/container |
+  grep -q '"status": "persisted"'
+
+echo "[container-image] verify persisted data offline"
+docker run --rm -v "$VOLUME:/var/lib/koutendb" --entrypoint kouten "$IMAGE" \
+  verify --data=/var/lib/koutendb/data --segments --json |
+  grep -q '"kind": "data"'
+
+echo "[container-image] OK"


### PR DESCRIPTION
## Summary
- add a TLS-enabled, non-root official OCI image for KoutenDB
- publish multi-architecture release images to GHCR with provenance
- add a runtime contract smoke covering CLI, named-volume persistence, and offline verification
- document the v0.14 self-hosted operations scope and safety invariants

## Verification
- Docker image built successfully from the repository root
- runtime UID/GID verified as 10001:10001
- persisted JSON read from a replacement container
- offline data/segment verification passed
- scripts/container_image_smoke.sh passed end to end and removed its resources
- bash -n scripts/container_image_smoke.sh
- git diff --check

Related to #110