### PR TITLE
release: prepare KoutenDB v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## Unreleased
 
+## v0.14.1 - 2026-08-29
+
+### Added
+
+- Added a five-minute quickstart that demonstrates write-time locality,
+  bounded neighborhood reads, subring narrowing, projections, and Atlas
+  inspection without requiring a cluster.
+- Added runnable Docker Compose web demos for the REKT stack (React, Express,
+  KoutenDB, TypeScript) and the PRK stack (Prologue, React, KoutenDB).
+- Added an adoption and ecosystem roadmap that separates first-use,
+  integration, service-trial, and distribution work from the v1 compatibility
+  plan.
+
+### Changed
+
+- Reorganized the README and documentation index around evaluation,
+  integration, operation, and maturity paths.
+- Clarified the installation boundary between the Nimble CLI/library, the
+  official server image, published language drivers, and source development.
+- Updated source-build examples to include TLS support.
+
+### Fixed
+
+- Made embedded `kouten atlas` honor `KOUTEN_DATA`, matching the other CLI
+  commands and the documented quickstart.
+
 ## v0.14.0 - 2026-08-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Choose the artifact that matches the first task:
 | Task | Install path |
 |---|---|
 | Local CLI or embedded Nim | `nimble install koutendb` |
-| Persistent self-hosted server | `ghcr.io/puffball1567/koutendb:0.14.0` and the self-host bundle |
+| Persistent self-hosted server | `ghcr.io/puffball1567/koutendb:0.14.1` and the self-host bundle |
 | Existing-language application | published driver plus a compatible KoutenDB server or native library |
 | Core development and full validation | source checkout |
 
@@ -718,7 +718,7 @@ tests/                 unit and smoke tests
 
 ## Operational Scope
 
-KoutenDB v0.14.0 is a public pre-v1 release with persistent storage, strong
+KoutenDB v0.14.1 is a public pre-v1 release with persistent storage, strong
 durability, recovery, transactions, topology controls, TLS-capable transport, a
 C ABI, published drivers, ring-local physical segments, bounded automatic
 maintenance, generation checkpoints, operational metrics, recoverable cluster

--- a/deploy/self-hosted/README.md
+++ b/deploy/self-hosted/README.md
@@ -13,7 +13,7 @@ bundle.
 After the v0.14 image is published:
 
 ```sh
-KOUTENDB_VERSION=0.14.0 \
+KOUTENDB_VERSION=0.14.1 \
   deploy/self-hosted/bootstrap.sh /opt/koutendb
 
 cd /opt/koutendb
@@ -184,8 +184,8 @@ Upgrade to an explicitly versioned image or immutable digest:
 
 ```sh
 ./operator.sh upgrade \
-  ghcr.io/puffball1567/koutendb:0.14.0 \
-  before-0.14.0
+  ghcr.io/puffball1567/koutendb:0.14.1 \
+  before-0.14.1
 ```
 
 The operator rejects an unversioned image and the mutable `latest` tag. Before

--- a/deploy/self-hosted/bootstrap.sh
+++ b/deploy/self-hosted/bootstrap.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 SOURCE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OUTPUT="${1:-$PWD/koutendb-selfhost}"
-VERSION="${KOUTENDB_VERSION:-0.14.0}"
+VERSION="${KOUTENDB_VERSION:-0.14.1}"
 
 fail() {
   echo "[self-host-bootstrap] $*" >&2

--- a/docs/github-release-v0.14.1.md
+++ b/docs/github-release-v0.14.1.md
@@ -1,0 +1,49 @@
+# KoutenDB v0.14.1
+
+KoutenDB v0.14.1 makes the locality model easier to evaluate from a clean
+environment and adds two complete web application examples. It retains the
+v0.14 storage, wire, C ABI, security, and self-host compatibility boundaries.
+
+## Faster Evaluation Path
+
+- a five-minute embedded CLI quickstart that writes one entity and nearby
+  records, reads the bounded neighborhood, narrows it by subring, and inspects
+  the resulting coordinates with Atlas;
+- a task-oriented documentation index for evaluation, application integration,
+  service operation, and maturity review;
+- explicit installation choices for Nimble, the official GHCR server image,
+  published language drivers, and source development;
+- an adoption roadmap that keeps ecosystem work separate from the v1.0
+  compatibility and quality gates.
+
+## Runnable Web Application Demos
+
+- **REKT:** React, Express, KoutenDB, and TypeScript;
+- **PRK:** Prologue, React, and KoutenDB through the public Nim API.
+
+Both Docker Compose demos expose the same responsive CRUD interface and run
+against an authenticated, persistent KoutenDB node. They demonstrate category
+rings, tag-related reads scoped to one ring, point reads, updates, deletion,
+and moving a record when its category changes. The interface reports the ring
+and candidate count so the locality boundary remains visible.
+
+The demos are application examples, not separate supported frameworks or
+benchmarks. Their source and run instructions are under `examples/web/`.
+
+## Fixes And Documentation
+
+- embedded `kouten atlas` now honors `KOUTEN_DATA` consistently with the other
+  CLI commands;
+- source-build instructions now enable TLS explicitly;
+- current self-host examples and defaults use the v0.14.1 image.
+
+## Validation
+
+The release candidate passed the complete Linux CI suite, including core,
+runtime-contract, C ABI, TLS transport, CLI, cluster, recovery, Universe, and
+OCI-image checks, plus the macOS TLS-enabled C ABI build. Both web Compose
+stacks were also built and exercised through the shared CRUD/locality smoke
+test from clean persistent volumes.
+
+No storage-format, wire-protocol, or C ABI version change is introduced by this
+patch release. External driver releases remain versioned independently.

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,6 +94,7 @@ trial to maintained application is in the
 ## Release
 
 - [Release Checklist](release-checklist.md)
+- [v0.14.1 Release Notes](github-release-v0.14.1.md)
 - [v0.14.0 Release Notes](github-release-v0.14.0.md)
 - [v0.13.0 Release Notes](github-release-v0.13.0.md)
 - [v0.12.1 Release Notes](github-release-v0.12.1.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -83,13 +83,13 @@ ghcr.io/puffball1567/koutendb:<version>
 
 The supported server path uses the repository's self-host bundle to generate
 TLS certificates, external secret files, persistent storage, health checks, and
-strong-durability configuration. For v0.14.0:
+strong-durability configuration. For v0.14.1:
 
 ```sh
-git clone --depth 1 --branch v0.14.0 \
+git clone --depth 1 --branch v0.14.1 \
   https://github.com/puffball1567/koutendb.git
 cd koutendb
-KOUTENDB_VERSION=0.14.0 \
+KOUTENDB_VERSION=0.14.1 \
   deploy/self-hosted/bootstrap.sh "$PWD/../koutendb-selfhost"
 cd ../koutendb-selfhost
 docker compose up -d

--- a/docs/koutendb-status.md
+++ b/docs/koutendb-status.md
@@ -5,7 +5,7 @@ references and may lag behind this file.
 
 Release checklist: [release-checklist.md](./release-checklist.md)
 
-Current release evidence: [v0.14.0 release notes](./github-release-v0.14.0.md)
+Current release evidence: [v0.14.1 release notes](./github-release-v0.14.1.md)
 
 Current v1.0 preparation: [v1.0 stabilization plan](./v1-stabilization.md)
 

--- a/koutendb.nimble
+++ b/koutendb.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version     = "0.14.0"
+version     = "0.14.1"
 author      = "puffball1567"
 description = "KoutenDB: ring-oriented NoSQL document/vector store for smaller working sets"
 license     = "Apache-2.0"

--- a/scripts/self_host_bundle_smoke.sh
+++ b/scripts/self_host_bundle_smoke.sh
@@ -48,7 +48,7 @@ if deploy/self-hosted/bootstrap.sh "$WORK/symlink-output" >/dev/null 2>&1; then
   exit 1
 fi
 
-KOUTENDB_VERSION=0.14.0 deploy/self-hosted/bootstrap.sh "$BUNDLE" >/dev/null
+KOUTENDB_VERSION=0.14.1 deploy/self-hosted/bootstrap.sh "$BUNDLE" >/dev/null
 sed -i "s|^KOUTENDB_IMAGE=.*|KOUTENDB_IMAGE=$IMAGE|" "$BUNDLE/.env"
 test -x "$BUNDLE/operator.sh"
 test -x "$BUNDLE/capacity.sh"


### PR DESCRIPTION
## Summary

- set the core package and current deployment examples to v0.14.1
- add release notes for the five-minute evaluation path and adoption roadmap
- include the runnable REKT and PRK web CRUD/locality demos in the release scope
- document the KOUTEN_DATA Atlas fix and unchanged storage, wire, and C ABI compatibility boundaries

## Validation

- Nimble package validation passed
- complete core test suite passed
- CLI CRUD smoke passed, including KOUTEN_DATA Atlas coverage
- all Compose configurations passed validation
- official container and self-host runtime smoke passed, including persistence, recovery, backup retention, upgrade rollback, certificate rotation, capacity planning, and watchdog behavior
- both web demo stacks passed their shared CRUD/locality smoke before release preparation