### PR TITLE
Bootstrap protected main promotion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,12 @@ name: CI
 
 on:
   pull_request:
+    branches:
+      - devel
+      - main
   push:
     branches:
-      - main
+      - devel
   workflow_dispatch:
 
 permissions:
@@ -15,8 +18,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  route-policy:
+    name: Branch route policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Validate pull request route
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            exit 0
+          fi
+
+          if [[ "$BASE_REF" == "devel" ]]; then
+            exit 0
+          fi
+
+          if [[ "$BASE_REF" == "main" && "$HEAD_REF" == hotfix/* ]]; then
+            exit 0
+          fi
+
+          echo "::error::Pull requests into main are restricted to hotfix/* branches. Promote devel with the dedicated workflow."
+          exit 1
+
   checks:
     name: Nim checks and C ABI
+    needs: route-policy
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -61,6 +93,7 @@ jobs:
 
   capi-macos-build:
     name: C ABI TLS-enabled build on macOS
+    needs: route-policy
     runs-on: macos-latest
     timeout-minutes: 20
     steps:
@@ -83,6 +116,7 @@ jobs:
 
   core-tests:
     name: Core test suite
+    needs: route-policy
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -105,6 +139,7 @@ jobs:
 
   smoke-tests:
     name: CLI, cluster, recovery, and universe smoke
+    needs: route-policy
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -172,6 +207,7 @@ jobs:
 
   tls-smoke:
     name: TLS transport smoke
+    needs: route-policy
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/promote-main.yml
+++ b/.github/workflows/promote-main.yml
@@ -1,0 +1,139 @@
+name: Promote devel to main
+
+on:
+  workflow_dispatch:
+    inputs:
+      devel_sha:
+        description: Exact 40-character devel HEAD SHA to promote
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  actions: read
+  pull-requests: read
+
+concurrency:
+  group: promote-devel-to-main
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: Verify and promote devel
+    if: github.actor == github.repository_owner
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+      EXPECTED_DEVEL_SHA: ${{ inputs.devel_sha }}
+    steps:
+      - name: Checkout main history
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Verify source and CI
+        id: verify
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$EXPECTED_DEVEL_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::devel_sha must be an exact lowercase 40-character commit SHA."
+            exit 1
+          fi
+
+          git fetch --no-tags origin \
+            +refs/heads/main:refs/remotes/origin/main \
+            +refs/heads/devel:refs/remotes/origin/devel
+
+          main_sha="$(git rev-parse refs/remotes/origin/main)"
+          devel_sha="$(git rev-parse refs/remotes/origin/devel)"
+
+          if [[ "$devel_sha" != "$EXPECTED_DEVEL_SHA" ]]; then
+            echo "::error::devel moved: expected $EXPECTED_DEVEL_SHA but found $devel_sha."
+            exit 1
+          fi
+
+          ci_conclusion="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?branch=devel&event=push&status=completed&per_page=100" \
+              --jq "[.workflow_runs[] | select(.head_sha == \"$devel_sha\")] | first | .conclusion // empty"
+          )"
+
+          if [[ "$ci_conclusion" != "success" ]]; then
+            echo "::error::No successful devel push CI run exists for $devel_sha."
+            exit 1
+          fi
+
+          source_pr="$(
+            gh api \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/commits/${devel_sha}/pulls" \
+              --jq 'map(select(.base.ref == "devel" and .merged_at != null)) | sort_by(.merged_at) | last | .number // empty'
+          )"
+
+          if [[ -z "$source_pr" ]]; then
+            echo "::error::devel HEAD is not associated with a merged pull request into devel."
+            exit 1
+          fi
+
+          devel_tree="$(git rev-parse refs/remotes/origin/devel^{tree})"
+
+          {
+            echo "main_sha=$main_sha"
+            echo "devel_sha=$devel_sha"
+            echo "devel_tree=$devel_tree"
+            echo "source_pr=$source_pr"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Merge and push main
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch --force-create main refs/remotes/origin/main
+
+          if git merge-base --is-ancestor \
+            refs/remotes/origin/devel refs/remotes/origin/main; then
+            echo "devel is already contained in main." >>"$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          git merge --no-ff --no-commit refs/remotes/origin/devel
+
+          promoted_tree="$(git write-tree)"
+          if [[ "$promoted_tree" != "${{ steps.verify.outputs.devel_tree }}" ]]; then
+            echo "::error::Promotion produced a tree that differs from verified devel."
+            git merge --abort
+            exit 1
+          fi
+
+          git commit -m "Merge devel for release"
+
+          git fetch --no-tags origin \
+            +refs/heads/main:refs/remotes/origin/main \
+            +refs/heads/devel:refs/remotes/origin/devel
+
+          if [[ "$(git rev-parse refs/remotes/origin/main)" != "${{ steps.verify.outputs.main_sha }}" ]]; then
+            echo "::error::main moved during promotion."
+            exit 1
+          fi
+
+          if [[ "$(git rev-parse refs/remotes/origin/devel)" != "${{ steps.verify.outputs.devel_sha }}" ]]; then
+            echo "::error::devel moved during promotion."
+            exit 1
+          fi
+
+          git push origin HEAD:refs/heads/main
+
+          {
+            echo "## Promoted devel to main"
+            echo
+            echo "- Source PR: #${{ steps.verify.outputs.source_pr }}"
+            echo "- devel: \`${{ steps.verify.outputs.devel_sha }}\`"
+            echo "- main: \`$(git rev-parse HEAD)\`"
+          } >>"$GITHUB_STEP_SUMMARY"

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -14,6 +14,16 @@ KoutenDB uses a stable-main workflow.
 | `release/vX.Y.Z` | Short-lived release preparation branch cut from `devel` after the next release scope is ready. |
 | `hotfix/...` | Urgent fix branch cut from `main` when the released state needs a direct patch. |
 
+## Protected Branch Routes
+
+| Source | Target | Required gate |
+| --- | --- | --- |
+| `devel` | `main` | The promotion workflow verifies successful CI for the exact `devel` HEAD; no release PR is opened. |
+| `hotfix/*` | `main` | Pull request with the complete CI suite. |
+| `main` | `devel` | Pull request with the complete CI suite. |
+| any other branch | `main` | Rejected by the branch route policy. |
+| direct push | `main` | Rejected by the repository ruleset. |
+
 ## Normal Feature Flow
 
 1. Update local `devel`.
@@ -31,12 +41,18 @@ default state.
 1. Decide the next release scope on `devel`.
 2. Cut `release/vX.Y.Z` from `devel`.
 3. Update package metadata, release notes, and release checklist state.
-4. Open a PR from `release/vX.Y.Z` into `main`.
-5. Merge after CI passes.
-6. Tag the merge commit on `main`.
-7. Create the GitHub Release from the release notes.
+4. Open a PR from `release/vX.Y.Z` into `devel` and merge it after CI passes.
+5. Wait for the CI run on the resulting `devel` HEAD to pass.
+6. Run the `Promote devel to main` workflow with that exact 40-character
+   `devel` commit SHA.
+7. Tag the promotion commit on `main`.
+8. Create the GitHub Release from the release notes.
 
-Tags are created only from `main`.
+The promotion workflow is the only PR-free path into `main`. It verifies that
+the requested SHA is still the current `devel` HEAD, that the HEAD came from a
+merged PR into `devel`, that its push CI succeeded, and that the resulting tree
+is exactly the verified `devel` tree. A `devel` to `main` release PR is not
+used. Tags are created only from `main`.
 
 ## Hotfix Flow
 
@@ -45,8 +61,13 @@ Use a hotfix only when the currently released state needs a direct correction.
 1. Create `hotfix/...` from `main`.
 2. Apply the smallest safe fix.
 3. PR into `main`.
-4. Tag a patch release after merge.
-5. Merge or cherry-pick the fix back into `devel`.
+4. Merge only after the complete PR CI suite passes.
+5. Tag a patch release after merge.
+6. Open a PR from `main` into `devel` and merge only after the complete PR CI
+   suite passes.
+
+Branches other than `hotfix/*` cannot open an accepted PR into `main`. Human
+pushes directly to `main` are prohibited by the repository ruleset.
 
 ## Work In Progress
 
@@ -56,7 +77,14 @@ the feature branch. Do not apply unfinished feature work directly to `devel`.
 
 ## CI Expectations
 
-The repository CI is the release gate for merged branches. Core checks include:
+The repository CI is the release gate for merged branches. Pull requests into
+`devel`, `hotfix/*` pull requests into `main`, and `main` synchronization pull
+requests into `devel` run the complete suite. A push to `devel` runs the same
+suite and creates the exact-SHA evidence consumed by the promotion workflow.
+Other pull-request routes into `main` fail the branch route policy before the
+expensive jobs start.
+
+Core checks include:
 
 - Nim semantic checks;
 - SSL-enabled checks;


### PR DESCRIPTION
## Summary

- install the protected branch route policy on `main`
- add exact-SHA validation for future `devel` promotions
- document the release and hotfix paths

This is the one-time bootstrap PR. Future releases promote a successful `devel` HEAD without a second release PR.

## Validation

- the complete CI suite passed on the corresponding change in PR #129
- workflow YAML parsing passed
- the allow/reject branch-route matrix passed
- promotion tree-equivalence and divergent-tree rejection tests passed
- `git diff --check` passed