### PR TITLE
release: KoutenDB v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 ## Unreleased
 
+## v0.14.0 - 2026-08-27
+
+### Added
+
+- Added an official TLS-enabled multi-architecture OCI image release path for
+  `linux/amd64` and `linux/arm64` through GHCR.
+- Added a single-node self-host bundle with non-root/read-only containers,
+  persistent strong-durability storage, generated TLS/auth configuration,
+  health checks, and bounded supervised restart integration.
+- Added operator-controlled checkpoint export, independent restore
+  verification, scheduled verified backups, and fail-safe retention.
+- Added rollback-safe image upgrades and certificate rotation with preflight,
+  recovery-generation verification, and post-change health checks.
+- Added bounded capacity history, growth forecasts, content-derived plan IDs,
+  explicit approval, and one-shot prepared-capacity verification.
+- Added documented `reader`, `writer`, `replicator`, and `admin` roles plus
+  explicit peer service credentials for node-to-node traffic.
+
+### Changed
+
+- Authenticated connections are bound to one galaxy, and ring-scoped reads,
+  retrieval, statistics, migration, and replication paths enforce their
+  declared authorization boundaries.
+- New encrypted backups derive keys with Argon2id and authenticated secretbox
+  encryption while retaining read compatibility with legacy V1 backups.
+- Newly created POSIX data directories and managed artifacts use owner-only
+  permissions, and managed output paths reject symbolic-link targets.
+- Remote password authentication now refuses non-loopback plaintext deployment
+  unless TLS, secret-key transport, or the explicit development override is
+  configured.
+
+### Fixed / Hardened
+
+- Added authentication throttling and equivalent first-response behavior for
+  configured and unknown identities.
+- Added symmetric request/response framing limits, bounded C ABI allocation
+  inputs, validated handles, and catchable public API failures.
+- Prevented application writers from invoking replication, owner-apply,
+  coordinator, Universe, and topology-maintenance operations.
+- Replaced remotely exposed internal exception text with stable error
+  categories and restricted non-admin health/statistics disclosure.
+- Added focused confidentiality, RBAC, malformed-frame, backup-migration,
+  artifact-permission, C ABI, TLS, and multi-node peer-role validation.
+
 ## v0.13.0 - 2026-08-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Typical NoSQL](docs/nosql-positioning.md) for the full model.
 - v0.12 implementation and validation record: [docs/v0.12-roadmap.md](docs/v0.12-roadmap.md)
 - Coordinator failover: [docs/coordinator-failover.md](docs/coordinator-failover.md)
 - Release checklist: [docs/release-checklist.md](docs/release-checklist.md)
+- v0.14.0 release notes: [docs/github-release-v0.14.0.md](docs/github-release-v0.14.0.md)
 - v0.13.0 release notes: [docs/github-release-v0.13.0.md](docs/github-release-v0.13.0.md)
 - v0.12.1 release notes: [docs/github-release-v0.12.1.md](docs/github-release-v0.12.1.md)
 - v0.12.0 release notes: [docs/github-release-v0.12.0.md](docs/github-release-v0.12.0.md)
@@ -717,12 +718,16 @@ tests/                 unit and smoke tests
 
 ## Operational Scope
 
-KoutenDB v0.13.0 is a public pre-v1 release with persistent storage, strong
+KoutenDB v0.14.0 is a public pre-v1 release with persistent storage, strong
 durability, recovery, transactions, topology controls, TLS-capable transport, a
 C ABI, published drivers, ring-local physical segments, bounded automatic
 maintenance, generation checkpoints, operational metrics, recoverable cluster
-transaction coordinator failover, and documented crash, corruption, container,
-driver, and 72-hour endurance validation.
+transaction coordinator failover, role-separated peer traffic, hardened
+confidentiality boundaries, and documented crash, corruption, container,
+driver, security, and 72-hour endurance validation. The official self-host path
+adds versioned multi-architecture images, supervised restart, verified scheduled
+backups, rollback-safe upgrades and certificate rotation, and approval-gated
+capacity plans.
 
 It is designed for teams that can express a meaningful locality boundary and
 want to evaluate a smaller-working-set retrieval architecture. Multi-machine

--- a/docs/github-release-v0.14.0.md
+++ b/docs/github-release-v0.14.0.md
@@ -1,0 +1,70 @@
+# KoutenDB v0.14.0
+
+KoutenDB v0.14.0 adds a reproducible self-host operations path and hardens the
+database's confidentiality and trust boundaries. The release combines
+versioned multi-architecture images, verified recovery workflows, safe
+lifecycle automation, explicit service roles, stricter authorization, and
+bounded protocol and C ABI inputs.
+
+## Self-Hosted Operations
+
+- official TLS-enabled `linux/amd64` and `linux/arm64` OCI image publishing
+  through `ghcr.io/puffball1567/koutendb`;
+- a non-root, read-only single-node Compose deployment with persistent
+  strong-durability storage, generated TLS/auth configuration, and health
+  checks;
+- bounded watchdog restart behavior that distinguishes an unhealthy process
+  from a persistent operational fault;
+- checkpoint creation, staged export, independent restore verification,
+  scheduled backups, and verified-generation retention;
+- rollback-safe versioned image upgrades and certificate rotation;
+- bounded capacity history and forecasts plus content-derived, explicitly
+  approved execution plans.
+
+The operator executes only typed KoutenDB actions. It does not provision cloud
+instances, resize physical storage, or execute arbitrary infrastructure hooks.
+
+## Confidentiality And Access Control
+
+- separate `reader`, `writer`, `replicator`, and `admin` roles;
+- explicit `peerAuth` credentials for node-to-node replication and coordinator
+  traffic;
+- galaxy-bound authenticated sessions and authorization-aware ring retrieval,
+  listing, counting, querying, updates, deletes, and statistics;
+- admin-only topology migration and maintenance boundaries;
+- fail-closed non-loopback password deployment unless TLS, secret-key
+  transport, or an explicit development override is configured;
+- bounded authentication guessing and identity-neutral challenge negotiation;
+- stable remote error categories that do not expose internal exception text.
+
+## Storage And API Hardening
+
+- new encrypted backups use Argon2id password derivation plus authenticated
+  secretbox encryption while legacy V1 backups remain readable;
+- passphrases can come from owner-managed files or environment variables;
+- newly created POSIX data directories use mode `0700`, managed artifacts use
+  mode `0600`, and symbolic-link output targets are rejected;
+- request and response framing limits are enforced before allocation;
+- C ABI payload, vector, batch, string, boolean, and orbital inputs are bounded
+  and validated;
+- C ABI handles fail closed after close, and public API misuse raises catchable
+  errors instead of process-ending assertions.
+
+## Validation
+
+The release branch passed the complete core and smoke suites. The validation
+includes Linux and macOS C ABI builds, CA-verified TLS, role and peer-service
+authorization, galaxy and ring isolation, malformed protocol frames, encrypted
+backup migration, POSIX artifact permissions, crash and storage-failure
+recovery, topology migration, coordinator failover, Universe synchronization,
+and OCI image construction.
+
+The security guarantees and their executable evidence are listed in the
+[Security Validation Matrix](security-validation.md). Self-host lifecycle
+invariants and operational boundaries are documented in
+[v0.14 Self-Hosted Operations](v0.14-self-hosted-operations.md).
+
+External driver repository releases remain independent from this core release.
+KoutenDB does not claim transparent WAL encryption, distributed login
+throttling, managed fleet PKI, automatic cloud provisioning, or independent
+penetration-test certification.

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,6 +71,7 @@ downstream AI/RAG or application logic.
 ## Release
 
 - [Release Checklist](release-checklist.md)
+- [v0.14.0 Release Notes](github-release-v0.14.0.md)
 - [v0.13.0 Release Notes](github-release-v0.13.0.md)
 - [v0.12.1 Release Notes](github-release-v0.12.1.md)
 - [v0.12.0 Release Notes](github-release-v0.12.0.md)

--- a/docs/koutendb-status.md
+++ b/docs/koutendb-status.md
@@ -5,11 +5,11 @@ references and may lag behind this file.
 
 Release checklist: [release-checklist.md](./release-checklist.md)
 
-Current release evidence: [v0.13.0 release notes](./github-release-v0.13.0.md)
+Current release evidence: [v0.14.0 release notes](./github-release-v0.14.0.md)
 
 Current v1.0 preparation: [v1.0 stabilization plan](./v1-stabilization.md)
 
-Current self-host work: [v0.14 self-hosted operations](./v0.14-self-hosted-operations.md)
+Current self-host operations: [v0.14 self-hosted operations](./v0.14-self-hosted-operations.md)
 
 Human evaluation path: [hands-on evaluation](./hands-on-evaluation.md) and
 [service trial](./service-trial.md)

--- a/koutendb.nimble
+++ b/koutendb.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version     = "0.13.0"
+version     = "0.14.0"
 author      = "puffball1567"
 description = "KoutenDB: ring-oriented NoSQL document/vector store for smaller working sets"
 license     = "Apache-2.0"


### PR DESCRIPTION
## Summary

- publish the v0.14.0 package version, changelog, and release notes
- document the self-host operations and security hardening delivered since v0.13.0
- update README and documentation status links to the current release

## Validation

- scripts/test_core.sh
- scripts/test_all_smoke.sh
- scripts/container_image_smoke.sh
- nimble check
- git diff --check