### PR TITLE
docs: define adoption and onboarding roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,65 +83,43 @@ into a ring. Reads use ring hierarchy, nearby subrings, retrieval profiles, and
 projections to keep the candidate set small. See [How KoutenDB Differs From
 Typical NoSQL](docs/nosql-positioning.md) for the full model.
 
-## Documents
+## Choose Your Starting Path
 
-- Documentation site entry point: [docs/index.md](docs/index.md)
-- Installation: [docs/installation.md](docs/installation.md)
-- Hands-on evaluation: [docs/hands-on-evaluation.md](docs/hands-on-evaluation.md)
-- Service operation trial: [docs/service-trial.md](docs/service-trial.md)
-- v1.0 stabilization plan: [docs/v1-stabilization.md](docs/v1-stabilization.md)
-- Public API reference: [docs/public-api.md](docs/public-api.md)
-- Configuration reference: [docs/config-reference.md](docs/config-reference.md)
-- CLI reference: [docs/cli-reference.md](docs/cli-reference.md)
-- How KoutenDB differs from typical NoSQL: [docs/nosql-positioning.md](docs/nosql-positioning.md)
-- Unique data model and operating patterns: [docs/unique-data-model.md](docs/unique-data-model.md)
-- Technical FAQ for database reviewers: [docs/technical-faq.md](docs/technical-faq.md)
-- Concept: [docs/koutendb-concept.md](docs/koutendb-concept.md)
-- Detailed design: [docs/koutendb-design.md](docs/koutendb-design.md)
-- Feature status / roadmap: [docs/koutendb-status.md](docs/koutendb-status.md)
-- v0.12 implementation and validation record: [docs/v0.12-roadmap.md](docs/v0.12-roadmap.md)
-- Coordinator failover: [docs/coordinator-failover.md](docs/coordinator-failover.md)
-- Release checklist: [docs/release-checklist.md](docs/release-checklist.md)
-- v0.14.0 release notes: [docs/github-release-v0.14.0.md](docs/github-release-v0.14.0.md)
-- v0.13.0 release notes: [docs/github-release-v0.13.0.md](docs/github-release-v0.13.0.md)
-- v0.12.1 release notes: [docs/github-release-v0.12.1.md](docs/github-release-v0.12.1.md)
-- v0.12.0 release notes: [docs/github-release-v0.12.0.md](docs/github-release-v0.12.0.md)
-- 72-hour strong-durability result: [docs/soak-testing.md](docs/soak-testing.md)
-- Driver / FFI roadmap: [docs/koutendb-driver-roadmap.md](docs/koutendb-driver-roadmap.md)
-- Driver installation guide: [docs/driver-installation.md](docs/driver-installation.md)
-- Exact vector retrieval: [docs/vector-backends.md](docs/vector-backends.md)
-- Protocol compatibility: [docs/protocol-compatibility.md](docs/protocol-compatibility.md)
-- TLS transport: [docs/tls-transport.md](docs/tls-transport.md)
-- Query safety: [docs/query-safety.md](docs/query-safety.md)
-- Payload codecs and prepared selections: [docs/payload-codecs.md](docs/payload-codecs.md)
-- Use case recipes: [docs/use-case-recipes.md](docs/use-case-recipes.md)
-- Universe sync: [docs/universe-sync.md](docs/universe-sync.md)
-- Threat model: [docs/threat-model.md](docs/threat-model.md)
-- Security validation matrix: [docs/security-validation.md](docs/security-validation.md)
-- Benchmark notes: [docs/koutendb-bench.md](docs/koutendb-bench.md)
-- Effect validation: [docs/effect-validation.md](docs/effect-validation.md)
-- Generation checkpoints: [docs/generation-checkpoints.md](docs/generation-checkpoints.md)
-- Prometheus/OpenMetrics and cloud operations: [docs/cloud-operations.md](docs/cloud-operations.md)
-- Topology configuration reference: [docs/topology-config.md](docs/topology-config.md)
-- Topology pattern catalog: [docs/topology-examples.md](docs/topology-examples.md)
-- Topology remapping: [docs/topology-remapping.md](docs/topology-remapping.md)
-- Shelfer integration boundary: [docs/koutendb-shelfer-integration.md](docs/koutendb-shelfer-integration.md)
-- Halo capture design: [docs/koutendb-halo-capture.md](docs/koutendb-halo-capture.md)
-- Changelog: [CHANGELOG.md](CHANGELOG.md)
-- Third-party notices: [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md)
-- Contribution policy: [CONTRIBUTING.md](CONTRIBUTING.md)
+| Goal | Start here |
+|---|---|
+| See the ring model with three CLI writes | [Five-Minute Quickstart](docs/quickstart.md) |
+| Prove reopen, migration, backup, and restore | [Hands-on Evaluation](docs/hands-on-evaluation.md) |
+| Embed the database in a Nim application | [Public API](docs/public-api.md) |
+| Use Rust, TypeScript, Python, PHP, or C++ | [Driver Installation](docs/driver-installation.md) |
+| Run a TLS/authenticated persistent server | [v0.14 Self-Hosted Operations](docs/v0.14-self-hosted-operations.md) |
+| Measure AI/RAG working-set reduction | [Effect Validation](docs/effect-validation.md) |
+| Evaluate an ongoing service deployment | [Service Trial](docs/service-trial.md) |
+
+The complete guide index is in [KoutenDB Documentation](docs/index.md). Product
+adoption work is tracked separately from compatibility work in the
+[Adoption And Ecosystem Roadmap](docs/adoption-roadmap.md) and the
+[v1.0 Stabilization Plan](docs/v1-stabilization.md).
 
 ## Installation
 
-KoutenDB is available through Nimble. Rust, JavaScript / TypeScript, PHP, and
-Python drivers are published as language packages, while the remaining non-Nim
-language drivers are still repository-local foundations.
+Choose the artifact that matches the first task:
+
+| Task | Install path |
+|---|---|
+| Local CLI or embedded Nim | `nimble install koutendb` |
+| Persistent self-hosted server | `ghcr.io/puffball1567/koutendb:0.14.0` and the self-host bundle |
+| Existing-language application | published driver plus a compatible KoutenDB server or native library |
+| Core development and full validation | source checkout |
+
+Rust, JavaScript / TypeScript, PHP, Python, and C++ drivers are published. The
+remaining non-Nim language drivers are repository-local foundations.
 
 Prerequisites:
 
 - Nim `2.0.0` or newer
 - `git`
 - `gcc` or another C compiler supported by Nim
+- `libsodium` development files for `nimsodium`
 
 Install the CLI and Nim library:
 
@@ -149,6 +127,14 @@ Install the CLI and Nim library:
 nimble install koutendb
 kouten --help
 ```
+
+Then run the [Five-Minute Quickstart](docs/quickstart.md) to write one entity,
+place related data nearby, and read the bounded neighborhood.
+
+For the released multi-architecture server image and TLS/authenticated
+self-host bootstrap, use [v0.14 Self-Hosted Operations](docs/v0.14-self-hosted-operations.md).
+Do not treat a language package as the database server: C ABI drivers need the
+native library, while TCP drivers need a running `koutend` endpoint.
 
 Clone the repository when you want to run the full source test suite, examples,
 or driver smoke tests:
@@ -171,8 +157,8 @@ For server-style installs, build locally and install the binaries into
 `/usr/local/bin`, the usual source-install location for database tools:
 
 ```sh
-nim c -d:release --nimcache:/tmp/nimcache_kouten -o:bin/kouten src/koutencli.nim
-nim c -d:release --nimcache:/tmp/nimcache_koutend -o:bin/koutend src/koutend.nim
+nim c -d:ssl -d:release --nimcache:/tmp/nimcache_kouten -o:bin/kouten src/koutencli.nim
+nim c -d:ssl -d:release --nimcache:/tmp/nimcache_koutend -o:bin/koutend src/koutend.nim
 sudo install -m 0755 bin/kouten /usr/local/bin/kouten
 sudo install -m 0755 bin/koutend /usr/local/bin/koutend
 ```
@@ -545,8 +531,8 @@ N=1000 examples/redis_docker_bench.sh
 ### Server Options
 
 ```sh
-nim c -d:release -o:bin/koutend src/koutend.nim
-nim c -d:release -o:bin/kouten src/koutencli.nim
+nim c -d:ssl -d:release -o:bin/koutend src/koutend.nim
+nim c -d:ssl -d:release -o:bin/kouten src/koutencli.nim
 ```
 
 Strong durability mode:

--- a/docs/adoption-roadmap.md
+++ b/docs/adoption-roadmap.md
@@ -1,0 +1,211 @@
+---
+layout: page
+title: Adoption And Ecosystem Roadmap
+---
+
+# KoutenDB Adoption And Ecosystem Roadmap
+
+KoutenDB already has a substantial database, recovery, security, packaging, and
+validation foundation. The next adoption problem is not solved by adding every
+possible database feature. It is solved by making one valuable workflow easy to
+discover, prove, integrate, and operate without knowledge held only by the
+maintainer.
+
+This document is the canonical adoption and ecosystem plan. The
+[v1.0 stabilization plan](v1-stabilization.md) remains the canonical quality
+and compatibility plan. The two plans reinforce each other but answer different
+questions:
+
+- stabilization asks whether KoutenDB behaves predictably and can be recovered;
+- adoption asks whether a new user can reach a useful result and keep using it.
+
+## Product Entry Point
+
+The primary entry point is:
+
+> Reduce unrelated retrieval work before vector ranking, reranking, or LLM
+> context construction by placing related data in explicit ring coordinates.
+
+KoutenDB also supports related application data, tenant-local reads, embedded
+state, and self-hosted services. Those uses should remain visible, but they must
+not obscure the first reason to try the project. KoutenDB is not positioned as a
+drop-in replacement for every relational, document, cache, graph, or analytical
+database.
+
+## Adoption Principles
+
+1. **Prove value before requiring migration.** A user should be able to place a
+   copy or a reconstructible subset of existing data in KoutenDB first.
+2. **Meet data where it already exists.** JSONL, files, application objects, and
+   existing database exports are better entry points than a mandatory rewrite.
+3. **Make the first success smaller than the first architecture decision.** A
+   local CLI or embedded trial should come before cluster and Universe design.
+4. **Integrate deeply where target users already work.** One maintained RAG or
+   application integration is worth more than several shallow package listings.
+5. **Publish executable evidence.** Candidate counts, bytes, latency, token
+   estimates, restart, verify, and restore results must remain reproducible.
+6. **Keep the core narrow.** Optional formats, frameworks, and operational
+   products should use adapters or external projects when they do not belong in
+   the storage and retrieval core.
+7. **Do not require telemetry.** Adoption evidence comes from opt-in reports,
+   package statistics, public integrations, and reproducible trials.
+
+## Stage 1: Five-Minute Local Success
+
+The first session must demonstrate the ring model rather than only prove that a
+process starts.
+
+Deliverables:
+
+- one short installation selector covering Nimble, the official container,
+  published drivers, and source development;
+- a five-minute CLI path that writes one entity and nearby records, reads the
+  neighborhood, and narrows it by subring;
+- one command or script that compares global and ring-scoped retrieval over the
+  same generated corpus;
+- expected output that explains candidate reduction in concrete numbers;
+- corrective instructions for every prerequisite and common first-run error.
+
+Exit evidence:
+
+- a clean supported environment reaches the first ring read in five minutes or
+  less after prerequisites are available;
+- the locality comparison completes in fifteen minutes or less;
+- the path requires no cluster, cloud account, or private maintainer knowledge.
+
+## Stage 2: Existing-Workflow Integration
+
+The preferred first deployment is incremental: keep the current source of truth
+and use KoutenDB for the locality-sensitive retrieval path until the application
+has enough evidence to expand its use.
+
+Deliverables:
+
+- maintained Python and TypeScript examples using published packages;
+- a reference AI/RAG integration, initially targeting the Python ecosystem and
+  the framework boundary used by LangChain or LlamaIndex;
+- documented JSONL and directory ingestion patterns;
+- a repeatable incremental import example from PostgreSQL or MySQL exports;
+- compatibility checks that tie each example to supported core and driver
+  versions;
+- explicit ownership boundaries: core API, driver, framework adapter, and
+  application code.
+
+Exit evidence:
+
+- a user can add KoutenDB beside an existing application without replacing its
+  primary database;
+- the reference RAG path shows the same answer-quality measurement while
+  reporting global and ring-scoped candidate and context sizes;
+- examples run from clean checkouts in their declared environments.
+
+## Stage 3: Public Dogfooding And Service Proof
+
+At least one useful maintained application must exercise KoutenDB continuously.
+It should use the locality model because the application benefits from it, not
+only because it is a KoutenDB demonstration.
+
+The application must cover:
+
+- normal create, update, delete, ring-read, and restart behavior;
+- one published driver or the public Nim API;
+- persistent data and scheduled verified recovery artifacts;
+- monitoring, bounded error handling, and an incident journal;
+- an independent restore and an upgrade/rollback rehearsal.
+
+The first application may use non-critical or reconstructible data. The
+[service trial](service-trial.md) defines the operational evidence, and the
+[v1.0 stabilization plan](v1-stabilization.md) defines the release gate.
+
+Exit evidence:
+
+- at least 30 consecutive days of useful application operation;
+- named workload and operation counts rather than uptime alone;
+- two successful independent restores;
+- every incident classified as fixed, documented, or release-blocking;
+- one publishable case study explaining the data shape, benefit, and limits.
+
+## Stage 4: Distribution Through Other Ecosystems
+
+KoutenDB should become available from the tools its target users already open.
+Distribution work follows demonstrated use; it does not begin with a large
+marketplace.
+
+Priorities:
+
+1. Python AI/RAG workflow;
+2. TypeScript service workflow;
+3. PostgreSQL/MySQL sidecar-import workflow;
+4. embedded Rust or Nim application workflow;
+5. additional framework adapters supported by an active example or user.
+
+Each integration must have one owner, a compatibility matrix, an executable
+example, and a release policy. An integration that cannot be tested against a
+released KoutenDB version is not listed as supported.
+
+Community extension infrastructure becomes justified when multiple independent
+extensions need common discovery, build, signature, and compatibility rules.
+Until then, separate repositories and a curated ecosystem index are simpler and
+safer.
+
+## Stage 5: v1.0 Trust And Compatibility
+
+Adoption claims must converge with the v1.0 gates rather than outrun them.
+
+Before v1.0 RC:
+
+- the five-minute path and hands-on evaluation work from released artifacts;
+- the public dogfood application has completed its service trial;
+- supported drivers pass the release compatibility matrix;
+- storage, JSONL migration, wire, C ABI, CLI, and configuration contracts are
+  named and tested;
+- stable and experimental features are labeled consistently;
+- recovery evidence is linked from the public documentation.
+
+Broad market adoption is not a v1.0 prerequisite. Reproducible use by someone
+who did not implement KoutenDB is.
+
+## Commercial Boundary
+
+The Apache-2.0 core should retain the safety and interoperability required to
+evaluate and operate KoutenDB: storage, retrieval, verification, backup,
+restore, security boundaries, metrics, drivers, and documented migration.
+
+Commercial work can add value without weakening that core through:
+
+- enterprise integration and prioritized engineering;
+- fleet-wide policy, hosted control planes, managed PKI/KMS, and cross-account
+  operations;
+- provider-specific deployment automation and operational dashboards;
+- support contracts and verified long-term compatibility programs;
+- private plugins that solve organization-specific operational problems.
+
+The commercial layer should sell reduced operational burden and direct access
+to expertise. It should not make a free deployment unable to protect or recover
+its own data.
+
+## Measures
+
+Review these measures at each minor release:
+
+| Area | Evidence |
+|---|---|
+| Activation | clean-install time to first successful ring read |
+| Value | scanned candidates, bytes, candidate memory, token estimate, and latency for the same workload |
+| Integration | released examples and adapters passing against supported versions |
+| Trust | service-trial duration, operation count, incidents, verified backups, and restores |
+| Retention | maintained applications still using KoutenDB after 30 and 90 days |
+| Ecosystem | public dependent projects, technical reports, integrations, and independent reproduction results |
+
+Stars and download counts are useful discovery signals, but they do not replace
+successful reads, maintained applications, recovery drills, or named users.
+
+## Work That Does Not Advance This Roadmap
+
+- adding a language binding without a released example and compatibility test;
+- adding a broad database feature without a locality-first use case;
+- claiming production readiness from uptime without restore evidence;
+- building a plugin marketplace before independent plugins exist;
+- building a managed cloud control plane before the self-hosted service path is
+  repeatedly operable;
+- hiding the first useful command behind architecture or benchmark documents.

--- a/docs/driver-installation.md
+++ b/docs/driver-installation.md
@@ -1,7 +1,8 @@
 # KoutenDB Driver Installation Guide
 
-This document shows the current technical-preview setup for each language. The
-English README and this file are the canonical driver installation references.
+This document separates published driver packages from repository-local driver
+foundations. The English README records released package versions; this file is
+the canonical setup and native-library reference.
 
 KoutenDB drivers currently use two paths:
 
@@ -23,9 +24,10 @@ For Rust, target selection is shell-friendly: use `--manifest-path=FILE`,
 It does not execute package-manager commands unless `--execute` is passed.
 
 The Nim package is available through Nimble. Rust, JavaScript / TypeScript, PHP,
-and Python drivers are also published as language-native packages. Other
-non-Nim drivers are still repository-local foundations, so those examples
-assume a local clone of this repository.
+Python, and the C++ source release are published independently from the core.
+Installing one of those packages installs a driver, not a KoutenDB server.
+Repository-local Go, Swift, C#, and Kotlin foundations are not published
+packages; their examples assume a local clone of this repository.
 
 ## Build the Native Library
 

--- a/docs/hands-on-evaluation.md
+++ b/docs/hands-on-evaluation.md
@@ -9,6 +9,10 @@ This guide is the shortest human path from a clean installation to a verified
 KoutenDB restore. It is for evaluation and maintainer dogfooding, not only for
 CI. Follow it before relying on less familiar cluster or Universe features.
 
+For a first ring read without the recovery exercises, begin with the
+[Five-Minute Quickstart](quickstart.md), then return here before keeping
+persistent evaluation data.
+
 ## What You Will Prove
 
 By the end, you will have:

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,32 +10,55 @@ coordinate-like `ring` and uses that placement at read time to reduce the amount
 of data that must be searched, transferred, held in memory, and passed to
 downstream AI/RAG or application logic.
 
-## Start Here
+## Evaluate KoutenDB
 
-- [Concept](koutendb-concept.md)
-- [Installation](installation.md)
-- [Hands-on Evaluation](hands-on-evaluation.md)
-- [Service Trial](service-trial.md)
-- [v1.0 Stabilization Plan](v1-stabilization.md)
-- [v0.14 Self-Hosted Operations](v0.14-self-hosted-operations.md)
-- [Single-Node Self-Host Bundle](https://github.com/puffball1567/koutendb/tree/main/deploy/self-hosted)
+1. [Install KoutenDB](installation.md).
+2. Complete the [Five-Minute Quickstart](quickstart.md).
+3. Run [Effect Validation](effect-validation.md) to compare global and
+   ring-scoped retrieval over the same data.
+4. Complete the [Hands-on Evaluation](hands-on-evaluation.md) before relying on
+   persistent data.
+
+Read [Concept](koutendb-concept.md) and
+[How KoutenDB Differs From Typical NoSQL](nosql-positioning.md) when deciding
+whether the locality-first model fits the workload.
+
+## Integrate An Application
+
 - [Public API](public-api.md)
+- [Driver Installation](driver-installation.md)
+- [Use Case Recipes](use-case-recipes.md)
 - [Configuration Reference](config-reference.md)
 - [CLI Reference](cli-reference.md)
-- [How KoutenDB Differs From Typical NoSQL](nosql-positioning.md)
 - [Unique Data Model And Operating Patterns](unique-data-model.md)
-- [Use Case Recipes](use-case-recipes.md)
-- [Technical FAQ](technical-faq.md)
-- [Feature Status / Roadmap](koutendb-status.md)
-- [v0.12 Implementation And Validation Record](v0.12-roadmap.md)
-- [v0.13 Coordinator Redundancy Record](v0.13-roadmap.md)
-- [Coordinator Failover](coordinator-failover.md)
+
+Published and planned ecosystem work is tracked in the
+[Driver / FFI Roadmap](koutendb-driver-roadmap.md). The broader path from first
+trial to maintained application is in the
+[Adoption And Ecosystem Roadmap](adoption-roadmap.md).
+
+## Operate A Service
+
+- [v0.14 Self-Hosted Operations](v0.14-self-hosted-operations.md)
+- [Single-Node Self-Host Bundle](https://github.com/puffball1567/koutendb/tree/main/deploy/self-hosted)
 - [Operational Trials](operational-trials.md)
+- [Service Trial](service-trial.md)
 - [72-Hour Strong-Durability Soak Result](soak-testing.md)
+- [Coordinator Failover](coordinator-failover.md)
+- [Cloud Operations Metrics](cloud-operations.md)
+
+## Review Maturity
+
+- [Feature Status / Roadmap](koutendb-status.md)
+- [v1.0 Stabilization Plan](v1-stabilization.md)
+- [Technical FAQ](technical-faq.md)
+- [Test Coverage](test-coverage.md)
+- [Security Validation Matrix](security-validation.md)
 - [Accelerated Churn Testing](accelerated-churn-testing.md)
 - [Benchmark Notes](koutendb-bench.md)
 - [Benchmark Comparison Tables](benchmark-comparison.md)
-- [Effect Validation](effect-validation.md)
+- [v0.12 Implementation And Validation Record](v0.12-roadmap.md)
+- [v0.13 Coordinator Redundancy Record](v0.13-roadmap.md)
 
 ## Core Guides
 
@@ -54,7 +77,7 @@ downstream AI/RAG or application logic.
 - [Roles And Service Accounts](access-control.md)
 - [Threat Model](threat-model.md)
 - [Security Validation Matrix](security-validation.md)
-- [Test Coverage](test-coverage.md)
+- [Effect Validation](effect-validation.md)
 - [Audit Remediation Tracker](audit-remediation.md)
 - [Development Workflow](development-workflow.md)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,6 +12,19 @@ For normal use, the command should be available as `kouten`, not as
 `bin/kouten`. The `bin/` form is only for source-tree development and smoke
 tests.
 
+## Choose An Installation Path
+
+| Goal | Artifact | Required locally |
+|---|---|---|
+| Try the CLI or embed KoutenDB in Nim | Nimble package | Nim, C compiler, libsodium |
+| Run a persistent TLS/authenticated server | GHCR image and self-host bundle | Docker with Compose, Git, OpenSSL |
+| Connect from an existing language | Published language driver | Driver-specific runtime plus a server or native library |
+| Develop KoutenDB itself | Source checkout | Full build and test toolchain |
+
+For the shortest introduction to the data model, install the Nimble package and
+continue with the [Five-Minute Quickstart](quickstart.md). Choose the container
+path when the first question is operational rather than embedded use.
+
 ## Prerequisites
 
 - Nim `2.0.0` or newer
@@ -19,7 +32,7 @@ tests.
 - `gcc` or another C compiler supported by Nim
 - `libsodium` development files for `nimsodium`
 
-## User Install
+## Local CLI And Embedded Nim
 
 Install KoutenDB from Nimble:
 
@@ -56,6 +69,51 @@ kouten --help
 koutend --help
 ```
 
+The installation is ready when `kouten --help` succeeds. Continue with the
+[Five-Minute Quickstart](quickstart.md); cluster configuration is not required
+for the first evaluation.
+
+## Self-Hosted Server Image
+
+Versioned `linux/amd64` and `linux/arm64` images are published at:
+
+```text
+ghcr.io/puffball1567/koutendb:<version>
+```
+
+The supported server path uses the repository's self-host bundle to generate
+TLS certificates, external secret files, persistent storage, health checks, and
+strong-durability configuration. For v0.14.0:
+
+```sh
+git clone --depth 1 --branch v0.14.0 \
+  https://github.com/puffball1567/koutendb.git
+cd koutendb
+KOUTENDB_VERSION=0.14.0 \
+  deploy/self-hosted/bootstrap.sh "$PWD/../koutendb-selfhost"
+cd ../koutendb-selfhost
+docker compose up -d
+docker compose ps
+```
+
+Read [v0.14 Self-Hosted Operations](v0.14-self-hosted-operations.md) before
+exposing the listener outside localhost. The bootstrap PKI is an evaluation and
+single-node starting point, not a replacement for an organization's approved
+issuer and trust-distribution process.
+
+## Language Drivers
+
+Published drivers are available for Rust, JavaScript/TypeScript, Python, PHP,
+and C++. A driver is not a standalone KoutenDB server:
+
+- native C ABI wrappers require a compatible `libkoutendb` build;
+- TCP drivers require a reachable `koutend` endpoint;
+- the core and driver versions must satisfy the documented compatibility
+  matrix.
+
+Use [Driver Installation](driver-installation.md) for package commands, native
+library setup, TLS/authentication requirements, and verification examples.
+
 ## System Install
 
 For server-style deployments, use `/usr/local/bin`, matching the usual source
@@ -65,8 +123,8 @@ binaries.
 Build repo-local binaries:
 
 ```sh
-nim c -d:release --nimcache:/tmp/nimcache_kouten -o:bin/kouten src/koutencli.nim
-nim c -d:release --nimcache:/tmp/nimcache_koutend -o:bin/koutend src/koutend.nim
+nim c -d:ssl -d:release --nimcache:/tmp/nimcache_kouten -o:bin/kouten src/koutencli.nim
+nim c -d:ssl -d:release --nimcache:/tmp/nimcache_koutend -o:bin/koutend src/koutend.nim
 ```
 
 Install them onto the system PATH:

--- a/docs/koutendb-status.md
+++ b/docs/koutendb-status.md
@@ -9,6 +9,8 @@ Current release evidence: [v0.14.0 release notes](./github-release-v0.14.0.md)
 
 Current v1.0 preparation: [v1.0 stabilization plan](./v1-stabilization.md)
 
+Current adoption and ecosystem plan: [adoption roadmap](./adoption-roadmap.md)
+
 Current self-host operations: [v0.14 self-hosted operations](./v0.14-self-hosted-operations.md)
 
 Human evaluation path: [hands-on evaluation](./hands-on-evaluation.md) and

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,86 @@
+---
+layout: page
+title: Five-Minute Quickstart
+---
+
+# Five-Minute Quickstart
+
+This path demonstrates KoutenDB's core behavior: write related data near one
+coordinate, read that bounded neighborhood, and narrow it without a global
+field scan. It uses the embedded CLI, so it does not require a server or cloud
+account.
+
+## Install
+
+KoutenDB requires Nim 2.0 or newer and the prerequisites listed in
+[Installation](installation.md).
+
+```sh
+nimble install koutendb
+kouten --help
+```
+
+If `kouten` is not found, add `~/.nimble/bin` to `PATH` as described in the
+installation guide.
+
+## Write One Neighborhood
+
+Use a disposable persistent directory:
+
+```sh
+export KOUTEN_DATA="$PWD/koutendb-quickstart"
+```
+
+Write one user and place related documents near that coordinate:
+
+```sh
+kouten put --ring=users/123 \
+  --payload='{"kind":"user","name":"Ada"}' --codec=json
+kouten put --near=users/123 --ring=profile \
+  --payload='{"kind":"profile","plan":"pro"}' --codec=json
+kouten put --near=users/123 --ring=orders \
+  --payload='{"kind":"order","number":"A-001","total":120}' --codec=json
+```
+
+The application supplied the locality at write time. KoutenDB does not need to
+discover this relationship by scanning every document later.
+
+## Read Broadly, Then Narrow
+
+Read the user neighborhood:
+
+```sh
+kouten get --ring=users/123 --subring=profile,orders
+```
+
+Keep the root entity, include only the nearby orders branch, and select the
+fields the caller needs:
+
+```sh
+kouten get --ring=users/123 --subring=orders \
+  --selection='{ kind number total }'
+```
+
+Inspect the available coordinates:
+
+```sh
+kouten atlas
+```
+
+The important result is not merely that three documents were stored. The read
+began from `users/123`, so unrelated users, tenants, repositories, or document
+families were outside the first candidate set.
+
+## Choose The Next Path
+
+| Goal | Continue with |
+|---|---|
+| Prove restart, migration, backup, and restore | [Hands-on Evaluation](hands-on-evaluation.md) |
+| Embed KoutenDB in Nim | [Public API](public-api.md) |
+| Use Rust, TypeScript, Python, PHP, or C++ | [Driver Installation](driver-installation.md) |
+| Run an authenticated persistent server | [Self-Hosted Operations](v0.14-self-hosted-operations.md) |
+| Evaluate AI/RAG working-set reduction | [Effect Validation](effect-validation.md) |
+| Model a real application | [Use Case Recipes](use-case-recipes.md) |
+| Understand the path to v1.0 | [v1.0 Stabilization](v1-stabilization.md) |
+
+Use non-sensitive and reconstructible data for the first evaluation.

--- a/docs/v1-stabilization.md
+++ b/docs/v1-stabilization.md
@@ -13,6 +13,8 @@ must preserve.
 
 This document is the canonical v1.0 stabilization plan. It does not assign an
 RC date. KoutenDB enters RC only after the evidence gates below are complete.
+The separate [adoption and ecosystem roadmap](adoption-roadmap.md) defines how
+new users reach and retain value; it does not weaken the release gates here.
 
 ## Release Sequence
 

--- a/scripts/cli_crud_smoke.sh
+++ b/scripts/cli_crud_smoke.sh
@@ -38,6 +38,11 @@ if [[ -z "$raw_id" ]]; then
   exit 1
 fi
 
+echo "[cli-crud] atlas uses KOUTEN_DATA"
+atlas_out="$(bin/kouten atlas)"
+grep -q '"name": "docs/japan"' <<<"$atlas_out"
+grep -q '"documents": 1' <<<"$atlas_out"
+
 echo "[cli-crud] count/list/get/query"
 bin/kouten count-ring --ring=docs/japan |
   grep -q "count=1"

--- a/src/koutencli.nim
+++ b/src/koutencli.nim
@@ -1098,6 +1098,7 @@ proc runRings(peers, username, password, authToken, secretKey, galaxy: string,
 proc runAtlas(dataDir, peers, username, password, authToken, secretKey,
               galaxy: string, tls: bool, tlsCaFile, tlsServerName: string,
               tlsInsecureSkipVerify: bool) =
+  let actualDataDir = requireCliTarget(dataDir, peers)
   var db =
     if peers.len > 0:
       connect(peers, username = username, password = password,
@@ -1106,7 +1107,7 @@ proc runAtlas(dataDir, peers, username, password, authToken, secretKey,
               tlsServerName = tlsServerName,
               tlsInsecureSkipVerify = tlsInsecureSkipVerify)
     else:
-      open(dataDir = dataDir)
+      open(dataDir = actualDataDir)
   echo db.atlas().pretty
   db.close()
 


### PR DESCRIPTION
## Summary

- add a staged adoption and ecosystem roadmap with measurable activation, integration, dogfooding, and v1 gates
- add a five-minute ring-locality quickstart and reorganize README and Pages navigation by user goal
- clarify Nimble, GHCR, external-driver, source, and TLS-enabled system installation paths
- make `kouten atlas` honor `KOUTEN_DATA` and cover the environment-selected path

## Validation

- `scripts/cli_crud_smoke.sh`
- local Markdown link validation
- `git diff --check`